### PR TITLE
fix(ssh): capture stderr from ExtendedData

### DIFF
--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -398,6 +398,22 @@ async fn drain_until_marker_with_exit(
                                 // Find the start of the marker line (go back to the previous newline).
                                 let line_start = buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
                                 let output = buf[..line_start].to_string();
+                                // Drain any trailing ExtendedData (stderr) that may still
+                                // be buffered on the channel. Without this, late stderr
+                                // from the current command could contaminate the next
+                                // run's result. Best-effort: uses a short timeout since
+                                // in normal operation all stderr arrives before the marker.
+                                loop {
+                                    match tokio::time::timeout(
+                                        Duration::from_millis(50),
+                                        channel.wait(),
+                                    ).await {
+                                        Ok(Some(ChannelMsg::ExtendedData { ref data, ext })) if ext == 1 => {
+                                            stderr_buf.push_str(&String::from_utf8_lossy(data.as_ref()));
+                                        }
+                                        _ => break,
+                                    }
+                                }
                                 return Ok((output, stderr_buf, Some(code)));
                             }
                         }
@@ -549,7 +565,8 @@ mod tests {
         // `ls` on a non-existent path writes to stderr and exits non-zero.
         let result = session.run("ls /nonexistent_path_xyz").await.unwrap();
 
-        assert_ne!(result.exit_code, Some(0), "expected non-zero exit code");
+        let code = result.exit_code.expect("expected command to report an exit code");
+        assert_ne!(code, 0, "expected non-zero exit code");
         assert!(
             !result.stderr.is_empty(),
             "stderr should not be empty for a failing command"

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -12,7 +12,7 @@ use russh::client::{self, Handle, Msg};
 use russh::keys::*;
 use russh::{Channel, ChannelMsg, Disconnect};
 use tokio::sync::Mutex;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use filar_core::{CoreError, Result, SshAuth, SshTarget};
@@ -223,11 +223,11 @@ impl SshSession {
         )
         .await
         {
-            Ok((output, exit_code)) => {
+            Ok((stdout, stderr, exit_code)) => {
                 let duration = start.elapsed();
                 Ok(CommandResult {
-                    stdout: output,
-                    stderr: String::new(),
+                    stdout,
+                    stderr,
                     exit_code,
                     duration,
                 })
@@ -350,6 +350,10 @@ async fn drain_until_marker(
                     return Ok(());
                 }
             }
+            ChannelMsg::ExtendedData { .. } => {
+                // Extended data (e.g. stderr) — drain silently during sync.
+                // Sync markers are sent via stdout, so we don't need to collect this.
+            }
             ChannelMsg::Eof | ChannelMsg::Close => {
                 return Err(CoreError::Other(
                     "channel closed before marker received".into(),
@@ -366,8 +370,9 @@ async fn drain_until_marker_with_exit(
     channel: &mut Channel<Msg>,
     marker_tag: &str,
     timeout: Duration,
-) -> Result<(String, Option<i32>)> {
+) -> Result<(String, String, Option<i32>)> {
     let mut buf = String::new();
+    let mut stderr_buf = String::new();
     let deadline = tokio::time::Instant::now() + timeout;
 
     loop {
@@ -393,11 +398,20 @@ async fn drain_until_marker_with_exit(
                                 // Find the start of the marker line (go back to the previous newline).
                                 let line_start = buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
                                 let output = buf[..line_start].to_string();
-                                return Ok((output, Some(code)));
+                                return Ok((output, stderr_buf, Some(code)));
                             }
                         }
                     }
                     // Marker tag found but couldn't parse exit code — keep reading.
+                }
+            }
+            ChannelMsg::ExtendedData { ref data, ext } => {
+                // SSH EXTENDED_DATA with data_type_code 1 = stderr.
+                // Note: stdout/stderr interleaving is lost with separate buffers;
+                // this is acceptable — the agent receives them as independent streams.
+                if ext == 1 {
+                    debug!(len = data.len(), "stderr data received from SSH channel");
+                    stderr_buf.push_str(&String::from_utf8_lossy(data.as_ref()));
                 }
             }
             ChannelMsg::Eof | ChannelMsg::Close => {
@@ -513,6 +527,38 @@ mod tests {
 
         assert_eq!(before.stdout.trim(), after.stdout.trim(),
             "zero-install violated: file count changed");
+
+        session.close().await.unwrap();
+    }
+
+    /// Integration test — verifies stderr capture from a failing command.
+    #[tokio::test]
+    #[ignore = "requires Docker sshd container on port 2222"]
+    async fn ssh_stderr_capture() {
+        let target = SshTarget {
+            name: "test".into(),
+            host: "127.0.0.1".into(),
+            port: 2222,
+            user: "testuser".into(),
+            auth: SshAuth::Password { password: None },
+        };
+        std::env::set_var("SSH_PASSWORD", "testpassword");
+
+        let session = SshSession::connect(&target).await.unwrap();
+
+        // `ls` on a non-existent path writes to stderr and exits non-zero.
+        let result = session.run("ls /nonexistent_path_xyz").await.unwrap();
+
+        assert_ne!(result.exit_code, Some(0), "expected non-zero exit code");
+        assert!(
+            !result.stderr.is_empty(),
+            "stderr should not be empty for a failing command"
+        );
+        assert!(
+            result.stderr.contains("No such file or directory"),
+            "stderr should contain error message, got: {:?}",
+            result.stderr
+        );
 
         session.close().await.unwrap();
     }


### PR DESCRIPTION
## Summary

Fixes stderr being silently lost in SSH transport.

Previously, `drain_until_marker_with_exit` and `drain_until_marker` only handled `ChannelMsg::Data`. Since the shell channel is opened without PTY, stderr arrives as `ChannelMsg::ExtendedData { ext: 1, data }` and was silently discarded by the `_ => {}` catch-all arm. As a result, `CommandResult.stderr` was always an empty string.

### Changes

- **`drain_until_marker_with_exit`**: Added `stderr_buf` to accumulate `ExtendedData` with `ext == 1` (SSH stderr). Changed return type to `Result<(String, String, Option<i32>)>` (stdout, stderr, exit_code). Marker search logic untouched — still searches only in the stdout buffer.
- **`drain_until_marker`**: Added explicit `ChannelMsg::ExtendedData { .. }` arm to drain extended data silently during sync.
- **`SshSession::run`**: Now uses the returned `stderr` string instead of `String::new()`.
- Added integration test `ssh_stderr_capture` that runs `ls /nonexistent_path_xyz` and checks `exit_code != 0` and `stderr` contains `"No such file or directory"`.

### Notes

- stdout/stderr interleaving is lost (two separate buffers) — this is expected and documented in a comment.
- The integration test `ssh_stderr_capture` is marked `#[ignore]` and requires the docker-sshd container on port 2222. It was not run locally (container not running).
- All 62 non-ignored tests pass.

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSH command execution now captures remote **stderr** alongside **stdout**, so failures include the actual error output.
  * Improved handling of SSH channel messages prevents error output from interfering with completion/exit-code detection.
  * Remote commands that fail now reliably report a non-zero exit code with stderr preserved separately for easier diagnosis.
* **Tests**
  * Added integration coverage to verify stderr content for failing remote commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->