### PR TITLE
fix(ssh,security): strip synthetic newline and fix redirect target detection

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -458,3 +458,25 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
   - TOFU-путь: если `append_known_hosts_entry` не удался → reject (`Ok(false)`)
     вместо accept с warning. Ключ должен быть закреплён, иначе подключение
     не должно проходить.
+
+### Issue #5: Косметика и грубые эвристики
+- **Файлы:** `crates/transport/src/ssh.rs`, `crates/agent/src/security.rs`
+- **Часть A — лишняя пустая строка в выводе:**
+  - **Проблема:** printf-маркер использует ведущий `\n` для надёжного детекта
+    начала строки. Этот `\n` попадал в output как лишний хвостовой перевод строки.
+  - **Фикс:** после извлечения `output` из буфера срезаем ровно один хвостовой
+    `\n` через `strip_suffix('\n')` — синтетический от printf, не трогая вывод команды.
+  - **Критерий:** `run("echo hi")` даёт `stdout == "hi\n"` без второго пустого ряда.
+- **Часть B — грубый `writes_to_system_path`:**
+  - **Проблема:** функция проверяла «где-то после `>`» встречается ли системный путь.
+    Ложное срабатывание: `grep x > /tmp/a; cat /etc/passwd` → true (из-за `/etc/`
+    в read-части, а не в redirect).
+  - **Фикс:** переписана — теперь разделяет по `;&|&`, находит каждый `>` или `>>`,
+    извлекает **непосредственно следующий токен** (цель редиректа) и проверяет
+    только его. `/dev/null` исключён (null device, не системный путь).
+  - **Критерий:** `writes_to_system_path("echo foo > /etc/passwd") == true`,
+    `writes_to_system_path("grep x > /tmp/a; cat /etc/passwd") == false`.
+- **Тесты:** `detect_system_redirect` обновлён — 7 кейсов (включая `/dev/null`
+  исключение, `>>` append, system path в read-части, `/dev/sda` device).
+- **Публичные контракты:** без изменений.
+- Total: 70 tests pass, 0 fail, 5 ignored (Docker).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -480,3 +480,12 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
   исключение, `>>` append, system path в read-части, `/dev/sda` device).
 - **Публичные контракты:** без изменений.
 - Total: 70 tests pass, 0 fail, 5 ignored (Docker).
+- **Review fixes (CodeRabbit PR #11):**
+  - `writes_to_system_path` использует `char_indices()` вместо `chars()` для
+    byte-safe offset'ов. Non-ASCII текст перед `>` больше не вызывает panic
+    при слайсинге строки.
+  - Quoted redirect targets: `trim_matches` снимает кавычки (`"`, `'`) с цели
+    редиректа перед проверкой. `echo foo >"/etc/passwd"` теперь корректно
+    распознаётся как запись в системный путь.
+  - Тесты расширены: quoted paths (`"/etc/passwd"`, `'/etc/passwd'`) и
+    non-ASCII перед `>` (`echo привет > /etc/passwd`).

--- a/crates/agent/src/security.rs
+++ b/crates/agent/src/security.rs
@@ -79,24 +79,55 @@ pub fn is_destructive(command: &str) -> bool {
 }
 
 /// Check whether a command writes to a system path (potential destruction).
+///
+/// Only checks the **immediate target** of each redirect operator (`>` or `>>`),
+/// not system paths that appear elsewhere in the command. This prevents false
+/// positives like `grep x > /tmp/a; cat /etc/passwd` where `/etc/passwd` is a
+/// read target, not a write target.
 fn writes_to_system_path(command: &str) -> bool {
     let lower = command.to_lowercase();
-    // Clean harmless redirects to /dev/null and stderr/stdout duplication.
-    let cleaned = lower
-        .replace("2>/dev/null", "")
-        .replace("1>/dev/null", "")
-        .replace(">/dev/null", "")
-        .replace("&>/dev/null", "")
-        .replace("2>&1", "")
-        .replace("1>&2", "");
+    // Remove non-redirect patterns that contain > (=>, ->, >=).
+    let cleaned = lower.replace("=>", "").replace("->", "").replace(">=", "");
+
     let system_paths = ["/etc/", "/boot/", "/sys/", "/proc/", "/dev/", "/usr/", "/lib/"];
-    // Look for redirect patterns: > /path  or >> /path
-    if let Some(idx) = cleaned.find('>') {
-        let after = &cleaned[idx..];
-        system_paths.iter().any(|p| after.contains(p))
-    } else {
-        false
+
+    // Split by shell operators to process each sub-command independently.
+    for sub in cleaned.split([';', '|', '&']) {
+        let sub = sub.trim();
+        let chars: Vec<char> = sub.chars().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            if chars[i] == '>' {
+                // Skip second '>' for '>>' append operator.
+                let mut target_start = i + 1;
+                if target_start < chars.len() && chars[target_start] == '>' {
+                    target_start += 1;
+                }
+                // Skip whitespace after redirect operator.
+                while target_start < chars.len() && chars[target_start].is_whitespace() {
+                    target_start += 1;
+                }
+                // Extract the target token (up to next whitespace or end).
+                let mut target_end = target_start;
+                while target_end < chars.len() && !chars[target_end].is_whitespace() {
+                    target_end += 1;
+                }
+                if target_end > target_start {
+                    let target: String = sub[target_start..target_end].to_string();
+                    // /dev/null is a null device, not a real system path write.
+                    if target != "/dev/null" {
+                        if system_paths.iter().any(|p| target.starts_with(p)) {
+                            return true;
+                        }
+                    }
+                }
+                i = target_end;
+            } else {
+                i += 1;
+            }
+        }
     }
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -357,6 +388,15 @@ mod tests {
         assert!(writes_to_system_path("echo foo > /etc/passwd"));
         assert!(writes_to_system_path("echo bar >> /boot/grub.cfg"));
         assert!(!writes_to_system_path("echo foo > /tmp/test"));
+        // /dev/null is a null device, not a real system path write.
+        assert!(!writes_to_system_path("echo foo > /dev/null"));
+        assert!(!writes_to_system_path("echo foo 2>/dev/null"));
+        // System path in a *read* sub-command must not trigger.
+        assert!(!writes_to_system_path("grep x > /tmp/a; cat /etc/passwd"));
+        // /dev/sda is a real device — should be flagged.
+        assert!(writes_to_system_path("dd if=/dev/zero > /dev/sda"));
+        // Append to system path.
+        assert!(writes_to_system_path("echo bad >> /etc/passwd"));
     }
 
     #[test]

--- a/crates/agent/src/security.rs
+++ b/crates/agent/src/security.rs
@@ -94,26 +94,39 @@ fn writes_to_system_path(command: &str) -> bool {
     // Split by shell operators to process each sub-command independently.
     for sub in cleaned.split([';', '|', '&']) {
         let sub = sub.trim();
-        let chars: Vec<char> = sub.chars().collect();
+        // Use char_indices() for byte-safe offsets — sub[...] slicing requires
+        // byte positions, not character positions. Non-ASCII text before '>'
+        // would otherwise cause a panic or incorrect extraction.
+        let indices: Vec<(usize, char)> = sub.char_indices().collect();
         let mut i = 0;
-        while i < chars.len() {
-            if chars[i] == '>' {
+        while i < indices.len() {
+            if indices[i].1 == '>' {
                 // Skip second '>' for '>>' append operator.
                 let mut target_start = i + 1;
-                if target_start < chars.len() && chars[target_start] == '>' {
+                if target_start < indices.len() && indices[target_start].1 == '>' {
                     target_start += 1;
                 }
                 // Skip whitespace after redirect operator.
-                while target_start < chars.len() && chars[target_start].is_whitespace() {
+                while target_start < indices.len() && indices[target_start].1.is_whitespace() {
                     target_start += 1;
                 }
                 // Extract the target token (up to next whitespace or end).
                 let mut target_end = target_start;
-                while target_end < chars.len() && !chars[target_end].is_whitespace() {
+                while target_end < indices.len() && !indices[target_end].1.is_whitespace() {
                     target_end += 1;
                 }
                 if target_end > target_start {
-                    let target: String = sub[target_start..target_end].to_string();
+                    // Use byte offsets for slicing.
+                    let byte_start = indices[target_start].0;
+                    let byte_end = if target_end < indices.len() {
+                        indices[target_end].0
+                    } else {
+                        sub.len()
+                    };
+                    let target = &sub[byte_start..byte_end];
+                    // Strip surrounding shell quotes so that
+                    // `echo foo >"/etc/passwd"` is still caught.
+                    let target = target.trim_matches(|c| c == '"' || c == '\'');
                     // /dev/null is a null device, not a real system path write.
                     if target != "/dev/null" {
                         if system_paths.iter().any(|p| target.starts_with(p)) {
@@ -397,6 +410,12 @@ mod tests {
         assert!(writes_to_system_path("dd if=/dev/zero > /dev/sda"));
         // Append to system path.
         assert!(writes_to_system_path("echo bad >> /etc/passwd"));
+        // Quoted redirect targets must still be caught.
+        assert!(writes_to_system_path("echo foo >\"/etc/passwd\""));
+        assert!(writes_to_system_path("echo foo >>'/etc/passwd'"));
+        // Non-ASCII before '>' must not panic (byte-safe indexing).
+        assert!(writes_to_system_path("echo привет > /etc/passwd"));
+        assert!(!writes_to_system_path("echo привет > /tmp/test"));
     }
 
     #[test]

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -694,6 +694,13 @@ async fn recv_until_marker(
                                 let line_start =
                                     buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
                                 let output = buf[..line_start].to_string();
+                                // Strip the synthetic trailing newline added by the
+                                // printf marker's leading '\n'. This removes
+                                // exactly one '\n' — not the command's own output.
+                                let output = output
+                                    .strip_suffix('\n')
+                                    .map(str::to_string)
+                                    .unwrap_or(output);
 
                                 // Drain any trailing stderr that may still be
                                 // in the event pipeline. Without this, late


### PR DESCRIPTION
## Summary

Two fixes from issue #5:

### Part A: Extra empty line in command output (`ssh.rs`)

The printf marker uses a leading `\n` for reliable line-start detection. This `\n` was leaking into the extracted command output as an extra trailing empty line. Tests passed due to `.trim()`, but the UI showed a blank row after each command.

**Fix:** After extracting output from the buffer, strip exactly one trailing `\n` — the synthetic one from printf, not the command's own output.

### Part B: Crude `writes_to_system_path` (`security.rs`)

The function checked if any system path appears anywhere after a `>` character, causing false positives like `grep x > /tmp/a; cat /etc/passwd` (flagged because `/etc/` appears in the read part).

**Fix:** Rewritten to split by shell operators (`;`, `|`, `&`), find each `>` or `>>` redirect, and check only the **immediate next token** (the redirect target). `/dev/null` is excluded as a null device.

## Test cases

`detect_system_redirect` expanded to 7 cases:
- `echo foo > /etc/passwd` → true
- `echo bar >> /boot/grub.cfg` → true (append)
- `echo foo > /tmp/test` → false (non-system path)
- `echo foo > /dev/null` → false (null device)
- `echo foo 2>/dev/null` → false (stderr redirect)
- `grep x > /tmp/a; cat /etc/passwd` → false (system path in read, not redirect)
- `dd if=/dev/zero > /dev/sda` → true (real device)

## Test results

```
70 passed; 0 failed; 5 ignored (Docker SSH integration)
```

The 5 ignored tests require a Docker sshd container and should be verified manually.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command output so results no longer include an unintended extra trailing newline.
  * Improved redirect handling when checking whether commands write to sensitive system paths, reducing false positives across split shell segments and append redirects.
  * Ensured `/dev/null`-style exclusions and quoted redirect targets are handled correctly.
* **Tests**
  * Expanded unit coverage for redirect detection with additional edge cases (e.g., quoted targets, non-ASCII content, and device-path-like targets).
* **Documentation**
  * Updated progress notes with details on the above fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->