### PR TITLE
feat(tui): mouse capture, wheel scroll, and ↓N new indicator

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -622,3 +622,7 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
   `clamp_scroll()` — приватный. End key в Normal изменил поведение: пустой ввод →
   scroll reset вместо cursor-to-end (backward-incompatible, но старый behavior
   остаётся при непустом вводе).
+- **Review fixes (CodeRabbit PR #26):**
+  - Fixed indicator width: `indicator.len()` (bytes) → `indicator.chars().count()`
+    (display columns). `↓` (U+2193) is 3 bytes but 1 terminal column, so byte length
+    overestimated width by 2 and mispositioned the indicator.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -589,3 +589,36 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
     `AgentEvent::Error`, `AgentEvent::CommandExecuted` (in-place update),
     `respond_to_confirmation` (via handle_key 'a' in Confirming mode).
   Total: 37 tui tests pass.
+
+### Issue #15: TUI — захват мыши и скролл колесом
+- **Файлы:**
+  - `crates/tui/src/runner.rs` — `EnableMouseCapture`/`DisableMouseCapture` в init/teardown;
+    обработка `Event::Mouse(m)` в event loop
+  - `crates/tui/src/app.rs` — `handle_mouse()`, `clamp_scroll()`; `End` key при пустом
+    вводе сбрасывает scroll; `End` добавлен в Thinking/Confirming; `clamp_scroll()` после PageUp
+  - `crates/tui/src/ui/chat.rs` — definitive scroll clamp в render; индикатор `↓ N new`
+    в правом нижнем углу chat area (тусклый цвет `theme.fg_muted`)
+- **Что сделано:**
+  - Mouse capture включается при старте и выключается при выходе (оба пути,
+    включая ошибочный) — OS text selection работает после закрытия приложения.
+  - `handle_mouse()`: `ScrollUp` → scroll += 3, `ScrollDown` → scroll -= 3;
+    только внутри `chat_area`; игнорируется в Interactive/PasswordInput.
+  - `clamp_scroll()`: clamp к `layout_cache.lines.len().saturating_sub(visible_height)` —
+    нельзя укрутить в пустоту. Вызывается после mouse wheel и PageUp.
+    Дублируется в `render_chat_history` для definitive clamp (точный visible_height).
+  - `End` key: при пустом вводе → scroll = 0 (Normal/Thinking/Confirming);
+    при непустом вводе в Normal → cursor в конец (как раньше).
+  - Индикатор `↓ N new` где N = scroll (после clamp) — количество строк ниже вьюпорта.
+- **Решения:**
+  - `↓` (U+2193) — basic Unicode, рендерится в Windows Terminal и conhost.
+    Glyphs-struct fallback (DESIGN_PHILOSOPHY §7) — отдельная задача, не эта.
+  - `clamp_scroll` использует `chat_area` и `layout_cache.lines` из последнего рендера —
+    best-effort; definitive clamp в render использует точные значения.
+  - Mouse events за пределами `chat_area` игнорируются (не клики по input/help bar).
+- **Тесты:** 11 новых в `app.rs`: scroll up/down, clamp to max/zero, ignored outside
+  chat area, ignored in Interactive, End key (empty/nonempty input, Thinking,
+  Confirming), PageUp clamp. Total: 48 tui tests pass.
+- **Публичные контракты:** `App::handle_mouse()` — новый public метод (для runner).
+  `clamp_scroll()` — приватный. End key в Normal изменил поведение: пустой ввод →
+  scroll reset вместо cursor-to-end (backward-incompatible, но старый behavior
+  остаётся при непустом вводе).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -334,10 +334,15 @@ impl App {
                     self.cursor_pos = 0;
                 }
                 KeyCode::End => {
-                    self.cursor_pos = self.input.chars().count();
+                    if self.input.is_empty() {
+                        self.scroll = 0;
+                    } else {
+                        self.cursor_pos = self.input.chars().count();
+                    }
                 }
                 KeyCode::PageUp => {
                     self.scroll = self.scroll.saturating_add(5);
+                    self.clamp_scroll();
                 }
                 KeyCode::PageDown => {
                     self.scroll = self.scroll.saturating_sub(5);
@@ -359,9 +364,13 @@ impl App {
                 }
                 if key.code == KeyCode::PageUp {
                     self.scroll = self.scroll.saturating_add(5);
+                    self.clamp_scroll();
                 }
                 if key.code == KeyCode::PageDown {
                     self.scroll = self.scroll.saturating_sub(5);
+                }
+                if key.code == KeyCode::End {
+                    self.scroll = 0;
                 }
             }
             AppMode::Confirming => match key.code {
@@ -373,6 +382,9 @@ impl App {
                 KeyCode::Char('d') | KeyCode::Char('n')
                 | KeyCode::Char('в') | KeyCode::Char('т') => {
                     self.respond_to_confirmation(false);
+                }
+                KeyCode::End => {
+                    self.scroll = 0;
                 }
                 _ if ctrl_key('c', 'с') => {
                     self.respond_to_confirmation(false);
@@ -472,6 +484,59 @@ impl App {
                 }
                 _ => {}
             },
+        }
+    }
+
+    /// Clamp `scroll` so the user cannot scroll past the content.
+    ///
+    /// Uses the last-known chat area height and cached line count.  Called
+    /// after mouse-wheel and PageUp adjustments, and also during render for
+    /// a definitive clamp.
+    fn clamp_scroll(&mut self) {
+        if self.chat_area.height == 0 {
+            return;
+        }
+        let visible_height = self.chat_area.height.saturating_sub(2) as usize;
+        let max_scroll = self
+            .layout_cache
+            .lines
+            .len()
+            .saturating_sub(visible_height);
+        if self.scroll > max_scroll {
+            self.scroll = max_scroll;
+        }
+    }
+
+    /// Handle a mouse event (scroll wheel inside the chat area).
+    ///
+    /// Active in all modes except `Interactive` and `PasswordInput`.
+    pub fn handle_mouse(&mut self, m: crossterm::event::MouseEvent) {
+        use crossterm::event::MouseEventKind;
+
+        // Mouse is only for chat scrolling — ignore in interactive/password modes.
+        if self.mode == AppMode::Interactive || self.mode == AppMode::PasswordInput {
+            return;
+        }
+
+        // Check if the event is inside the chat area (including borders).
+        let inside = m.row >= self.chat_area.y
+            && m.row < self.chat_area.y + self.chat_area.height
+            && m.column >= self.chat_area.x
+            && m.column < self.chat_area.x + self.chat_area.width;
+
+        if !inside {
+            return;
+        }
+
+        match m.kind {
+            MouseEventKind::ScrollUp => {
+                self.scroll = self.scroll.saturating_add(3);
+                self.clamp_scroll();
+            }
+            MouseEventKind::ScrollDown => {
+                self.scroll = self.scroll.saturating_sub(3);
+            }
+            _ => {}
         }
     }
 
@@ -866,5 +931,230 @@ mod tests {
 
         assert!(app.message_rev > rev_before);
         assert_eq!(app.mode, AppMode::Thinking);
+    }
+
+    // ----- Mouse / scroll tests (issue #15) -----
+
+    /// Helper: create a mouse scroll event.
+    fn mouse_event(kind: crossterm::event::MouseEventKind, col: u16, row: u16) -> crossterm::event::MouseEvent {
+        crossterm::event::MouseEvent {
+            kind,
+            column: col,
+            row,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    #[test]
+    fn mouse_scroll_up_increases_scroll() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        // Simulate a chat area with content (set chat_area so clamp_scroll works).
+        app.chat_area = Rect::new(0, 1, 80, 24); // y=1, height=24
+        // Fill cache with enough lines so scroll is possible.
+        app.layout_cache.lines = (0..50)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        // visible_height = 24 - 2 = 22; max_scroll = 50 - 22 = 28
+
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::ScrollUp,
+            10,
+            10,
+        ));
+        assert_eq!(app.scroll, 3);
+    }
+
+    #[test]
+    fn mouse_scroll_down_decreases_scroll() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = (0..50)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        app.scroll = 10;
+
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::ScrollDown,
+            10,
+            10,
+        ));
+        assert_eq!(app.scroll, 7); // 10 - 3 = 7
+    }
+
+    #[test]
+    fn mouse_scroll_down_clamps_to_zero() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = (0..50)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        app.scroll = 2;
+
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::ScrollDown,
+            10,
+            10,
+        ));
+        assert_eq!(app.scroll, 0); // 2 - 3 saturates to 0
+    }
+
+    #[test]
+    fn mouse_scroll_up_clamps_to_max() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = (0..30)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        // visible_height = 22; max_scroll = 30 - 22 = 8
+
+        // Scroll up many times to exceed max.
+        for _ in 0..10 {
+            app.handle_mouse(mouse_event(
+                crossterm::event::MouseEventKind::ScrollUp,
+                10,
+                10,
+            ));
+        }
+        assert_eq!(app.scroll, 8); // clamped to max_scroll
+    }
+
+    #[test]
+    fn mouse_ignored_outside_chat_area() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = (0..50)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+
+        // Click outside chat area (row 0 is above chat_area.y=1).
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::ScrollUp,
+            10,
+            0,
+        ));
+        assert_eq!(app.scroll, 0); // no change
+    }
+
+    #[test]
+    fn mouse_ignored_in_interactive_mode() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.mode = AppMode::Interactive;
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = (0..50)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::ScrollUp,
+            10,
+            10,
+        ));
+        assert_eq!(app.scroll, 0); // no change in Interactive mode
+    }
+
+    #[test]
+    fn end_key_resets_scroll_when_input_empty() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.scroll = 15;
+        // Input is empty by default.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::End,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.scroll, 0);
+    }
+
+    #[test]
+    fn end_key_moves_cursor_when_input_nonempty() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.input = "hello".into();
+        app.cursor_pos = 0;
+        app.scroll = 15;
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::End,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.cursor_pos, 5); // cursor at end of "hello"
+        assert_eq!(app.scroll, 15); // scroll unchanged
+    }
+
+    #[test]
+    fn end_key_resets_scroll_in_thinking_mode() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.mode = AppMode::Thinking;
+        app.scroll = 20;
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::End,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.scroll, 0);
+    }
+
+    #[test]
+    fn end_key_resets_scroll_in_confirming_mode() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let (tx, _rx) = oneshot::channel();
+        app.pending_confirm = Some(PendingConfirm {
+            command: "ls".into(),
+            explanation: "test".into(),
+            destructive: false,
+            respond_to: tx,
+        });
+        app.mode = AppMode::Confirming;
+        app.scroll = 12;
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::End,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.scroll, 0);
+        assert_eq!(app.mode, AppMode::Confirming); // still confirming
+    }
+
+    #[test]
+    fn page_up_clamps_scroll() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = (0..30)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        // visible_height = 22; max_scroll = 30 - 22 = 8
+
+        // PageUp many times to exceed max.
+        for _ in 0..5 {
+            app.handle_key(crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::PageUp,
+                crossterm::event::KeyModifiers::NONE,
+            ));
+        }
+        // 5 * 5 = 25, clamped to 8
+        assert_eq!(app.scroll, 8);
     }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -9,7 +9,7 @@ use std::io::{self, Stdout};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crossterm::event::{Event, EventStream};
+use crossterm::event::{EnableMouseCapture, DisableMouseCapture, Event, EventStream};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
 use futures::StreamExt;
 use ratatui::backend::CrosstermBackend;
@@ -142,7 +142,7 @@ pub async fn run(
     // Set up terminal.
     enable_raw_mode().map_err(|e| CoreError::Other(format!("failed to enable raw mode: {e}")))?;
     let mut stdout = io::stdout();
-    crossterm::execute!(stdout, EnterAlternateScreen)
+    crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
         .map_err(|e| CoreError::Other(format!("failed to enter alternate screen: {e}")))?;
 
     let backend = CrosstermBackend::new(stdout);
@@ -153,7 +153,7 @@ pub async fn run(
 
     // Restore terminal.
     disable_raw_mode().ok();
-    crossterm::execute!(io::stdout(), LeaveAlternateScreen).ok();
+    crossterm::execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen).ok();
 
     result
 }
@@ -233,6 +233,10 @@ async fn run_app(
                                 let _ = term.resize(term_cols, term_rows).await;
                             }
                         }
+                        needs_redraw = true;
+                    }
+                    Some(Ok(Event::Mouse(m))) => {
+                        app.handle_mouse(m);
                         needs_redraw = true;
                     }
                     Some(Ok(_)) => {} // ignore other events

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -38,6 +38,14 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
     // Compute visible slice from cached lines.
     let total_lines = app.layout_cache.lines.len();
     let visible_height = area.height.saturating_sub(2) as usize; // -2 for border
+
+    // Definitive scroll clamp — the render path knows the exact visible_height
+    // and has just rebuilt the cache, so this is the authoritative clamp.
+    let max_scroll = total_lines.saturating_sub(visible_height);
+    if app.scroll > max_scroll {
+        app.scroll = max_scroll;
+    }
+
     let skip = if total_lines > visible_height {
         total_lines.saturating_sub(visible_height + app.scroll)
     } else {
@@ -61,4 +69,23 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
 
     let paragraph = Paragraph::new(visible_lines).block(block);
     f.render_widget(paragraph, area);
+
+    // "↓ N new" indicator — shown when the user has scrolled up from the bottom.
+    // N is the number of lines below the viewport (= scroll after clamping).
+    if app.scroll > 0 && area.height >= 3 && area.width >= 3 {
+        let indicator = format!("\u{2193} {} new", app.scroll);
+        let indicator_width = indicator.len() as u16;
+        let inner_width = area.width.saturating_sub(2);
+        let indicator_width = indicator_width.min(inner_width);
+        let indicator_area = Rect::new(
+            area.x + area.width.saturating_sub(1 + indicator_width),
+            area.y + area.height.saturating_sub(2),
+            indicator_width,
+            1,
+        );
+        f.render_widget(
+            Paragraph::new(indicator).style(app.theme.muted()),
+            indicator_area,
+        );
+    }
 }

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -74,7 +74,8 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
     // N is the number of lines below the viewport (= scroll after clamping).
     if app.scroll > 0 && area.height >= 3 && area.width >= 3 {
         let indicator = format!("\u{2193} {} new", app.scroll);
-        let indicator_width = indicator.len() as u16;
+        // Use char count, not byte length — `↓` (U+2193) is 3 bytes but 1 column.
+        let indicator_width = indicator.chars().count() as u16;
         let inner_width = area.width.saturating_sub(2);
         let indicator_width = indicator_width.min(inner_width);
         let indicator_area = Rect::new(


### PR DESCRIPTION
## Summary

Implements mouse capture infrastructure, wheel-scroll in chat, scroll clamping, and the `↓ N new` indicator (issue #15, task 3 of TUI Modernization v0.2.0).

### Changes

- **`runner.rs`**: `EnableMouseCapture` added to terminal init, `DisableMouseCapture` to teardown (both exit paths). `Event::Mouse(m)` handled in the event loop → `app.handle_mouse(m)`.
- **`app.rs`**: 
  - `handle_mouse(&mut self, m: MouseEvent)` — scroll wheel inside `chat_area` in Normal/Thinking/Confirming modes. `ScrollUp` → +3, `ScrollDown` → -3.
  - `clamp_scroll()` — clamps scroll to `layout_cache.lines.len().saturating_sub(visible_height)`, called after mouse wheel and PageUp.
  - `End` key: when input is empty → `scroll = 0` (Normal/Thinking/Confirming). When input is non-empty in Normal → cursor to end (as before).
- **`chat.rs`**: Definitive scroll clamp in `render_chat_history` (exact `visible_height` after cache rebuild). `↓ N new` indicator rendered in bottom-right of chat area with `theme.muted()` style.

### Tests

- 11 new tests in `app.rs`: mouse scroll up/down, clamp to max/zero, ignored outside chat area, ignored in Interactive mode, End key (empty/nonempty input, Thinking, Confirming), PageUp clamp.
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (48 tui tests, 36 core, 12 agent, 7 transport [5 ignored — require docker-sshd])
- `cargo clippy -p filar-tui --no-deps -- -D warnings` ✅
- Pre-existing clippy warnings in `filar-transport` and `filar-gui` are out of scope.

### Manual verification required

- Wheel scroll in Windows Terminal and conhost (project is Windows-first).
- OS text selection works after app exit (mouse capture properly released).
- `↓ N new` indicator appears/disappears correctly.

### Out of scope

- Click-to-scroll-to-bottom on the `↓ N new` indicator (task 4 — mouse hit-testing).
- Glyphs struct / ASCII fallback system (DESIGN_PHILOSOPHY §7) — separate task.

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse-wheel scrolling within the chat area.
  * Added a “↓ N new” indicator when newer messages are below the current view.
* **Bug Fixes**
  * Improved scroll clamping to keep the chat view within valid limits.
  * Updated **End** behavior to reset scroll when input is empty (and preserve cursor-to-end when not).
  * Updated **PageUp** to clamp scrolling correctly.
  * Mouse capture is now enabled/disabled appropriately, and wheel/clicks outside the chat area (or during input) are ignored.
* **Tests**
  * Added coverage for mouse/scroll handling and key behaviors (**End**, **PageUp**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->