### PR TITLE
fix(agent): mirror user's language instead of hardcoded Russian

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -489,3 +489,20 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
     распознаётся как запись в системный путь.
   - Тесты расширены: quoted paths (`"/etc/passwd"`, `'/etc/passwd'`) и
     non-ASCII перед `>` (`echo привет > /etc/passwd`).
+
+### Issue #6: Отвечать на языке исходного запроса
+- **Файл:** `crates/agent/src/agent.rs`, функция `build_system_prompt`
+- **Проблема:** язык ответа жёстко зашит как русский в двух местах промпта:
+  строка `Always respond in Russian` и правило №6 `final answer in Russian`.
+- **Фикс:**
+  - Удалены обе зашитые ссылки на русский.
+  - Вместо `Always respond in Russian` — инструкция зеркалирования: определить
+    язык **первого** запроса пользователя и писать все пояснения, сводки,
+    вопросы и финальный ответ на том же языке. Сырой вывод команд
+    (stdout/stderr) не переводится — только prose агента.
+  - Правило №6: `final answer in the user's language` вместо `in Russian`.
+- **Тест:** `prompt_mirrors_user_language` — проверяет отсутствие `Russian`
+  в промпте, наличие `user's` + `same language`, и оговорку про неперевод
+  вывода команд (`must NOT be translated`).
+- **Публичные контракты:** без изменений — `build_system_prompt` сигнатура та же.
+- Total: 71 tests pass, 0 fail, 5 ignored (Docker).

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -83,7 +83,12 @@ fn build_system_prompt(is_local: bool, ssh_info: Option<&str>, is_windows: bool)
 "{transport_desc} \
 You have tools to run commands, read files, and list directories. \
 \
-IMPORTANT: Always respond in Russian. All explanations, summaries, and questions must be in Russian.\
+IMPORTANT: Determine the language of the user's FIRST request in this conversation, \
+and write ALL of your explanations, summaries, questions, and the final answer in \
+that same language. Keep this language consistent for the entire session. Do NOT \
+default to any fixed language. Note: raw command output (stdout/stderr) is passed \
+through as-is and must NOT be translated — only your own prose around it follows the \
+user's language.\
 \
 Rules:\
 1. Always explain what you're about to do before calling a tool.\
@@ -91,7 +96,7 @@ Rules:\
 3. Be cautious with destructive commands (rm, dd, mkfs, Remove-Item, Format-Volume, etc.).\
 4. If a command is denied by the user, do not retry it — try a different approach.\
 5. Summarize the results concisely after each command.\
-6. When the task is complete, provide a clear final answer in Russian.\
+6. When the task is complete, provide a clear final answer in the user's language.\
 7. If you need information from the user (e.g. a password, a choice between options), ask them directly in your text response — do not try to use interactive prompts in commands. Wait for their reply before continuing.\
 8. Never put passwords or secrets directly in commands. If a password is needed, ask the user to provide it. The user can press Ctrl+P to enter the password in a secure masked input field. The password will be stored as a secret variable (e.g. $FILAR_SECRET_1) and you will be told the variable name. Use this variable directly in your commands (e.g. echo \"user:$FILAR_SECRET_1\" | chpasswd). The actual value is substituted at execution time — you never see the real password. Do not try to echo or print secret variables.\
 9. NEVER run interactive commands (vim, nano, top, htop, less, man, mc, screen, tmux, ssh, etc.). These commands take over the terminal and will hang indefinitely. Instead, use non-interactive alternatives: 'cat file' instead of 'less file', 'grep -n pattern file' instead of 'vim file', 'head -n 50 file' to preview. For editing files, use 'sed' or 'tee' with heredocs.
@@ -655,6 +660,26 @@ mod tests {
         assert!(
             prompt.contains("does NOT persist"),
             "Local prompt should mention state does NOT persist, got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn prompt_mirrors_user_language() {
+        // The prompt must NOT hardcode Russian as the response language.
+        let prompt = build_system_prompt(true, None, false);
+        assert!(
+            !prompt.contains("Russian"),
+            "Prompt should not hardcode Russian, got: {prompt}"
+        );
+        // The prompt must instruct the model to mirror the user's language.
+        assert!(
+            prompt.contains("user's") && prompt.contains("same language"),
+            "Prompt should mention mirroring the user's language, got: {prompt}"
+        );
+        // Raw command output must not be translated.
+        assert!(
+            prompt.contains("must NOT be translated"),
+            "Prompt should state that command output is not translated, got: {prompt}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded Russian response language in `build_system_prompt` with an instruction to mirror the language of the user's first request.

### Changes
- **`crates/agent/src/agent.rs`**, `build_system_prompt`:
  - Removed `IMPORTANT: Always respond in Russian...` — replaced with language-mirroring instruction: determine the language of the user's FIRST request and write all explanations, summaries, questions, and final answer in that same language.
  - Rule #6: `final answer in Russian` → `final answer in the user's language`.
  - Raw command output (stdout/stderr) is explicitly excluded from translation — only the agent's prose follows the user's language.

### Test
- New unit test `prompt_mirrors_user_language`: verifies the prompt does NOT contain `"Russian"`, contains `user's` + `same language`, and includes the `must NOT be translated` clause.
- All 71 tests pass (0 fail, 5 ignored — Docker sshd).

### Out of scope
- No Rust-side language detection (by design — the model mirrors language via prompt instruction).

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Responses now follow the language of the user’s first message instead of always using Russian.
  * Explanations, summaries, questions, and final answers stay consistent with the user’s language throughout the session.
  * Raw command output is left unchanged and is not translated.
* **Tests**
  * Added coverage to verify the prompt reflects the user’s language and no longer includes language-specific wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->