### PR TITLE
fix(ssh): implement TOFU host key verification via known_hosts

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -421,3 +421,33 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
   - `debug!` логирует только kind + length, не raw content (безопасность).
   - Тесты используют `env::var("SSH_PASSWORD").expect(...)` вместо хардкода.
   - Тест обёрнут `timeout(2s, cancel())` для проверки latency самого `cancel()`.
+
+### Issue #4: host key не проверяется, MITM
+- **Файлы:** `crates/core/src/config.rs`, `crates/core/src/lib.rs`,
+  `crates/transport/src/ssh.rs`, `crates/transport/src/interactive.rs`,
+  `crates/tui/src/runner.rs`, `crates/app/src/main.rs`
+- **Проблема:** `check_server_key` всегда возвращал `Ok(true)` — любой MITM
+  проходил незамеченным.
+- **Фикс — TOFU (Trust On First Use):**
+  - Добавлен `HostKeyPolicy` enum в `config.rs`: `Strict`, `Tofu` (default),
+    `AcceptNew`. Сериализация `snake_case`.
+  - Поле `host_key_policy: HostKeyPolicy` добавлено в `SshTarget` с
+    `#[serde(default)]`.
+  - `SshHandler` (ssh.rs) теперь содержит поля: `host`, `port`, `policy`,
+    `known_hosts_path`.
+  - `check_server_key` вычисляет SHA256 fingerprint, проверяет known_hosts.
+    - `Match` → accept.
+    - `Mismatch` → reject (`Ok(false)`).
+    - `New` → зависит от policy: `Strict` reject, `Tofu` accept+save,
+      `AcceptNew` accept без сохранения.
+  - Known_hosts файл: `~/.config/filar/known_hosts`, формат `host:port SHA256:fp`.
+  - Хелперы: `known_hosts_path()`, `parse_known_hosts_contents()`,
+    `parse_known_hosts()`, `append_known_hosts_entry()`, `check_host_key()`.
+  - `interactive.rs` и `runner.rs` обновлены для construction `SshHandler` с
+    полями и `SshTarget` с `host_key_policy`.
+- **Тесты (5 unit):** `known_hosts_parse_contents`, `known_hosts_append_and_read`,
+  `host_key_check_match`, `host_key_check_mismatch`, `host_key_check_new`.
+- **Публичные контракты:** `HostKeyPolicy` добавлен в re-exports `filar-core`.
+  `SshTarget` получил новое поле (backward-incompatible для ручной инициализации,
+  но serde-совместимо через `#[serde(default)]`).
+- Total: 70 tests pass, 0 fail, 5 ignored (Docker).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -451,3 +451,10 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
   `SshTarget` получил новое поле (backward-incompatible для ручной инициализации,
   но serde-совместимо через `#[serde(default)]`).
 - Total: 70 tests pass, 0 fail, 5 ignored (Docker).
+- **Review fixes (CodeRabbit PR #10):**
+  - `parse_known_hosts` возвращает `Result` вместо silent empty map. Только
+    `NotFound` → пустая карта (first connection); остальные I/O ошибки →
+    reject (fail closed).
+  - TOFU-путь: если `append_known_hosts_entry` не удался → reject (`Ok(false)`)
+    вместо accept с warning. Ключ должен быть закреплён, иначе подключение
+    не должно проходить.

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -221,6 +221,7 @@ async fn run() -> anyhow::Result<()> {
                     auth: filar_core::SshAuth::Password {
                         password: if s.password.is_empty() { None } else { Some(s.password) },
                     },
+                    host_key_policy: filar_core::HostKeyPolicy::Tofu,
                 });
 
                 (

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -69,6 +69,10 @@ pub struct SshTarget {
     /// Authentication strategy.
     #[serde(default)]
     pub auth: SshAuth,
+
+    /// Host key verification policy (default: TOFU).
+    #[serde(default)]
+    pub host_key_policy: HostKeyPolicy,
 }
 
 fn default_ssh_port() -> u16 {
@@ -93,6 +97,30 @@ pub enum SshAuth {
         #[serde(default)]
         password: Option<String>,
     },
+}
+
+// ---------------------------------------------------------------------------
+// Host key policy
+// ---------------------------------------------------------------------------
+
+/// Host key verification policy for SSH connections.
+///
+/// Controls how the client handles the server's public key:
+/// - [`Strict`](Self::Strict): reject unknown hosts (must be in known_hosts).
+/// - [`Tofu`](Self::Tofu): trust on first use — accept, record, then verify.
+/// - [`AcceptNew`](Self::AcceptNew): accept new keys without recording.
+///
+/// There is **no** "accept everything silently" option.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HostKeyPolicy {
+    /// Reject unknown hosts — only accept keys already in known_hosts.
+    Strict,
+    /// Trust on first use: accept and record new keys, reject mismatches (default).
+    #[default]
+    Tofu,
+    /// Accept new keys without recording, reject mismatches.
+    AcceptNew,
 }
 
 // ---------------------------------------------------------------------------
@@ -346,6 +374,30 @@ type = "agent"
         assert_eq!(cfg.confirm_mode, CommandConfirmMode::Allowlist);
         assert_eq!(cfg.ssh_targets.len(), 2);
         assert_eq!(cfg.ssh_target("staging").unwrap().host, "10.0.0.6");
+    }
+
+    #[test]
+    fn parse_host_key_policy() {
+        let toml = r#"
+[llm]
+model = "glm-5.1"
+api_base_url = "https://open.bigmodel.cn/api/paas/v4"
+
+[[ssh_targets]]
+name = "prod"
+host = "10.0.0.5"
+user = "deploy"
+host_key_policy = "strict"
+
+[[ssh_targets]]
+name = "dev"
+host = "10.0.0.6"
+user = "dev"
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.ssh_targets[0].host_key_policy, HostKeyPolicy::Strict);
+        // Default is Tofu.
+        assert_eq!(cfg.ssh_targets[1].host_key_policy, HostKeyPolicy::Tofu);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,6 @@ pub mod secrets;
 pub mod session;
 
 pub use chat::ChatBlock;
-pub use config::{Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig};
+pub use config::{Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig, HostKeyPolicy};
 pub use error::{CoreError, Result};
 pub use session::{Session, SessionMeta, SessionStore};

--- a/crates/transport/src/interactive.rs
+++ b/crates/transport/src/interactive.rs
@@ -23,7 +23,7 @@ use tracing::info;
 
 use filar_core::{CoreError, Result, SshAuth, SshTarget};
 
-use crate::ssh::{dirs_or_default, SshHandler};
+use crate::ssh::{dirs_or_default, known_hosts_path, SshHandler};
 
 // ---------------------------------------------------------------------------
 // InteractiveTerminal trait
@@ -242,7 +242,13 @@ impl SshInteractive {
         let addr = (target.host.as_str(), target.port);
         info!(host = %target.host, port = target.port, user = %target.user, "connecting interactive SSH");
 
-        let mut session = client::connect(config, addr, SshHandler)
+        let handler = SshHandler {
+            host: target.host.clone(),
+            port: target.port,
+            policy: target.host_key_policy,
+            known_hosts_path: known_hosts_path(),
+        };
+        let mut session = client::connect(config, addr, handler)
             .await
             .map_err(|e| CoreError::Other(format!("SSH connect failed: {e}")))?;
 

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -5,6 +5,8 @@
 //! boundary detection and exit-code extraction. **Zero files are created
 //! on the remote machine.**
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -16,7 +18,7 @@ use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use filar_core::{CoreError, Result, SshAuth, SshTarget};
+use filar_core::{CoreError, HostKeyPolicy, Result, SshAuth, SshTarget};
 
 use crate::CommandResult;
 
@@ -34,9 +36,18 @@ const MARKER_PREFIX: &str = "__FILAR_";
 
 /// Handler for SSH session events.
 ///
-/// Currently accepts all host keys (with a warning). TODO: verify against
-/// `known_hosts`.
-pub(crate) struct SshHandler;
+/// Implements TOFU (trust on first use) host key verification via a
+/// `known_hosts` file at `~/.config/filar/known_hosts`.
+pub(crate) struct SshHandler {
+    /// Remote host (for known_hosts lookup).
+    pub(crate) host: String,
+    /// Remote port.
+    pub(crate) port: u16,
+    /// Host key verification policy.
+    pub(crate) policy: HostKeyPolicy,
+    /// Path to the known_hosts file.
+    pub(crate) known_hosts_path: PathBuf,
+}
 
 impl client::Handler for SshHandler {
     type Error = russh::Error;
@@ -46,8 +57,49 @@ impl client::Handler for SshHandler {
         server_public_key: &ssh_key::PublicKey,
     ) -> std::result::Result<bool, Self::Error> {
         let fingerprint = server_public_key.fingerprint(ssh_key::HashAlg::Sha256);
-        warn!(%fingerprint, "accepting unverified host key (known_hosts check not yet implemented)");
-        Ok(true)
+        let fp_str = fingerprint.to_string();
+        let host_port = format!("{}:{}", self.host, self.port);
+
+        let entries = parse_known_hosts(&self.known_hosts_path);
+
+        match check_host_key(&entries, &host_port, &fp_str) {
+            HostKeyCheck::Match => {
+                debug!(host = %host_port, "host key verified (matches known_hosts)");
+                Ok(true)
+            }
+            HostKeyCheck::Mismatch => {
+                warn!(
+                    host = %host_port,
+                    "HOST KEY MISMATCH — possible MITM, rejecting"
+                );
+                Ok(false)
+            }
+            HostKeyCheck::New => match self.policy {
+                HostKeyPolicy::Strict => {
+                    warn!(
+                        host = %host_port,
+                        "unknown host key (strict mode — rejecting)"
+                    );
+                    Ok(false)
+                }
+                HostKeyPolicy::Tofu => {
+                    info!(host = %host_port, "host key added (TOFU)");
+                    if let Err(e) =
+                        append_known_hosts_entry(&self.known_hosts_path, &host_port, &fp_str)
+                    {
+                        warn!(error = %e, "failed to write known_hosts entry");
+                    }
+                    Ok(true)
+                }
+                HostKeyPolicy::AcceptNew => {
+                    info!(
+                        host = %host_port,
+                        "host key accepted (accept-new, not recorded)"
+                    );
+                    Ok(true)
+                }
+            },
+        }
     }
 }
 
@@ -118,7 +170,13 @@ impl SshSession {
         let addr = (target.host.as_str(), target.port);
         info!(host = %target.host, port = target.port, user = %target.user, "connecting via SSH");
 
-        let mut session = client::connect(config, addr, SshHandler)
+        let handler = SshHandler {
+            host: target.host.clone(),
+            port: target.port,
+            policy: target.host_key_policy,
+            known_hosts_path: known_hosts_path(),
+        };
+        let mut session = client::connect(config, addr, handler)
             .await
             .map_err(|e| CoreError::Other(format!("SSH connect failed: {e}")))?;
 
@@ -453,6 +511,89 @@ pub(crate) fn dirs_or_default() -> std::path::PathBuf {
     std::path::PathBuf::from(&home).join(".ssh/id_rsa")
 }
 
+/// Default known_hosts path: `~/.config/filar/known_hosts`.
+pub(crate) fn known_hosts_path() -> PathBuf {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".into());
+    PathBuf::from(&home)
+        .join(".config")
+        .join("filar")
+        .join("known_hosts")
+}
+
+/// Parse known_hosts file contents into a `host:port → fingerprint` map.
+fn parse_known_hosts_contents(contents: &str) -> HashMap<String, String> {
+    let mut entries = HashMap::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.splitn(2, char::is_whitespace);
+        if let (Some(host), Some(fp)) = (parts.next(), parts.next()) {
+            entries.insert(host.trim().to_string(), fp.trim().to_string());
+        }
+    }
+    entries
+}
+
+/// Read and parse the known_hosts file. Returns an empty map if the file
+/// doesn't exist or can't be read.
+fn parse_known_hosts(path: &Path) -> HashMap<String, String> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => parse_known_hosts_contents(&contents),
+        Err(_) => HashMap::new(),
+    }
+}
+
+/// Append a new entry to the known_hosts file. Creates the file (and parent
+/// directories) if it doesn't exist.
+fn append_known_hosts_entry(
+    path: &Path,
+    host_port: &str,
+    fingerprint: &str,
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let exists = path.exists();
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    if !exists {
+        writeln!(file, "# filar known_hosts — do not edit manually")?;
+    }
+    writeln!(file, "{host_port} {fingerprint}")?;
+    Ok(())
+}
+
+/// Result of comparing a server key against known_hosts.
+#[derive(Debug, PartialEq, Eq)]
+enum HostKeyCheck {
+    /// Key matches the known entry.
+    Match,
+    /// Key doesn't match — possible MITM.
+    Mismatch,
+    /// No entry for this host — first connection.
+    New,
+}
+
+/// Check a fingerprint against known_hosts entries.
+fn check_host_key(
+    entries: &HashMap<String, String>,
+    host_port: &str,
+    fingerprint: &str,
+) -> HostKeyCheck {
+    match entries.get(host_port) {
+        Some(known_fp) if known_fp == fingerprint => HostKeyCheck::Match,
+        Some(_) => HostKeyCheck::Mismatch,
+        None => HostKeyCheck::New,
+    }
+}
+
 /// Read from the channel until `marker` is found in the accumulated output.
 /// Returns the output *before* the marker (discarded for sync).
 ///
@@ -640,6 +781,7 @@ mod tests {
             port: 2222,
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
+            host_key_policy: HostKeyPolicy::Tofu,
         };
         std::env::var("SSH_PASSWORD")
             .expect("set SSH_PASSWORD to run ignored SSH integration tests");
@@ -665,6 +807,7 @@ mod tests {
             port: 2222,
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
+            host_key_policy: HostKeyPolicy::Tofu,
         };
         std::env::var("SSH_PASSWORD")
             .expect("set SSH_PASSWORD to run ignored SSH integration tests");
@@ -689,6 +832,7 @@ mod tests {
             port: 2222,
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
+            host_key_policy: HostKeyPolicy::Tofu,
         };
         std::env::var("SSH_PASSWORD")
             .expect("set SSH_PASSWORD to run ignored SSH integration tests");
@@ -722,6 +866,7 @@ mod tests {
             port: 2222,
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
+            host_key_policy: HostKeyPolicy::Tofu,
         };
         std::env::var("SSH_PASSWORD")
             .expect("set SSH_PASSWORD to run ignored SSH integration tests");
@@ -765,6 +910,7 @@ mod tests {
             port: 2222,
             user: "testuser".into(),
             auth: SshAuth::Password { password: None },
+            host_key_policy: HostKeyPolicy::Tofu,
         };
         std::env::var("SSH_PASSWORD")
             .expect("set SSH_PASSWORD to run ignored SSH integration tests");
@@ -818,5 +964,76 @@ mod tests {
         assert_eq!(result.exit_code, Some(0));
 
         session.close().await.unwrap();
+    }
+
+    // ── known_hosts unit tests ───────────────────────────────────────
+
+    #[test]
+    fn known_hosts_parse_contents() {
+        let contents = "# filar known_hosts\n127.0.0.1:2222 SHA256:abc123\n10.0.0.5:22 SHA256:def456\n\n# comment line\n";
+        let entries = parse_known_hosts_contents(contents);
+        assert_eq!(
+            entries.get("127.0.0.1:2222"),
+            Some(&"SHA256:abc123".to_string())
+        );
+        assert_eq!(
+            entries.get("10.0.0.5:22"),
+            Some(&"SHA256:def456".to_string())
+        );
+        assert!(entries.get("unknown:22").is_none());
+    }
+
+    #[test]
+    fn known_hosts_append_and_read() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "filar_test_known_hosts_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        append_known_hosts_entry(&path, "host1:22", "SHA256:aaa").unwrap();
+        append_known_hosts_entry(&path, "host2:22", "SHA256:bbb").unwrap();
+
+        let entries = parse_known_hosts(&path);
+        assert_eq!(
+            entries.get("host1:22"),
+            Some(&"SHA256:aaa".to_string())
+        );
+        assert_eq!(
+            entries.get("host2:22"),
+            Some(&"SHA256:bbb".to_string())
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn host_key_check_match() {
+        let mut entries = HashMap::new();
+        entries.insert("127.0.0.1:2222".to_string(), "SHA256:abc".to_string());
+        assert_eq!(
+            check_host_key(&entries, "127.0.0.1:2222", "SHA256:abc"),
+            HostKeyCheck::Match
+        );
+    }
+
+    #[test]
+    fn host_key_check_mismatch() {
+        let mut entries = HashMap::new();
+        entries.insert("127.0.0.1:2222".to_string(), "SHA256:abc".to_string());
+        assert_eq!(
+            check_host_key(&entries, "127.0.0.1:2222", "SHA256:xyz"),
+            HostKeyCheck::Mismatch
+        );
+    }
+
+    #[test]
+    fn host_key_check_new() {
+        let entries: HashMap<String, String> = HashMap::new();
+        assert_eq!(
+            check_host_key(&entries, "127.0.0.1:2222", "SHA256:abc"),
+            HostKeyCheck::New
+        );
     }
 }

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -60,7 +60,18 @@ impl client::Handler for SshHandler {
         let fp_str = fingerprint.to_string();
         let host_port = format!("{}:{}", self.host, self.port);
 
-        let entries = parse_known_hosts(&self.known_hosts_path);
+        let entries = match parse_known_hosts(&self.known_hosts_path) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(e) => {
+                warn!(
+                    host = %host_port,
+                    error = %e,
+                    "failed to read known_hosts, rejecting host key"
+                );
+                return Ok(false);
+            }
+        };
 
         match check_host_key(&entries, &host_port, &fp_str) {
             HostKeyCheck::Match => {
@@ -83,13 +94,24 @@ impl client::Handler for SshHandler {
                     Ok(false)
                 }
                 HostKeyPolicy::Tofu => {
-                    info!(host = %host_port, "host key added (TOFU)");
-                    if let Err(e) =
-                        append_known_hosts_entry(&self.known_hosts_path, &host_port, &fp_str)
-                    {
-                        warn!(error = %e, "failed to write known_hosts entry");
+                    match append_known_hosts_entry(
+                        &self.known_hosts_path,
+                        &host_port,
+                        &fp_str,
+                    ) {
+                        Ok(()) => {
+                            info!(host = %host_port, "host key added (TOFU)");
+                            Ok(true)
+                        }
+                        Err(e) => {
+                            warn!(
+                                host = %host_port,
+                                error = %e,
+                                "failed to write known_hosts entry, rejecting host key"
+                            );
+                            Ok(false)
+                        }
                     }
-                    Ok(true)
                 }
                 HostKeyPolicy::AcceptNew => {
                     info!(
@@ -538,13 +560,14 @@ fn parse_known_hosts_contents(contents: &str) -> HashMap<String, String> {
     entries
 }
 
-/// Read and parse the known_hosts file. Returns an empty map if the file
-/// doesn't exist or can't be read.
-fn parse_known_hosts(path: &Path) -> HashMap<String, String> {
-    match std::fs::read_to_string(path) {
-        Ok(contents) => parse_known_hosts_contents(&contents),
-        Err(_) => HashMap::new(),
-    }
+/// Read and parse the known_hosts file.
+///
+/// Returns `Ok(empty_map)` when the file doesn't exist (first connection).
+/// Returns `Err` for any other I/O error — callers should reject the host key
+/// (fail closed) rather than silently downgrading verification.
+fn parse_known_hosts(path: &Path) -> std::io::Result<HashMap<String, String>> {
+    std::fs::read_to_string(path)
+        .map(|contents| parse_known_hosts_contents(&contents))
 }
 
 /// Append a new entry to the known_hosts file. Creates the file (and parent
@@ -995,7 +1018,7 @@ mod tests {
         append_known_hosts_entry(&path, "host1:22", "SHA256:aaa").unwrap();
         append_known_hosts_entry(&path, "host2:22", "SHA256:bbb").unwrap();
 
-        let entries = parse_known_hosts(&path);
+        let entries = parse_known_hosts(&path).unwrap();
         assert_eq!(
             entries.get("host1:22"),
             Some(&"SHA256:aaa".to_string())

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -341,6 +341,7 @@ async fn run_app(
                                 auth: filar_core::SshAuth::Password {
                                     password: Some(password),
                                 },
+                                host_key_policy: filar_core::HostKeyPolicy::Tofu,
                             };
                             match filar_transport::SshExecutor::connect(&target).await {
                                 Ok(ssh_exec) => {


### PR DESCRIPTION
## Problem

`check_server_key` always returned `Ok(true)` — any MITM attack passed undetected.

## Solution — TOFU (Trust On First Use)

### Changes

**`crates/core/src/config.rs`**
- Added `HostKeyPolicy` enum: `Strict`, `Tofu` (default), `AcceptNew`
  - `#[serde(rename_all = "snake_case")]`, `#[derive(Default)]` → `Tofu`
- Added `host_key_policy: HostKeyPolicy` field to `SshTarget` with `#[serde(default)]`

**`crates/transport/src/ssh.rs`**
- `SshHandler` now carries: `host`, `port`, `policy`, `known_hosts_path`
- `check_server_key` computes SHA256 fingerprint, looks up `known_hosts`:
  - **Match** → accept
  - **Mismatch** → reject (`Ok(false)`)
  - **New** → policy-dependent:
    - `Strict` → reject
    - `Tofu` → accept + save to known_hosts
    - `AcceptNew` → accept (no save)
- Known_hosts file: `~/.config/filar/known_hosts`, format: `host:port SHA256:fp`
- Helper functions: `known_hosts_path()`, `parse_known_hosts_contents()`, `parse_known_hosts()`, `append_known_hosts_entry()`, `check_host_key()`

**`crates/transport/src/interactive.rs`**
- Updated `SshHandler` construction to pass host, port, policy, known_hosts_path

**`crates/tui/src/runner.rs`, `crates/app/src/main.rs`**
- Added `host_key_policy: HostKeyPolicy::Tofu` to dynamic `SshTarget` initializers

### Tests (5 unit)
- `known_hosts_parse_contents` — parsing known_hosts file content
- `known_hosts_append_and_read` — write + read roundtrip
- `host_key_check_match` — known key → Match
- `host_key_check_mismatch` — different key → Mismatch
- `host_key_check_new` — unknown host → New

### Test results
```
70 passed; 0 failed; 5 ignored (Docker SSH integration)
```

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable SSH host key verification with a trust-on-first-use default (TOFU), plus options for strict checking and “accept new”.
  * Host key decisions are stored in a local `known_hosts` file to enable later verification.
* **Bug Fixes**
  * SSH no longer silently accepts potentially tampered host keys; mismatches are rejected or warned according to policy.
  * GUI and terminal SSH connection flows now use the same host key verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->