### PR TITLE
fix(agent): make shell persistence prompt transport-dependent

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -374,3 +374,18 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
 5. Для отладки иконок: `filar.exe` в Explorer + Свойства → Подробно
 6. Для тестирования SSH: `!ssh user@host` в Normal режиме → Ctrl+P для пароля
 7. Все изменения в коде — на русском языке в комментариях и сообщениях пользователю
+
+---
+
+## 11. Недавние изменения (R1 milestone)
+
+### Issue #2: Системный промпт противоречит killer-фиче
+- **Файл:** `crates/agent/src/agent.rs`, функция `build_system_prompt`
+- **Проблема:** промпт говорил «shell state does NOT persist» для всех режимов,
+  включая SSH, где состояние персистентного канала сохраняется между командами.
+- **Фикс:** `shell_desc` теперь зависит от `is_local`:
+  - Local (Windows/POSIX): «does NOT persist» (соответствует `LocalExecutor` —
+    каждая команда в отдельном процессе).
+  - SSH: «DOES persist ... carry over» (соответствует персистентному каналу `SshSession`).
+- **Тесты:** добавлены `ssh_prompt_states_persistence` и `local_prompt_states_no_persistence`.
+- **Публичные контракты:** без изменений — `build_system_prompt` сигнатура та же.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -61,14 +61,22 @@ fn build_system_prompt(is_local: bool, ssh_info: Option<&str>, is_windows: bool)
         }
     };
 
-    let shell_desc = if is_windows && is_local {
-        "You are running on Windows with PowerShell. \
-         Each command runs in a separate process — shell state (cwd, env) does NOT persist between calls. \
-         Use absolute paths or chain commands with semicolons if needed."
+    let shell_desc = if is_local {
+        if is_windows {
+            "You are running on Windows with PowerShell. \
+             Each command runs in a separate process — shell state (cwd, env) does NOT persist between calls. \
+             Use absolute paths or chain commands with semicolons if needed."
+        } else {
+            "You are running on a POSIX shell. \
+             Each command runs in a separate process — shell state (cwd, env) does NOT persist between calls. \
+             Use absolute paths or chain commands with && or ; if needed."
+        }
     } else {
-        "You are running on a POSIX shell. \
-         Each command runs in a separate process — shell state (cwd, env) does NOT persist between calls. \
-         Use absolute paths or chain commands with && or ; if needed."
+        // SSH: persistent channel — state persists between commands.
+        "You are running on a persistent POSIX shell session over SSH. \
+         Shell state (cwd, env) DOES persist between calls: your `cd`, exported variables \
+         and environment carry over to subsequent commands. Prefer using this (e.g. \
+         `cd /var/log` then `ls`)."
     };
 
     format!(
@@ -624,5 +632,29 @@ mod tests {
         assert!(truncated.starts_with("0123456789"));
         assert!(truncated.contains("truncated"));
         assert!(truncated.contains("16"));
+    }
+
+    #[test]
+    fn ssh_prompt_states_persistence() {
+        // SSH mode: prompt should mention persistence.
+        let prompt = build_system_prompt(false, None, false);
+        assert!(
+            prompt.contains("DOES persist") || prompt.contains("carry over"),
+            "SSH prompt should mention shell state persistence, got: {prompt}"
+        );
+        assert!(
+            !prompt.contains("does NOT persist"),
+            "SSH prompt should NOT say state does not persist"
+        );
+    }
+
+    #[test]
+    fn local_prompt_states_no_persistence() {
+        // Local mode: prompt should say state does NOT persist.
+        let prompt = build_system_prompt(true, None, false);
+        assert!(
+            prompt.contains("does NOT persist"),
+            "Local prompt should mention state does NOT persist, got: {prompt}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the system prompt contradicting filar's killer feature — persistent SSH shell.

Previously, `build_system_prompt` told the LLM that "shell state (cwd, env) does NOT persist between calls" for **all** modes, including SSH. But the entire point of the persistent SSH channel is that state **does** persist (tested in `ssh_state_preservation`). The agent was told not to use filar's main capability.

### Changes

**`crates/agent/src/agent.rs`** — `build_system_prompt`:
- `shell_desc` now branches on `is_local`:
  - **Local** (Windows/POSIX): "does NOT persist" — matches `LocalExecutor` which runs each command in a separate `tokio::process::Command`.
  - **SSH**: "DOES persist ... carry over" — matches `SshSession` persistent channel where `cd` and env vars survive between commands.
- Added 2 unit tests:
  - `ssh_prompt_states_persistence` — verifies SSH prompt contains "DOES persist"/"carry over" and NOT "does NOT persist".
  - `local_prompt_states_no_persistence` — verifies local prompt contains "does NOT persist".

**`PROGRESS.md`** — added section 11 with issue #2 summary.

### Verification

- `cargo build --workspace` — green
- `cargo test --workspace` — 64 passed, 0 failed, 4 ignored
- New tests: `ssh_prompt_states_persistence` ✓, `local_prompt_states_no_persistence` ✓
- `LocalExecutor` behavior confirmed non-persistent (each command in separate process, per `local.rs` doc and code)

### Not in scope

- Issue #6 (language mirroring) also touches `build_system_prompt` — separate PR.

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the assistant’s shell guidance to reflect different behavior in local and SSH sessions, including whether command state persists between commands.
  * Improved wording for Windows and POSIX environments so users get more accurate expectations.

* **Tests**
  * Added coverage to verify the prompt now distinguishes persistent SSH sessions from non-persistent local sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->