### PR TITLE
refactor(tui): cache chat layout for efficient rendering and hit-testing

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -69,7 +69,7 @@ c:\dev\warper\
 │   │   └── src/{lib,glm,agent,tools,security}.rs
 │   ├── tui/                # ratatui + crossterm TUI + terminal emulator — ГОТОВ
 │   │   ├── Cargo.toml
-│   │   └── src/{lib,app,ui/mod,ui/theme,ui/text,ui/bars,ui/chat,ui/input,event,confirmer,runner,terminal}.rs
+│   │   └── src/{lib,app,ui/mod,ui/theme,ui/text,ui/bars,ui/chat,ui/input,ui/layout_cache,event,confirmer,runner,terminal}.rs
 │   ├── gui/                # GUI-лаунчер на eframe + keyring — ГОТОВ
 │   │   ├── Cargo.toml
 │   │   └── src/lib.rs
@@ -545,3 +545,38 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
 - **Review fix (CodeRabbit PR #24):** `ChatBlock::System` — добавлен `strip_emoji`
   для системных сообщений (могут содержать user-controlled текст: target_name,
   SSH user/host). Теперь все варианты `ChatBlock` проходят emoji-фильтрацию.
+
+### Issue #14: TUI — кэширование layout чата (фундамент для мыши)
+- **Файлы:**
+  - `crates/tui/src/ui/layout_cache.rs` — новый модуль: `RenderedLine`, `LineRegion`, `ChatLayoutCache`
+  - `crates/tui/src/ui/chat.rs` — переписан: использует кэш вместо per-frame rebuild
+  - `crates/tui/src/ui/mod.rs` — `render()` и `render_interactive()` принимают `&mut App`
+  - `crates/tui/src/ui/input.rs` — `render_input_area()` принимает `&mut App`, записывает `input_area`
+  - `crates/tui/src/app.rs` — новые поля `layout_cache`, `message_rev`, `chat_area`, `input_area`,
+    `confirm_button_areas`; метод `push_message()`; все `self.messages.push(...)` заменены
+  - `crates/tui/src/runner.rs` — `ui::render(f, &mut app)`; bump `message_rev` в error path
+- **Что сделано:**
+  - `ChatLayoutCache` хранит pre-rendered `Vec<RenderedLine>` с метаданными
+    (`block_index`, `LineRegion`) для будущего hit-testing.
+  - Кэш инвалидируется при: изменении ширины, изменении `messages.len()`, изменении `message_rev`.
+  - `rebuild()` переносит логику построения строк из `chat.rs` (wrapping, emoji strip,
+    output truncation at 30 lines).
+  - `MAX_CACHED_LINES` поднят с 500 до 2000 — кэш делает per-frame cost = slice.
+  - `App::push_message()` — единая точка мутации `messages` + bump `message_rev`.
+    Все `self.messages.push(...)` заменены на `self.push_message(...)`.
+  - In-place update последнего Command блока (CommandExecuted event) — bump `message_rev`
+    для инвалидации кэша.
+  - `app.chat_area` и `app.input_area` заполняются при каждом рендере (для задачи 3).
+- **Решения:**
+  - `push_message()` оставлен приватным — runner bump’ит `message_rev` вручную для
+    единственного `app.messages.push` вне `App` (error path в interactive terminal).
+  - `collapsed: &HashSet<usize>` параметр в `rebuild()` зарезервирован для задачи 6
+    (collapse/expand output) — пока всегда пустой.
+  - `LineRegion::OutputToggle` помечает строку `... (N more lines)` — будущий target
+    для клик-Expand (задача 6).
+- **Тесты:** 6 новых в `layout_cache.rs` (invalidation on width/message/rev,
+  no-rebuild on same params, region correctness, command output + toggle).
+  Total: 30 tui tests pass.
+- **Публичные контракты:** `App` получил 5 новых полей (backward-incompatible для
+  ручной инициализации, но `App::new()` и `App::with_history()` работают без изменений).
+  `ui::render()` сигнатура изменена: `&App` → `&mut App`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -580,3 +580,12 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
 - **Публичные контракты:** `App` получил 5 новых полей (backward-incompatible для
   ручной инициализации, но `App::new()` и `App::with_history()` работают без изменений).
   `ui::render()` сигнатура изменена: `&App` → `&mut App`.
+- **Review fixes (CodeRabbit PR #25):**
+  - Добавлен `pub fn push_error()` — единая точка для внешних (runner) мутаций
+    `messages` с автоматическим bump `message_rev`. Runner больше не делает
+    прямой `app.messages.push(...)` + ручной bump.
+  - Добавлены 7 тестов в `app.rs` на `message_rev`-bumping paths: `push_error`,
+    `enter_interactive`, `exit_interactive`, `AgentEvent::TextResponse`,
+    `AgentEvent::Error`, `AgentEvent::CommandExecuted` (in-place update),
+    `respond_to_confirmation` (via handle_key 'a' in Confirming mode).
+  Total: 37 tui tests pass.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -175,6 +175,13 @@ impl App {
         self.message_rev = self.message_rev.wrapping_add(1);
     }
 
+    /// Append an error message from outside `App` (e.g. runner startup
+    /// failures) while still bumping [`message_rev`](Self::message_rev) so
+    /// the layout cache invalidates correctly.
+    pub fn push_error(&mut self, text: String) {
+        self.push_message(ChatBlock::Error(text));
+    }
+
     /// Handle a terminal keyboard event.
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::{KeyCode, KeyModifiers};
@@ -767,5 +774,97 @@ mod tests {
         ));
 
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn push_error_bumps_message_rev() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let rev_before = app.message_rev;
+        app.push_error("boom".into());
+        assert!(app.message_rev > rev_before);
+        assert!(matches!(app.messages.last(), Some(ChatBlock::Error(s)) if s == "boom"));
+    }
+
+    #[test]
+    fn enter_interactive_bumps_message_rev() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let rev_before = app.message_rev;
+        let model = crate::terminal::TerminalModel::new(80, 24);
+        app.enter_interactive(model);
+        assert!(app.message_rev > rev_before);
+        assert_eq!(app.mode, AppMode::Interactive);
+    }
+
+    #[test]
+    fn exit_interactive_bumps_message_rev() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let model = crate::terminal::TerminalModel::new(80, 24);
+        app.enter_interactive(model);
+        let rev_before = app.message_rev;
+        app.exit_interactive();
+        assert!(app.message_rev > rev_before);
+        assert_eq!(app.mode, AppMode::Normal);
+    }
+
+    #[test]
+    fn agent_text_response_bumps_message_rev() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let rev_before = app.message_rev;
+        app.handle_agent_event(AgentEvent::TextResponse("hello".into()));
+        assert!(app.message_rev > rev_before);
+    }
+
+    #[test]
+    fn agent_error_bumps_message_rev() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let rev_before = app.message_rev;
+        app.handle_agent_event(AgentEvent::Error("oops".into()));
+        assert!(app.message_rev > rev_before);
+        assert_eq!(app.mode, AppMode::Normal);
+    }
+
+    #[test]
+    fn agent_command_executed_inplace_bumps_message_rev() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        // Push a Command block without output — this is the one that will be
+        // updated in-place by CommandExecuted.
+        app.push_message(ChatBlock::Command {
+            command: "ls".into(),
+            explanation: String::new(),
+            output: None,
+            approved: false,
+        });
+        let rev_before = app.message_rev;
+        app.handle_agent_event(AgentEvent::CommandExecuted {
+            command: "ls".into(),
+            output: "file1\nfile2".into(),
+            approved: true,
+        });
+        assert!(app.message_rev > rev_before, "in-place update must bump rev");
+        // Verify the block was updated in-place, not duplicated.
+        assert_eq!(app.messages.len(), 2); // system + command (updated)
+    }
+
+    #[test]
+    fn confirmation_response_bumps_message_rev() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let (tx, _rx) = oneshot::channel();
+        app.pending_confirm = Some(PendingConfirm {
+            command: "rm -rf /tmp/test".into(),
+            explanation: "cleanup".into(),
+            destructive: false,
+            respond_to: tx,
+        });
+        app.mode = AppMode::Confirming;
+        let rev_before = app.message_rev;
+
+        // Press 'a' to approve.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('a'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        assert!(app.message_rev > rev_before);
+        assert_eq!(app.mode, AppMode::Thinking);
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -6,9 +6,11 @@
 
 use tokio::sync::oneshot;
 use filar_core::{ChatBlock, CommandConfirmMode};
+use ratatui::layout::Rect;
 
 use crate::event::AgentEvent;
 use crate::terminal::{key_to_bytes, TerminalModel};
+use crate::ui::layout_cache::ChatLayoutCache;
 use crate::ui::Theme;
 
 use std::collections::HashMap;
@@ -96,6 +98,17 @@ pub struct App {
     pub pending_ssh_password: Option<String>,
     /// Colour theme used by the UI renderer.
     pub theme: Theme,
+    /// Cached chat layout — avoids re-wrapping text on every frame.
+    pub layout_cache: ChatLayoutCache,
+    /// Revision counter — bumped on any mutation of `messages` to
+    /// invalidate [`layout_cache`](Self::layout_cache).
+    pub message_rev: u64,
+    /// Actual chat area on screen (filled during render, for hit-testing).
+    pub chat_area: Rect,
+    /// Actual input area on screen (filled during render, for hit-testing).
+    pub input_area: Rect,
+    /// Confirm button areas (filled later, for mouse click detection).
+    pub confirm_button_areas: Vec<(Rect, bool)>,
 }
 
 impl App {
@@ -126,6 +139,11 @@ impl App {
             pending_ssh: None,
             pending_ssh_password: None,
             theme: Theme::default_dark(),
+            layout_cache: ChatLayoutCache::new(),
+            message_rev: 0,
+            chat_area: Rect::default(),
+            input_area: Rect::default(),
+            confirm_button_areas: Vec::new(),
         }
     }
 
@@ -138,11 +156,23 @@ impl App {
         let mut app = Self::new(target_name, confirm_mode);
         if !messages.is_empty() {
             app.messages = messages;
-            app.messages.push(ChatBlock::System(
+            // Bump rev for the wholesale replacement so the cache rebuilds.
+            app.message_rev = app.message_rev.wrapping_add(1);
+            app.push_message(ChatBlock::System(
                 "Session restored — history loaded from disk".into(),
             ));
         }
         app
+    }
+
+    /// Append a message to the history and bump [`message_rev`](Self::message_rev).
+    ///
+    /// All mutations of `messages` must go through this method (or explicitly
+    /// bump `message_rev`) so that [`layout_cache`](Self::layout_cache)
+    /// invalidates correctly.
+    fn push_message(&mut self, msg: ChatBlock) {
+        self.messages.push(msg);
+        self.message_rev = self.message_rev.wrapping_add(1);
     }
 
     /// Handle a terminal keyboard event.
@@ -179,7 +209,7 @@ impl App {
                                         host.clone(),
                                         port,
                                     ));
-                                    self.messages.push(ChatBlock::System(format!(
+                                    self.push_message(ChatBlock::System(format!(
                                         "Connecting to {user}@{host}:{port} via SSH. \
                                          Press Ctrl+P to enter the password."
                                     )));
@@ -189,7 +219,7 @@ impl App {
                                     // Stay in Normal mode — user needs to press Ctrl+P.
                                 } else if is_interactive_command(&cmd) {
                                     // Block interactive commands — they hang the executor.
-                                    self.messages.push(ChatBlock::System(format!(
+                                    self.push_message(ChatBlock::System(format!(
                                         "Interactive command '{cmd}' is not supported in shell escape. \
                                          Use Ctrl+T to enter interactive terminal mode."
                                     )));
@@ -198,7 +228,7 @@ impl App {
                                     self.cursor_pos = 0;
                                 } else {
                                     // Regular shell escape.
-                                    self.messages.push(ChatBlock::Command {
+                                    self.push_message(ChatBlock::Command {
                                         command: cmd,
                                         explanation: "Shell escape (direct)".into(),
                                         output: None,
@@ -213,7 +243,7 @@ impl App {
                                 }
                             }
                         } else {
-                            self.messages.push(ChatBlock::User(text.clone()));
+                            self.push_message(ChatBlock::User(text.clone()));
                             self.scroll = 0;
                             self.input.clear();
                             self.cursor_pos = 0;
@@ -237,7 +267,7 @@ impl App {
                     self.mode = AppMode::PasswordInput;
                     // If there's a pending SSH connection, show a hint.
                     if let Some((user, host, port)) = &self.pending_ssh {
-                        self.messages.push(ChatBlock::System(format!(
+                        self.push_message(ChatBlock::System(format!(
                             "Enter SSH password for {user}@{host}:{port}"
                         )));
                         self.scroll = 0;
@@ -315,7 +345,7 @@ impl App {
                     self.pending_ssh = None;
                     self.pending_ssh_password = None;
                     self.mode = AppMode::Normal;
-                    self.messages.push(ChatBlock::System(
+                    self.push_message(ChatBlock::System(
                         "Cancelled.".into()
                     ));
                     self.scroll = 0;
@@ -388,7 +418,7 @@ impl App {
                                  Use this variable directly in your commands.",
                                 var_name
                             );
-                            self.messages.push(ChatBlock::System(
+                            self.push_message(ChatBlock::System(
                                 format!("Password provided as {} (hidden)", var_name)
                             ));
                             self.scroll = 0;
@@ -442,7 +472,7 @@ impl App {
     fn respond_to_confirmation(&mut self, approved: bool) {
         if let Some(confirm) = self.pending_confirm.take() {
             let _ = confirm.respond_to.send(approved);
-            self.messages.push(ChatBlock::Command {
+            self.push_message(ChatBlock::Command {
                 command: confirm.command,
                 explanation: confirm.explanation,
                 output: None,
@@ -459,7 +489,7 @@ impl App {
                 self.mode = AppMode::Thinking;
             }
             AgentEvent::TextResponse(text) => {
-                self.messages.push(ChatBlock::Agent(text));
+                self.push_message(ChatBlock::Agent(text));
             }
             AgentEvent::ConfirmationRequest {
                 command,
@@ -493,10 +523,12 @@ impl App {
                         *o = Some(output.clone());
                         *a = approved;
                         updated = true;
+                        // Bump rev so the cache rebuilds with updated output.
+                        self.message_rev = self.message_rev.wrapping_add(1);
                     }
                 }
                 if !updated {
-                    self.messages.push(ChatBlock::Command {
+                    self.push_message(ChatBlock::Command {
                         command,
                         explanation: String::new(),
                         output: Some(output),
@@ -506,13 +538,13 @@ impl App {
             }
             AgentEvent::Finished(text) => {
                 if !text.is_empty() {
-                    self.messages.push(ChatBlock::Agent(text));
+                    self.push_message(ChatBlock::Agent(text));
                 }
                 self.mode = AppMode::Normal;
                 self.agent_running = false;
             }
             AgentEvent::Error(err) => {
-                self.messages.push(ChatBlock::Error(err));
+                self.push_message(ChatBlock::Error(err));
                 self.mode = AppMode::Normal;
                 self.agent_running = false;
             }
@@ -543,7 +575,7 @@ impl App {
     pub fn enter_interactive(&mut self, model: TerminalModel) {
         self.terminal = Some(model);
         self.mode = AppMode::Interactive;
-        self.messages.push(ChatBlock::System(
+        self.push_message(ChatBlock::System(
             "Entered interactive terminal mode (Ctrl+T to switch back)".into(),
         ));
     }
@@ -552,7 +584,7 @@ impl App {
     pub fn exit_interactive(&mut self) {
         self.terminal = None;
         self.mode = AppMode::Normal;
-        self.messages.push(ChatBlock::System(
+        self.push_message(ChatBlock::System(
             "Returned to agent mode".into(),
         ));
     }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -201,7 +201,7 @@ async fn run_app(
     let mut interactive_term: Option<Arc<dyn InteractiveTerminal>> = None;
 
     // Draw initial UI.
-    terminal.draw(|f| ui::render(f, &app)).ok();
+    terminal.draw(|f| ui::render(f, &mut app)).ok();
 
     let mut prev_mode = app.mode;
     let mut needs_redraw = false;
@@ -277,6 +277,7 @@ async fn run_app(
                                 app.messages.push(ChatBlock::Error(
                                     format!("Failed to start terminal: {e}")
                                 ));
+                                app.message_rev = app.message_rev.wrapping_add(1);
                             }
                         }
                     }
@@ -438,7 +439,7 @@ async fn run_app(
                     needs_clear = false;
                     prev_mode = app.mode;
                 }
-                terminal.draw(|f| ui::render(f, &app)).ok();
+                terminal.draw(|f| ui::render(f, &mut app)).ok();
                 needs_redraw = false;
             }
         }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -274,10 +274,7 @@ async fn run_app(
                             }
                             Err(e) => {
                                 warn!(error = %e, "failed to start interactive terminal");
-                                app.messages.push(ChatBlock::Error(
-                                    format!("Failed to start terminal: {e}")
-                                ));
-                                app.message_rev = app.message_rev.wrapping_add(1);
+                                app.push_error(format!("Failed to start terminal: {e}"));
                             }
                         }
                     }

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -1,131 +1,42 @@
 //! Chat history rendering.
 
+use std::collections::HashSet;
+
 use ratatui::layout::Rect;
-use ratatui::text::{Line, Span};
+use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
 
 use crate::app::App;
-use filar_core::ChatBlock;
-
-use super::text::{strip_emoji, wrap_text};
 
 /// Render the chat history (scrollable).
-pub(crate) fn render_chat_history(f: &mut Frame, app: &App, area: Rect) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title("Chat")
-        .border_style(app.theme.muted());
+///
+/// Uses [`ChatLayoutCache`](super::layout_cache::ChatLayoutCache) to avoid
+/// re-wrapping text on every frame.  The cache is rebuilt only when the
+/// terminal width, message count, or message revision changes.
+pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
+    // Record the chat area for future hit-testing (task 3).
+    app.chat_area = area;
 
-    // Compute wrapping width: inner area minus border (2) minus prefix (2).
-    let inner_width = (area.width.saturating_sub(2)) as usize;
-    let content_width = inner_width.saturating_sub(2).max(1);  // "  " prefix
-    let output_width = inner_width.saturating_sub(4).max(1);   // "  | " prefix
+    // Inner width (without borders) — drives cache invalidation.
+    let inner_width = area.width.saturating_sub(2);
 
-    // Build lines from chat blocks, pre-wrapping long lines.
-    let mut lines: Vec<Line> = Vec::new();
-
-    for msg in &app.messages {
-        match msg {
-            ChatBlock::User(text) => {
-                let text = strip_emoji(text);
-                lines.push(Line::from(vec![
-                    Span::styled("> ", app.theme.user_style()),
-                    Span::styled("You", app.theme.user_style()),
-                ]));
-                for line in text.lines() {
-                    for wrapped in wrap_text(line, content_width) {
-                        lines.push(Line::from(format!("  {wrapped}")));
-                    }
-                }
-                lines.push(Line::from(""));
-            }
-            ChatBlock::Agent(text) => {
-                let text = strip_emoji(text);
-                lines.push(Line::from(vec![
-                    Span::styled("* ", app.theme.agent_style()),
-                    Span::styled("Agent", app.theme.agent_style()),
-                ]));
-                for line in text.lines() {
-                    for wrapped in wrap_text(line, content_width) {
-                        lines.push(Line::from(format!("  {wrapped}")));
-                    }
-                }
-                lines.push(Line::from(""));
-            }
-            ChatBlock::Command {
-                command,
-                explanation,
-                output,
-                approved,
-            } => {
-                let status = if *approved {
-                    Span::styled(" [ok] ", app.theme.success_fg())
-                } else {
-                    Span::styled(" [no] ", app.theme.danger_fg())
-                };
-
-                lines.push(Line::from(vec![
-                    Span::styled("> ", app.theme.warning_fg()),
-                    Span::styled("Command", app.theme.command_style()),
-                    status,
-                ]));
-
-                if !explanation.is_empty() {
-                    for wrapped in wrap_text(&strip_emoji(explanation), output_width) {
-                        lines.push(Line::from(format!("  | {wrapped}")));
-                    }
-                }
-                for wrapped in wrap_text(&format!("$ {command}"), output_width) {
-                    lines.push(Line::from(format!("  | {wrapped}")));
-                }
-
-                if let Some(out) = output {
-                    for (count, line) in out.lines().enumerate() {
-                        if count >= 30 {
-                            let remaining = out.lines().count().saturating_sub(30);
-                            lines.push(Line::from(format!("  | ... ({} more lines)", remaining)));
-                            break;
-                        }
-                        for wrapped in wrap_text(line, output_width) {
-                            lines.push(Line::from(format!("  | {wrapped}")));
-                        }
-                    }
-                }
-                lines.push(Line::from(""));
-            }
-            ChatBlock::Error(text) => {
-                let text = strip_emoji(text);
-                lines.push(Line::from(vec![
-                    Span::styled("! ", app.theme.error_style()),
-                    Span::styled("Error", app.theme.error_style()),
-                ]));
-                for line in text.lines() {
-                    for wrapped in wrap_text(line, content_width) {
-                        lines.push(Line::from(format!("  {wrapped}")));
-                    }
-                }
-                lines.push(Line::from(""));
-            }
-            ChatBlock::System(text) => {
-                let text = strip_emoji(text);
-                lines.push(Line::from(vec![
-                    Span::styled("- ", app.theme.muted()),
-                    Span::styled(text, app.theme.muted()),
-                ]));
-                lines.push(Line::from(""));
-            }
-        }
+    // Rebuild cache if any invalidation key changed.
+    if app
+        .layout_cache
+        .needs_rebuild(&app.messages, inner_width, app.message_rev)
+    {
+        app.layout_cache.rebuild(
+            &app.messages,
+            inner_width,
+            &app.theme,
+            &HashSet::new(), // no collapsed blocks yet (task 6)
+            app.message_rev,
+        );
     }
 
-    // Limit to last 500 lines to prevent rendering lag on long conversations.
-    const MAX_LINES: usize = 500;
-    if lines.len() > MAX_LINES {
-        lines = lines.split_off(lines.len() - MAX_LINES);
-    }
-
-    // Apply scroll: skip lines from the top if scrolled.
-    let total_lines = lines.len();
+    // Compute visible slice from cached lines.
+    let total_lines = app.layout_cache.lines.len();
     let visible_height = area.height.saturating_sub(2) as usize; // -2 for border
     let skip = if total_lines > visible_height {
         total_lines.saturating_sub(visible_height + app.scroll)
@@ -133,7 +44,20 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &App, area: Rect) {
         0
     };
     let skip = skip.min(total_lines);
-    let visible_lines: Vec<Line> = lines.into_iter().skip(skip).collect();
+
+    let visible_lines: Vec<Line> = app
+        .layout_cache
+        .lines
+        .iter()
+        .skip(skip)
+        .take(visible_height)
+        .map(|rl| rl.line.clone())
+        .collect();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title("Chat")
+        .border_style(app.theme.muted());
 
     let paragraph = Paragraph::new(visible_lines).block(block);
     f.render_widget(paragraph, area);

--- a/crates/tui/src/ui/input.rs
+++ b/crates/tui/src/ui/input.rs
@@ -9,7 +9,10 @@ use ratatui::Frame;
 use crate::app::{App, AppMode};
 
 /// Render the input area or confirmation dialog.
-pub(crate) fn render_input_area(f: &mut Frame, app: &App, area: Rect) {
+pub(crate) fn render_input_area(f: &mut Frame, app: &mut App, area: Rect) {
+    // Record the input area for future hit-testing (task 3).
+    app.input_area = area;
+
     match app.mode {
         AppMode::Normal => render_normal_input(f, app, area),
         AppMode::Thinking => render_thinking(f, app, area),

--- a/crates/tui/src/ui/layout_cache.rs
+++ b/crates/tui/src/ui/layout_cache.rs
@@ -1,0 +1,390 @@
+//! Cached chat layout for efficient rendering and mouse hit-testing.
+//!
+//! [`ChatLayoutCache`] stores pre-rendered lines so that `render_chat_history`
+//! does not re-wrap text on every frame (up to 60 fps).  The cache is
+//! invalidated when the terminal width changes, when messages are
+//! added/removed, or when the last block's revision changes (for streaming
+//! updates in task 7).
+//!
+//! Each [`RenderedLine`] carries a `block_index` back-pointer into
+//! `app.messages` and a [`LineRegion`] tag, enabling future mouse
+//! hit-testing ("which block was clicked?") without a separate scan.
+
+use std::collections::HashSet;
+
+use ratatui::text::{Line, Span};
+
+use filar_core::ChatBlock;
+
+use super::text::{strip_emoji, wrap_text};
+use super::theme::Theme;
+
+/// Which part of a [`ChatBlock`] a rendered line belongs to.
+///
+/// Used for hit-testing precision: a click on a `Header` might select the
+/// whole block, while a click on `Output` could toggle output collapsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineRegion {
+    /// Header line: `> You`, `* Agent`, `> Command [ok]`, etc.
+    Header,
+    /// Body text: wrapped content of a user / agent / error message.
+    Body,
+    /// Command output line (prefixed with `  | `).
+    Output,
+    /// The `... (N more lines)` truncation marker (future toggle target).
+    OutputToggle,
+    /// Empty spacer line between blocks.
+    Spacer,
+}
+
+/// A single rendered line of chat, with metadata for hit-testing.
+pub struct RenderedLine {
+    /// The fully-styled line, ready for display.
+    pub line: Line<'static>,
+    /// Index into `app.messages`, or `None` for spacer lines.
+    pub block_index: Option<usize>,
+    /// Which region of the block this line represents.
+    pub region: LineRegion,
+}
+
+/// Cached layout of the chat history.
+///
+/// The cache is rebuilt only when one of its invalidation keys changes
+/// (width, message count, or message revision).  Between rebuilds,
+/// `render_chat_history` simply slices `lines` by scroll offset — no
+/// text wrapping or emoji stripping is repeated.
+pub struct ChatLayoutCache {
+    /// All rendered lines, in display order.
+    pub lines: Vec<RenderedLine>,
+    /// Width (inner, without borders) for which the cache was built.
+    width: u16,
+    /// `messages.len()` at build time.
+    message_count: usize,
+    /// `message_rev` at build time.
+    last_block_rev: u64,
+}
+
+/// Maximum number of rendered lines to cache.
+///
+/// Raised from 500 (pre-cache) to 2000 — the cache makes per-frame cost
+/// a simple slice, so a larger buffer is cheap and reduces the chance of
+/// losing context when scrolling long conversations.
+const MAX_CACHED_LINES: usize = 2000;
+
+impl ChatLayoutCache {
+    /// Create an empty cache (will always need a rebuild on first use).
+    pub fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            width: 0,
+            message_count: 0,
+            last_block_rev: 0,
+        }
+    }
+
+    /// Returns `true` if the cache must be rebuilt for the given parameters.
+    pub fn needs_rebuild(&self, messages: &[ChatBlock], width: u16, rev: u64) -> bool {
+        self.width != width
+            || self.message_count != messages.len()
+            || self.last_block_rev != rev
+    }
+
+    /// Rebuild the cache from scratch.
+    ///
+    /// `collapsed` contains indices of blocks whose output is collapsed
+    /// (reserved for task 6 — currently always empty).
+    pub fn rebuild(
+        &mut self,
+        messages: &[ChatBlock],
+        width: u16,
+        theme: &Theme,
+        collapsed: &HashSet<usize>,
+        rev: u64,
+    ) {
+        self.lines.clear();
+
+        // Compute wrapping widths — mirrors the pre-refactor chat.rs logic.
+        let inner = width as usize;
+        let content_width = inner.saturating_sub(2).max(1); // "  " prefix
+        let output_width = inner.saturating_sub(4).max(1); // "  | " prefix
+
+        for (idx, msg) in messages.iter().enumerate() {
+            let _is_collapsed = collapsed.contains(&idx);
+            match msg {
+                ChatBlock::User(text) => {
+                    let text = strip_emoji(text);
+                    self.push_header(idx, vec![
+                        Span::styled("> ", theme.user_style()),
+                        Span::styled("You", theme.user_style()),
+                    ]);
+                    for line in text.lines() {
+                        for wrapped in wrap_text(line, content_width) {
+                            self.push_body(idx, format!("  {wrapped}"));
+                        }
+                    }
+                    self.push_spacer();
+                }
+
+                ChatBlock::Agent(text) => {
+                    let text = strip_emoji(text);
+                    self.push_header(idx, vec![
+                        Span::styled("* ", theme.agent_style()),
+                        Span::styled("Agent", theme.agent_style()),
+                    ]);
+                    for line in text.lines() {
+                        for wrapped in wrap_text(line, content_width) {
+                            self.push_body(idx, format!("  {wrapped}"));
+                        }
+                    }
+                    self.push_spacer();
+                }
+
+                ChatBlock::Command {
+                    command,
+                    explanation,
+                    output,
+                    approved,
+                } => {
+                    let status = if *approved {
+                        Span::styled(" [ok] ", theme.success_fg())
+                    } else {
+                        Span::styled(" [no] ", theme.danger_fg())
+                    };
+
+                    self.push_header(idx, vec![
+                        Span::styled("> ", theme.warning_fg()),
+                        Span::styled("Command", theme.command_style()),
+                        status,
+                    ]);
+
+                    if !explanation.is_empty() {
+                        for wrapped in wrap_text(&strip_emoji(explanation), output_width) {
+                            self.push_output(idx, format!("  | {wrapped}"));
+                        }
+                    }
+                    for wrapped in wrap_text(&format!("$ {command}"), output_width) {
+                        self.push_output(idx, format!("  | {wrapped}"));
+                    }
+
+                    if let Some(out) = output {
+                        for (count, line) in out.lines().enumerate() {
+                            if count >= 30 {
+                                let remaining =
+                                    out.lines().count().saturating_sub(30);
+                                self.push_output_toggle(
+                                    idx,
+                                    format!("  | ... ({} more lines)", remaining),
+                                );
+                                break;
+                            }
+                            for wrapped in wrap_text(line, output_width) {
+                                self.push_output(idx, format!("  | {wrapped}"));
+                            }
+                        }
+                    }
+                    self.push_spacer();
+                }
+
+                ChatBlock::Error(text) => {
+                    let text = strip_emoji(text);
+                    self.push_header(idx, vec![
+                        Span::styled("! ", theme.error_style()),
+                        Span::styled("Error", theme.error_style()),
+                    ]);
+                    for line in text.lines() {
+                        for wrapped in wrap_text(line, content_width) {
+                            self.push_body(idx, format!("  {wrapped}"));
+                        }
+                    }
+                    self.push_spacer();
+                }
+
+                ChatBlock::System(text) => {
+                    let text = strip_emoji(text);
+                    self.push_header(idx, vec![
+                        Span::styled("- ", theme.muted()),
+                        Span::styled(text, theme.muted()),
+                    ]);
+                    self.push_spacer();
+                }
+            }
+        }
+
+        // Truncate to the last MAX_CACHED_LINES to bound memory.
+        if self.lines.len() > MAX_CACHED_LINES {
+            let start = self.lines.len() - MAX_CACHED_LINES;
+            self.lines.drain(0..start);
+        }
+
+        self.width = width;
+        self.message_count = messages.len();
+        self.last_block_rev = rev;
+    }
+
+    // ----- Internal push helpers -------------------------------------------
+
+    fn push_header(&mut self, idx: usize, spans: Vec<Span<'static>>) {
+        self.lines.push(RenderedLine {
+            line: Line::from(spans),
+            block_index: Some(idx),
+            region: LineRegion::Header,
+        });
+    }
+
+    fn push_body(&mut self, idx: usize, text: String) {
+        self.lines.push(RenderedLine {
+            line: Line::from(text),
+            block_index: Some(idx),
+            region: LineRegion::Body,
+        });
+    }
+
+    fn push_output(&mut self, idx: usize, text: String) {
+        self.lines.push(RenderedLine {
+            line: Line::from(text),
+            block_index: Some(idx),
+            region: LineRegion::Output,
+        });
+    }
+
+    fn push_output_toggle(&mut self, idx: usize, text: String) {
+        self.lines.push(RenderedLine {
+            line: Line::from(text),
+            block_index: Some(idx),
+            region: LineRegion::OutputToggle,
+        });
+    }
+
+    fn push_spacer(&mut self) {
+        self.lines.push(RenderedLine {
+            line: Line::from(""),
+            block_index: None,
+            region: LineRegion::Spacer,
+        });
+    }
+}
+
+impl Default for ChatLayoutCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_messages() -> Vec<ChatBlock> {
+        vec![
+            ChatBlock::User("Hello".into()),
+            ChatBlock::Agent("Hi there".into()),
+            ChatBlock::System("connected".into()),
+        ]
+    }
+
+    #[test]
+    fn cache_invalidates_on_width_change() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+        let msgs = sample_messages();
+
+        // Initial build at width 80.
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+        assert!(!cache.needs_rebuild(&msgs, 80, 1));
+
+        // Width changed → needs rebuild.
+        assert!(cache.needs_rebuild(&msgs, 60, 1));
+    }
+
+    #[test]
+    fn cache_invalidates_on_message_added() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+        let msgs = sample_messages();
+
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+        assert!(!cache.needs_rebuild(&msgs, 80, 1));
+
+        // Message added → needs rebuild.
+        let mut more = msgs.clone();
+        more.push(ChatBlock::User("extra".into()));
+        assert!(cache.needs_rebuild(&more, 80, 1));
+    }
+
+    #[test]
+    fn cache_invalidates_on_rev_change() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+        let msgs = sample_messages();
+
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+        assert!(!cache.needs_rebuild(&msgs, 80, 1));
+
+        // Same messages, same width, but rev changed (e.g. last block mutated).
+        assert!(cache.needs_rebuild(&msgs, 80, 2));
+    }
+
+    #[test]
+    fn cache_does_not_rebuild_on_same_params() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+        let msgs = sample_messages();
+
+        // Build once.
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+        let line_count = cache.lines.len();
+        assert!(line_count > 0);
+
+        // Check again with identical parameters → should NOT need rebuild.
+        assert!(!cache.needs_rebuild(&msgs, 80, 1));
+
+        // Rebuild anyway to verify line count is stable.
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+        assert_eq!(cache.lines.len(), line_count);
+    }
+
+    #[test]
+    fn rendered_lines_have_correct_regions() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+
+        let msgs = vec![ChatBlock::User("hello".into())];
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+
+        // Expected: Header, Body, Spacer (3 lines for a single-line user message).
+        assert_eq!(cache.lines.len(), 3);
+        assert_eq!(cache.lines[0].region, LineRegion::Header);
+        assert_eq!(cache.lines[0].block_index, Some(0));
+        assert_eq!(cache.lines[1].region, LineRegion::Body);
+        assert_eq!(cache.lines[1].block_index, Some(0));
+        assert_eq!(cache.lines[2].region, LineRegion::Spacer);
+        assert_eq!(cache.lines[2].block_index, None);
+    }
+
+    #[test]
+    fn command_block_produces_output_and_toggle_regions() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+
+        let long_output = (0..50).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+        let msgs = vec![ChatBlock::Command {
+            command: "test".into(),
+            explanation: "expl".into(),
+            output: Some(long_output),
+            approved: true,
+        }];
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+
+        // Should have: Header, Output (expl), Output ($ test), Output x30, OutputToggle, Spacer
+        let has_toggle = cache.lines.iter().any(|l| l.region == LineRegion::OutputToggle);
+        assert!(has_toggle, "expected an OutputToggle line for truncated output");
+        let has_output = cache.lines.iter().any(|l| l.region == LineRegion::Output);
+        assert!(has_output, "expected Output lines");
+    }
+}

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -21,6 +21,7 @@
 mod bars;
 mod chat;
 mod input;
+pub mod layout_cache;
 mod text;
 pub mod theme;
 
@@ -34,7 +35,7 @@ use ratatui::Frame;
 use crate::app::{App, AppMode};
 
 /// Render the entire UI.
-pub fn render(f: &mut Frame, app: &App) {
+pub fn render(f: &mut Frame, app: &mut App) {
     if app.mode == AppMode::Interactive {
         render_interactive(f, app);
         return;
@@ -57,7 +58,7 @@ pub fn render(f: &mut Frame, app: &App) {
 }
 
 /// Render the interactive terminal mode.
-fn render_interactive(f: &mut Frame, app: &App) {
+fn render_interactive(f: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([


### PR DESCRIPTION
## Summary

Closes #14

Implements `ChatLayoutCache` — a cached chat layout that avoids re-wrapping text on every frame (up to 60 fps). The cache stores pre-rendered `RenderedLine` objects with `block_index` and `LineRegion` metadata, enabling future mouse hit-testing (task 3).

### Key changes

- **`layout_cache.rs`** (new) — `RenderedLine`, `LineRegion`, `ChatLayoutCache` with `needs_rebuild()` and `rebuild()`. Invalidation keys: terminal width, message count, message revision.
- **`chat.rs`** — rewritten: checks/rebuilds cache, then slices cached lines by scroll offset. No per-frame text wrapping.
- **`app.rs`** — new fields: `layout_cache`, `message_rev`, `chat_area`, `input_area`, `confirm_button_areas`. Private `push_message()` method centralizes all message mutations with `message_rev` bumping. All `self.messages.push(...)` replaced.
- **`mod.rs` / `input.rs`** — `render()` and `render_input_area()` now take `&mut App` to fill `chat_area` / `input_area`.
- **`runner.rs`** — `ui::render(f, &mut app)`; manual `message_rev` bump for the one `app.messages.push` outside `App`.

### Design decisions

- `MAX_CACHED_LINES` raised from 500 → 2000 (cache makes per-frame cost = slice).
- `push_message()` is private — runner bumps `message_rev` manually for its single direct `messages.push`.
- `collapsed: &HashSet<usize>` parameter in `rebuild()` reserved for task 6 (collapsible output).
- `LineRegion::OutputToggle` marks the `... (N more lines)` truncation line — future click-to-expand target.

### Tests

- `cargo build --workspace` ✅
- `cargo clippy -p filar-tui --all-targets --no-deps -- -D warnings` ✅
- `cargo test --workspace` ✅ — 30 tui tests pass (24 existing + 6 new cache tests)
- New tests: cache invalidation on width/message/rev change, no-rebuild on same params, region correctness, command output + toggle regions
- `#[ignore]` tests (Docker sshd): not run — require manual verification

### Not in scope

- Mouse hit-testing (task 3 — #15)
- Collapsible output blocks (task 6 — #18)
- Streaming partial block updates (task 7 — #19)
- `confirm_button_areas` — initialized empty, will be filled in task 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chat layout caching to speed up TUI redraws and reduce re-wrapping.
  * Improved mouse-ready hit areas by tracking the chat and input pane regions for more accurate interactions.

* **Bug Fixes**
  * Ensured chat rendering stays consistent by rebuilding cached layout when chat history, terminal width, or revision changes.
  * Centralized error/message updates so inline updates and new errors reliably trigger cache refreshes.

* **Documentation**
  * Updated workspace progress notes with the new layout caching approach and related follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->