### PR TITLE
fix(ssh): decouple cancel() from run() via reader-task architecture

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -414,3 +414,10 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
 - **Публичные контракты:** без изменений — `SshSession::run/cancel/close` и
   `SshExecutor::run/cancel` сигнатуры те же. `SshSessionInner` удалён (внутренняя
   деталь реализации).
+- **Review fixes (CodeRabbit PR #9):**
+  - Маркер команды дополнен UUID (`req_{id}_{uuid}`) для защиты от коллизий.
+  - Drain stale events перенесён **до** отправки команды (был после — мог
+    терять вывод быстрых команд).
+  - `debug!` логирует только kind + length, не raw content (безопасность).
+  - Тесты используют `env::var("SSH_PASSWORD").expect(...)` вместо хардкода.
+  - Тест обёрнут `timeout(2s, cancel())` для проверки latency самого `cancel()`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -389,3 +389,28 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
   - SSH: «DOES persist ... carry over» (соответствует персистентному каналу `SshSession`).
 - **Тесты:** добавлены `ssh_prompt_states_persistence` и `local_prompt_states_no_persistence`.
 - **Публичные контракты:** без изменений — `build_system_prompt` сигнатура та же.
+
+### Issue #3: cancel() не может прервать выполняющуюся команду
+- **Файл:** `crates/transport/src/ssh.rs` — `SshSession`, `SshExecutor`
+- **Проблема:** `run()` держал `self.inner.lock().await` всё время выполнения команды
+  (до 120 c). `cancel()` лочил тот же мьютекс → Ctrl-C проходил только после
+  завершения команды. Прерывание зависшей команды фактически не работало.
+- **Фикс — reader-task архитектура:**
+  - На `connect` заспавнен долгоживущий таск, который **единолично владеет**
+    `Channel<Msg>`. Таск в цикле `tokio::select!` читает из канала
+    (`channel.wait()`) и принимает команды из `mpsc` (`cmd_rx`).
+  - `ChannelCmd::Write(Vec<u8>)` — запись в канал; `ChannelCmd::Interrupt` —
+    отправка `\x03` (Ctrl-C).
+  - `ChannelEvent::Data(String)`, `ChannelEvent::Stderr(String)`,
+    `ChannelEvent::Closed` — события наружу через `mpsc::unbounded_channel`.
+  - `SshSession` хранит: `cmd_tx` (отправка команд в таск), `run_lock: Mutex<()>`
+    (сериализация команд), `event_rx: Mutex<UnboundedReceiver>` (чтение событий).
+  - `run()` шлёт payload через `cmd_tx`, читает события из `event_rx` — **не
+    держа** лока, который нужен `cancel()`.
+  - `cancel()` просто шлёт `Interrupt` в `cmd_tx` — мгновенно, без contention.
+- **Тесты:** добавлен интеграционный тест `ssh_cancel_interrupts_long_command`
+  (`#[ignore]`): `sleep 30` прерывается через 1 c, общая длительность < 15 c,
+  последующий `echo ok` возвращает `ok` с exit code 0.
+- **Публичные контракты:** без изменений — `SshSession::run/cancel/close` и
+  `SshExecutor::run/cancel` сигнатуры те же. `SshSessionInner` удалён (внутренняя
+  деталь реализации).

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -5,13 +5,14 @@
 //! boundary detection and exit-code extraction. **Zero files are created
 //! on the remote machine.**
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use russh::client::{self, Handle, Msg};
 use russh::keys::*;
 use russh::{Channel, ChannelMsg, Disconnect};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -51,19 +52,32 @@ impl client::Handler for SshHandler {
 }
 
 // ---------------------------------------------------------------------------
-// SshSession — persistent shell channel
+// Reader-task types
 // ---------------------------------------------------------------------------
 
-/// Inner state protected by a mutex.
-struct SshSessionInner {
-    /// Handle to the SSH session (used for disconnect).
-    #[allow(dead_code)]
-    session: Handle<SshHandler>,
-    /// The persistent shell channel.
-    channel: Channel<Msg>,
-    /// Monotonic counter for request IDs.
-    req_counter: u64,
+/// Commands sent **to** the channel-owning reader task.
+#[derive(Debug)]
+enum ChannelCmd {
+    /// Write raw bytes to the SSH channel (payload, sync marker, etc.).
+    Write(Vec<u8>),
+    /// Send Ctrl-C (0x03) to interrupt the running command.
+    Interrupt,
 }
+
+/// Events received **from** the channel-owning reader task.
+#[derive(Debug)]
+enum ChannelEvent {
+    /// stdout data (`ChannelMsg::Data`).
+    Data(String),
+    /// stderr data (`ChannelMsg::ExtendedData` with `ext == 1`).
+    Stderr(String),
+    /// Channel was closed (EOF, Close, or `None` from `channel.wait()`).
+    Closed,
+}
+
+// ---------------------------------------------------------------------------
+// SshSession — persistent shell channel with reader-task
+// ---------------------------------------------------------------------------
 
 /// An SSH session maintaining a single persistent shell channel.
 ///
@@ -71,8 +85,25 @@ struct SshSessionInner {
 /// followed by a marker `printf` and reads output until the marker is found.
 /// Shell state (cwd, env) is preserved between commands because the channel
 /// is never closed.
+///
+/// **Architecture:** A long-lived reader task owns the `Channel<Msg>` and is
+/// the sole reader/writer. `run()` sends commands and reads events through
+/// `mpsc` channels, while `cancel()` sends an `Interrupt` command that does
+/// **not** compete for any lock held by `run()`.
 pub struct SshSession {
-    inner: Mutex<SshSessionInner>,
+    /// Sender to the reader task (write data, send interrupts).
+    cmd_tx: mpsc::Sender<ChannelCmd>,
+    /// Lightweight per-command mutex — serialises commands but is NOT
+    /// needed by `cancel()`.
+    run_lock: Mutex<()>,
+    /// Event receiver from the reader task, wrapped in a mutex so `run()`
+    /// can call `recv()` (which needs `&mut`). `cancel()` never touches this.
+    event_rx: Mutex<mpsc::UnboundedReceiver<ChannelEvent>>,
+    /// SSH session handle (for disconnect in `close()`). `Handle` contains a
+    /// `JoinHandle` which is `Send` but not `Sync`, so we wrap in `Mutex`.
+    session: Mutex<Handle<SshHandler>>,
+    /// Monotonic counter for request IDs.
+    req_counter: AtomicU64,
 }
 
 impl SshSession {
@@ -144,7 +175,7 @@ impl SshSession {
         }
 
         // ── Open persistent shell channel ──────────────────────────────
-        let channel = session
+        let mut channel = session
             .channel_open_session()
             .await
             .map_err(|e| CoreError::Other(format!("failed to open channel: {e}")))?;
@@ -155,34 +186,38 @@ impl SshSession {
             .await
             .map_err(|e| CoreError::Other(format!("failed to request shell: {e}")))?;
 
-        let mut inner = SshSessionInner {
-            session,
-            channel,
-            req_counter: 0,
-        };
-
         // ── Sync: drain initial shell output ───────────────────────────
-        // Send a unique sync marker and wait for it to appear.
+        // Send a unique sync marker and wait for it to appear. This is done
+        // directly on the channel BEFORE spawning the reader task.
         let sync_id = format!("sync_{}", Uuid::new_v4().simple());
         let sync_cmd = format!(
             "printf '\\n{}{}\\n'\n",
             MARKER_PREFIX, sync_id
         );
-        inner
-            .channel
+        channel
             .data(sync_cmd.as_bytes())
             .await
             .map_err(|e| CoreError::Other(format!("failed to send sync marker: {e}")))?;
 
-        // Read until we find the sync marker.
         let sync_marker = format!("{}{}", MARKER_PREFIX, sync_id);
-        drain_until_marker(&mut inner.channel, &sync_marker, Duration::from_secs(10))
+        drain_until_marker(&mut channel, &sync_marker, Duration::from_secs(10))
             .await?;
+
+        // ── Spawn reader task ──────────────────────────────────────────
+        // The task is the sole owner of `Channel<Msg>` from this point on.
+        let (cmd_tx, cmd_rx) = mpsc::channel::<ChannelCmd>(16);
+        let (event_tx, event_rx) = mpsc::unbounded_channel::<ChannelEvent>();
+
+        tokio::spawn(reader_task(channel, cmd_rx, event_tx));
 
         info!("SSH shell channel ready and synchronised");
 
         Ok(Self {
-            inner: Mutex::new(inner),
+            cmd_tx,
+            run_lock: Mutex::new(()),
+            event_rx: Mutex::new(event_rx),
+            session: Mutex::new(session),
+            req_counter: AtomicU64::new(0),
         })
     }
 
@@ -195,34 +230,40 @@ impl SshSession {
     /// If the command times out, Ctrl-C is sent to the shell and a resync
     /// marker is used to restore the channel to a known state.
     pub async fn run(&self, command: &str) -> Result<CommandResult> {
-        let mut inner = self.inner.lock().await;
-        let req_id = inner.req_counter;
-        inner.req_counter += 1;
-    
+        // Serialize commands — only one `run()` at a time.
+        let _guard = self.run_lock.lock().await;
+
+        let req_id = self.req_counter.fetch_add(1, Ordering::Relaxed);
         let marker_id = format!("req_{:08x}", req_id);
         let marker_tag = format!("{}{}", MARKER_PREFIX, marker_id);
-    
+
         // Build the full payload: <command>\n printf marker\n
         let payload = format!(
             "{}\nprintf '\\n{}__%d__\\n' \"$?\"\n",
             command, marker_tag
         );
-    
+
         let start = Instant::now();
-        inner
-            .channel
-            .data(payload.as_bytes())
+
+        // Send the payload to the reader task (which owns the channel).
+        self.cmd_tx
+            .send(ChannelCmd::Write(payload.into_bytes()))
             .await
-            .map_err(|e| CoreError::Other(format!("failed to send command: {e}")))?;
-    
-        // Read until we find the marker.
-        match drain_until_marker_with_exit(
-            &mut inner.channel,
-            &marker_tag,
-            Duration::from_secs(120),
-        )
-        .await
+            .map_err(|_| CoreError::Other("channel task closed".into()))?;
+
+        // Lock the event receiver. `cancel()` never touches this mutex.
+        let mut event_rx = self.event_rx.lock().await;
+
+        // Drain any stale events from a previous command.
+        while let Ok(Some(event)) =
+            tokio::time::timeout(Duration::from_millis(10), event_rx.recv()).await
         {
+            debug!(?event, "draining stale event");
+        }
+
+        // Read events until we find the marker — without holding any lock
+        // that `cancel()` needs.
+        match recv_until_marker(&mut event_rx, &marker_tag, Duration::from_secs(120)).await {
             Ok((stdout, stderr, exit_code)) => {
                 let duration = start.elapsed();
                 Ok(CommandResult {
@@ -236,37 +277,123 @@ impl SshSession {
                 // Command timed out or failed. Send Ctrl-C to interrupt
                 // any running process, then resync the shell.
                 warn!(error = %e, "command timed out, sending Ctrl-C and resyncing");
-                let ctrl_c: &[u8] = b"\x03";
-                let _ = inner.channel.data(ctrl_c).await; // Ctrl-C
-                // Drain any pending output and resync.
+                let _ = self.cmd_tx.send(ChannelCmd::Interrupt).await;
+                // Drain any remaining output and resync.
                 let sync_id = format!("sync_{}", Uuid::new_v4().simple());
                 let sync_cmd = format!(
                     "printf '\\n{}{}\\n'\n",
                     MARKER_PREFIX, sync_id
                 );
-                let _ = inner.channel.data(sync_cmd.as_bytes()).await;
+                let _ = self
+                    .cmd_tx
+                    .send(ChannelCmd::Write(sync_cmd.into_bytes()))
+                    .await;
                 let sync_marker = format!("{}{}", MARKER_PREFIX, sync_id);
-                let _ = drain_until_marker(
-                    &mut inner.channel,
-                    &sync_marker,
-                    Duration::from_secs(10),
-                )
-                .await;
+                let _ = recv_until_marker_simple(&mut event_rx, &sync_marker, Duration::from_secs(10))
+                    .await;
                 Err(e)
             }
         }
     }
 
+    /// Send Ctrl-C to interrupt the currently running command.
+    ///
+    /// This sends an `Interrupt` command to the reader task via `cmd_tx`.
+    /// It does **not** acquire any lock that `run()` holds, so it works
+    /// even while a command is executing.
+    pub async fn cancel(&self) -> Result<()> {
+        self.cmd_tx
+            .send(ChannelCmd::Interrupt)
+            .await
+            .map_err(|_| CoreError::Other("failed to send Ctrl-C: channel task closed".into()))?;
+        Ok(())
+    }
+
     /// Disconnect the SSH session.
     pub async fn close(&self) -> Result<()> {
-        let inner = self.inner.lock().await;
-        let _ = inner
-            .session
+        let session = self.session.lock().await;
+        let _ = session
             .disconnect(Disconnect::ByApplication, "", "English")
             .await;
         info!("SSH session closed");
         Ok(())
     }
+}
+
+// ---------------------------------------------------------------------------
+// Reader task — sole owner of `Channel<Msg>`
+// ---------------------------------------------------------------------------
+
+/// Long-lived task that owns the SSH `Channel` and is the sole reader/writer.
+///
+/// It accepts commands (`Write`, `Interrupt`) via `cmd_rx` and forwards
+/// channel events (`Data`, `Stderr`, `Closed`) via `event_tx`.
+async fn reader_task(
+    mut channel: Channel<Msg>,
+    mut cmd_rx: mpsc::Receiver<ChannelCmd>,
+    event_tx: mpsc::UnboundedSender<ChannelEvent>,
+) {
+    debug!("SSH reader task started");
+    loop {
+        tokio::select! {
+            // ── Incoming commands ──────────────────────────────────────
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(ChannelCmd::Write(data)) => {
+                        if let Err(e) = channel.data(&data[..]).await {
+                            warn!(error = %e, "reader: failed to write to channel");
+                            let _ = event_tx.send(ChannelEvent::Closed);
+                            break;
+                        }
+                    }
+                    Some(ChannelCmd::Interrupt) => {
+                        debug!("reader: sending Ctrl-C (0x03)");
+                        if let Err(e) = channel.data(&b"\x03"[..]).await {
+                            warn!(error = %e, "reader: failed to send Ctrl-C");
+                            let _ = event_tx.send(ChannelEvent::Closed);
+                            break;
+                        }
+                    }
+                    None => {
+                        // cmd_tx dropped — SshSession is shutting down.
+                        debug!("reader: cmd_rx closed, exiting");
+                        break;
+                    }
+                }
+            }
+            // ── Channel events ─────────────────────────────────────────
+            msg = channel.wait() => {
+                match msg {
+                    Some(ChannelMsg::Data { ref data }) => {
+                        let text = String::from_utf8_lossy(data.as_ref()).to_string();
+                        if event_tx.send(ChannelEvent::Data(text)).is_err() {
+                            // event_rx dropped — no one is listening.
+                            debug!("reader: event_tx closed, exiting");
+                            break;
+                        }
+                    }
+                    Some(ChannelMsg::ExtendedData { ref data, ext }) if ext == 1 => {
+                        debug!(len = data.len(), "stderr data received from SSH channel");
+                        let text = String::from_utf8_lossy(data.as_ref()).to_string();
+                        if event_tx.send(ChannelEvent::Stderr(text)).is_err() {
+                            debug!("reader: event_tx closed, exiting");
+                            break;
+                        }
+                    }
+                    Some(ChannelMsg::ExtendedData { .. }) => {
+                        // Other extended data — ignore.
+                    }
+                    Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
+                        warn!("reader: channel closed (EOF/Close/None)");
+                        let _ = event_tx.send(ChannelEvent::Closed);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    debug!("SSH reader task exited");
 }
 
 // ---------------------------------------------------------------------------
@@ -298,14 +425,7 @@ impl crate::CommandExecutor for SshExecutor {
     }
 
     async fn cancel(&self) -> Result<()> {
-        // Send Ctrl-C (0x03) to the SSH channel.
-        let inner = self.session.inner.lock().await;
-        inner
-            .channel
-            .data(&b"\x03"[..])
-            .await
-            .map_err(|e| CoreError::Other(format!("failed to send Ctrl-C: {e}")))?;
-        Ok(())
+        self.session.cancel().await
     }
 }
 
@@ -327,6 +447,9 @@ pub(crate) fn dirs_or_default() -> std::path::PathBuf {
 
 /// Read from the channel until `marker` is found in the accumulated output.
 /// Returns the output *before* the marker (discarded for sync).
+///
+/// This is used directly on the `Channel` in `connect()` **before** the
+/// reader task is spawned.
 async fn drain_until_marker(
     channel: &mut Channel<Msg>,
     marker: &str,
@@ -364,10 +487,14 @@ async fn drain_until_marker(
     }
 }
 
-/// Read from the channel until a marker of the form `<marker_tag>__<exit_code>__`
-/// is found. Returns the output before the marker and the parsed exit code.
-async fn drain_until_marker_with_exit(
-    channel: &mut Channel<Msg>,
+/// Read events from the reader task until a marker of the form
+/// `<marker_tag>__<exit_code>__` is found. Returns the output before the
+/// marker and the parsed exit code.
+///
+/// Unlike `drain_until_marker`, this reads from an `mpsc::UnboundedReceiver`
+/// and does NOT touch the SSH channel directly — the reader task does that.
+async fn recv_until_marker(
+    event_rx: &mut mpsc::UnboundedReceiver<ChannelEvent>,
     marker_tag: &str,
     timeout: Duration,
 ) -> Result<(String, String, Option<i32>)> {
@@ -376,40 +503,38 @@ async fn drain_until_marker_with_exit(
     let deadline = tokio::time::Instant::now() + timeout;
 
     loop {
-        let msg = tokio::time::timeout_at(deadline, channel.wait())
+        let event = tokio::time::timeout_at(deadline, event_rx.recv())
             .await
             .map_err(|_| CoreError::Other(format!("timeout waiting for command marker `{marker_tag}`")))?
             .ok_or_else(|| CoreError::Other("channel closed before marker received".into()))?;
 
-        match msg {
-            ChannelMsg::Data { ref data } => {
-                buf.push_str(&String::from_utf8_lossy(data.as_ref()));
+        match event {
+            ChannelEvent::Data(text) => {
+                buf.push_str(&text);
 
                 // Look for the marker line: <marker_tag>__<digits>__
                 if let Some(pos) = buf.find(marker_tag) {
-                    // Found the marker tag — try to parse the exit code.
                     let after_tag = &buf[pos + marker_tag.len()..];
-                    // Expected format: __<digits>__
                     if let Some(rest) = after_tag.strip_prefix("__") {
                         if let Some(end) = rest.find("__") {
                             let code_str = &rest[..end];
                             if let Ok(code) = code_str.trim().parse::<i32>() {
-                                // Output is everything before the marker line.
-                                // Find the start of the marker line (go back to the previous newline).
-                                let line_start = buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
+                                let line_start =
+                                    buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
                                 let output = buf[..line_start].to_string();
-                                // Drain any trailing ExtendedData (stderr) that may still
-                                // be buffered on the channel. Without this, late stderr
-                                // from the current command could contaminate the next
-                                // run's result. Best-effort: uses a short timeout since
-                                // in normal operation all stderr arrives before the marker.
+
+                                // Drain any trailing stderr that may still be
+                                // in the event pipeline. Without this, late
+                                // stderr could contaminate the next run's result.
                                 loop {
                                     match tokio::time::timeout(
                                         Duration::from_millis(50),
-                                        channel.wait(),
-                                    ).await {
-                                        Ok(Some(ChannelMsg::ExtendedData { ref data, ext })) if ext == 1 => {
-                                            stderr_buf.push_str(&String::from_utf8_lossy(data.as_ref()));
+                                        event_rx.recv(),
+                                    )
+                                    .await
+                                    {
+                                        Ok(Some(ChannelEvent::Stderr(text))) => {
+                                            stderr_buf.push_str(&text);
                                         }
                                         _ => break,
                                     }
@@ -421,21 +546,49 @@ async fn drain_until_marker_with_exit(
                     // Marker tag found but couldn't parse exit code — keep reading.
                 }
             }
-            ChannelMsg::ExtendedData { ref data, ext } => {
-                // SSH EXTENDED_DATA with data_type_code 1 = stderr.
-                // Note: stdout/stderr interleaving is lost with separate buffers;
-                // this is acceptable — the agent receives them as independent streams.
-                if ext == 1 {
-                    debug!(len = data.len(), "stderr data received from SSH channel");
-                    stderr_buf.push_str(&String::from_utf8_lossy(data.as_ref()));
-                }
+            ChannelEvent::Stderr(text) => {
+                stderr_buf.push_str(&text);
             }
-            ChannelMsg::Eof | ChannelMsg::Close => {
+            ChannelEvent::Closed => {
                 return Err(CoreError::Other(
                     "channel closed before command marker received".into(),
                 ));
             }
-            _ => {}
+        }
+    }
+}
+
+/// Read events from the reader task until `marker` is found. Used for
+/// resync after a timeout/cancel — output is discarded.
+async fn recv_until_marker_simple(
+    event_rx: &mut mpsc::UnboundedReceiver<ChannelEvent>,
+    marker: &str,
+    timeout: Duration,
+) -> Result<()> {
+    let mut buf = String::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let event = tokio::time::timeout_at(deadline, event_rx.recv())
+            .await
+            .map_err(|_| CoreError::Other(format!("timeout waiting for marker `{marker}`")))?
+            .ok_or_else(|| CoreError::Other("channel closed before marker received".into()))?;
+
+        match event {
+            ChannelEvent::Data(text) => {
+                buf.push_str(&text);
+                if buf.find(marker).is_some() {
+                    return Ok(());
+                }
+            }
+            ChannelEvent::Stderr(_) => {
+                // Ignore stderr during sync.
+            }
+            ChannelEvent::Closed => {
+                return Err(CoreError::Other(
+                    "channel closed before marker received".into(),
+                ));
+            }
         }
     }
 }
@@ -576,6 +729,76 @@ mod tests {
             "stderr should contain error message, got: {:?}",
             result.stderr
         );
+
+        session.close().await.unwrap();
+    }
+
+    /// Integration test — verifies that cancel() interrupts a long-running
+    /// command before its natural completion.
+    ///
+    /// Expected behaviour:
+    /// 1. `run("sleep 30")` is started in a background task.
+    /// 2. After 1 second, `cancel()` is called.
+    /// 3. `run()` should return quickly (well under 30 seconds) — either
+    ///    with an error (timeout) or with a non-zero exit code (SIGINT = 130).
+    /// 4. The shell remains usable: a subsequent `run("echo ok")` returns
+    ///    `ok` with exit code 0 (thanks to resync).
+    #[tokio::test]
+    #[ignore = "requires Docker sshd container on port 2222"]
+    async fn ssh_cancel_interrupts_long_command() {
+        let target = SshTarget {
+            name: "test".into(),
+            host: "127.0.0.1".into(),
+            port: 2222,
+            user: "testuser".into(),
+            auth: SshAuth::Password { password: None },
+        };
+        std::env::set_var("SSH_PASSWORD", "testpassword");
+
+        let session = Arc::new(SshSession::connect(&target).await.unwrap());
+
+        // Spawn the long-running command in a separate task.
+        let session_clone = session.clone();
+        let run_task = tokio::spawn(async move {
+            session_clone.run("sleep 30").await
+        });
+
+        // Give the command a moment to start, then cancel.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        session.cancel().await.unwrap();
+
+        // The command should return quickly (well under 30 seconds).
+        let start = Instant::now();
+        let result = tokio::time::timeout(Duration::from_secs(15), run_task)
+            .await
+            .expect("cancel did not interrupt the command in time");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(15),
+            "cancel took too long: {elapsed:?}"
+        );
+
+        // The result should be either an error (timeout/channel) or a
+        // non-zero exit code (SIGINT = 130). A `Some(0)` means the command
+        // was NOT interrupted — that's a failure.
+        match result {
+            Ok(Ok(r)) => {
+                assert_ne!(
+                    r.exit_code,
+                    Some(0),
+                    "expected non-zero exit code after cancel, got: {:?}",
+                    r.exit_code
+                );
+            }
+            // Error from run() (timeout) or JoinError — both acceptable.
+            Ok(Err(_)) | Err(_) => {}
+        }
+
+        // Verify the shell is still usable after cancel.
+        let result = session.run("echo ok").await.unwrap();
+        assert_eq!(result.stdout.trim(), "ok");
+        assert_eq!(result.exit_code, Some(0));
 
         session.close().await.unwrap();
     }

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -234,7 +234,7 @@ impl SshSession {
         let _guard = self.run_lock.lock().await;
 
         let req_id = self.req_counter.fetch_add(1, Ordering::Relaxed);
-        let marker_id = format!("req_{:08x}", req_id);
+        let marker_id = format!("req_{:08x}_{}", req_id, Uuid::new_v4().simple());
         let marker_tag = format!("{}{}", MARKER_PREFIX, marker_id);
 
         // Build the full payload: <command>\n printf marker\n
@@ -245,21 +245,29 @@ impl SshSession {
 
         let start = Instant::now();
 
+        // Lock the event receiver. `cancel()` never touches this mutex.
+        let mut event_rx = self.event_rx.lock().await;
+
+        // Drain any stale events from a previous command BEFORE sending
+        // the new payload — otherwise fast commands' output could be
+        // discarded as "stale".
+        while let Ok(Some(event)) =
+            tokio::time::timeout(Duration::from_millis(10), event_rx.recv()).await
+        {
+            // Log only metadata — raw output may contain secrets.
+            let (kind, len) = match &event {
+                ChannelEvent::Data(text) => ("stdout", text.len()),
+                ChannelEvent::Stderr(text) => ("stderr", text.len()),
+                ChannelEvent::Closed => ("closed", 0),
+            };
+            debug!(kind, len, "draining stale event");
+        }
+
         // Send the payload to the reader task (which owns the channel).
         self.cmd_tx
             .send(ChannelCmd::Write(payload.into_bytes()))
             .await
             .map_err(|_| CoreError::Other("channel task closed".into()))?;
-
-        // Lock the event receiver. `cancel()` never touches this mutex.
-        let mut event_rx = self.event_rx.lock().await;
-
-        // Drain any stale events from a previous command.
-        while let Ok(Some(event)) =
-            tokio::time::timeout(Duration::from_millis(10), event_rx.recv()).await
-        {
-            debug!(?event, "draining stale event");
-        }
 
         // Read events until we find the marker — without holding any lock
         // that `cancel()` needs.
@@ -622,6 +630,7 @@ mod tests {
 
     /// Integration test — requires a running SSH server.
     /// Start one with: docker run -d -p 2222:22 --name filar-sshd filar-sshd
+    /// Set SSH_PASSWORD env var, e.g. `set SSH_PASSWORD=testpassword`.
     #[tokio::test]
     #[ignore = "requires Docker sshd container on port 2222"]
     async fn ssh_run_basic() {
@@ -632,7 +641,8 @@ mod tests {
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
         };
-        std::env::set_var("SSH_PASSWORD", "testpassword");
+        std::env::var("SSH_PASSWORD")
+            .expect("set SSH_PASSWORD to run ignored SSH integration tests");
 
         let session = SshSession::connect(&target).await.unwrap();
         let result = session.run("echo hi").await.unwrap();
@@ -656,7 +666,8 @@ mod tests {
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
         };
-        std::env::set_var("SSH_PASSWORD", "testpassword");
+        std::env::var("SSH_PASSWORD")
+            .expect("set SSH_PASSWORD to run ignored SSH integration tests");
 
         let session = SshSession::connect(&target).await.unwrap();
 
@@ -679,7 +690,8 @@ mod tests {
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
         };
-        std::env::set_var("SSH_PASSWORD", "testpassword");
+        std::env::var("SSH_PASSWORD")
+            .expect("set SSH_PASSWORD to run ignored SSH integration tests");
 
         let session = SshSession::connect(&target).await.unwrap();
 
@@ -711,7 +723,8 @@ mod tests {
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
         };
-        std::env::set_var("SSH_PASSWORD", "testpassword");
+        std::env::var("SSH_PASSWORD")
+            .expect("set SSH_PASSWORD to run ignored SSH integration tests");
 
         let session = SshSession::connect(&target).await.unwrap();
 
@@ -753,7 +766,8 @@ mod tests {
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
         };
-        std::env::set_var("SSH_PASSWORD", "testpassword");
+        std::env::var("SSH_PASSWORD")
+            .expect("set SSH_PASSWORD to run ignored SSH integration tests");
 
         let session = Arc::new(SshSession::connect(&target).await.unwrap());
 
@@ -765,7 +779,10 @@ mod tests {
 
         // Give the command a moment to start, then cancel.
         tokio::time::sleep(Duration::from_secs(1)).await;
-        session.cancel().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), session.cancel())
+            .await
+            .expect("cancel() blocked")
+            .unwrap();
 
         // The command should return quickly (well under 30 seconds).
         let start = Instant::now();


### PR DESCRIPTION
## Summary

Fixes the deadlock where `cancel()` couldn't interrupt a running command because both `run()` and `cancel()` competed for the same `Mutex<SshSessionInner>`.

### Architecture change — reader-task

- A long-lived task spawned on `connect()` is the **sole owner** of `Channel<Msg>`
- It uses `tokio::select!` to either read channel events (`channel.wait()`) or accept commands (`cmd_rx.recv()`)
- `ChannelCmd::Write(Vec<u8>)` writes to the channel; `ChannelCmd::Interrupt` sends `\x03` (Ctrl-C)
- Events are forwarded via `mpsc::unbounded_channel`: `Data(String)`, `Stderr(String)`, `Closed`
- `SshSession` stores `cmd_tx` + `run_lock: Mutex<()>` (serialize commands) + `event_rx: Mutex<UnboundedReceiver>`
- `run()` sends payload via `cmd_tx`, reads events via `event_rx` — does NOT hold any lock that `cancel()` needs
- `cancel()` sends `Interrupt` via `cmd_tx` — **instant, zero lock contention**

### What changed

- `SshSessionInner` removed (was the source of the shared mutex)
- `drain_until_marker_with_exit` replaced by `recv_until_marker` (reads from mpsc, not channel directly)
- `drain_until_marker` kept for initial sync in `connect()` (before reader task is spawned)
- `SshSession::cancel()` is now a simple `cmd_tx.send(Interrupt)` — no locks

### Public API

No changes — `SshSession::run/cancel/close` and `SshExecutor::run/cancel` signatures are the same.

## Tests

- `cargo build --workspace` — green, no warnings
- `cargo test --workspace` — **64 passed, 0 failed, 5 ignored**
- New test `ssh_cancel_interrupts_long_command` (requires Docker sshd, `#[ignore]`):
  - Starts `sleep 30` in background, calls `cancel()` after 1s
  - Verifies total duration < 15s
  - Verifies shell is still usable: `echo ok` → `ok`, exit code 0

### Requires manual verification

All 5 `#[ignore]` tests need `docker run -d -p 2222:22 --name filar-sshd filar-sshd`:
- `ssh_run_basic`
- `ssh_state_preservation`
- `ssh_zero_install`
- `ssh_stderr_capture`
- `ssh_cancel_interrupts_long_command` (new)

## Out of scope

- `run_streaming` still uses the default buffered implementation (bonus item in the issue, not a blocker)
- Host key verification is issue #4

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH command cancellation so long-running commands are interrupted promptly.
  * Ensured the SSH session remains usable for subsequent commands after cancellation.
* **Tests**
  * Added an integration test that verifies `cancel()` interrupts a long-running SSH command and that a follow-up command succeeds.
  * Ignored SSH integration tests now require `SSH_PASSWORD` to be set externally.
* **Documentation**
  * Updated progress notes describing the cancellation behavior and the fix direction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->