### PR TITLE
feat(tui): modal confirm dialog with clickable buttons (#17)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -665,3 +665,47 @@ cargo test -p filar-tui -p filar-agent -p filar-transport
   - Fixed `update_scrollbar_drag` divisor: `visible_height` → `visible_height - 1`
     (track span). Old formula prevented thumb from reaching `scroll = 0` at bottom.
     Updated test to assert `scroll == 0` at bottom.
+
+## Issue #17: TUI: модальное подтверждение команд с кликабельными кнопками
+
+PR: #28
+
+**Задача:** Заменить текстовое подтверждение в нижней панели на центрированный
+модальный диалог с кликабельными кнопками Approve / Deny.
+
+**Файлы:**
+- `crates/tui/src/ui/confirm.rs` — НОВЫЙ модуль: рендеринг модального диалога
+  (Block с Rounded borders, Clear под ним, кнопки с hit-test areas)
+- `crates/tui/src/app.rs` — новые поля `confirm_selected` (bool, default false=Deny)
+  и `hovered_button` (Option<bool>); обновлён `handle_key` (Enter → активирует
+  selected, Tab/←/→ → toggle); обновлён `handle_mouse` (click на кнопку →
+  respond, Moved → hover tracking); `hit_test` — confirm buttons проверяются
+  первыми (поверх всего); `confirm_selected` сбрасывается при новом
+  ConfirmationRequest
+- `crates/tui/src/ui/mod.rs` — `mod confirm;`, рендер модала после всех зон
+  если mode == Confirming
+- `crates/tui/src/ui/input.rs` — `render_confirm` показывает приглушённый
+  `waiting for confirmation…` (layout не прыгает); убраны старые импорты
+  `Line`/`Span`
+- `crates/tui/src/ui/bars.rs` — help-bar для Confirming: `Tab=Switch | Enter=Confirm | a/y=Approve | d/n=Deny | Ctrl+C=Quit`
+
+**Решения:**
+- Enter теперь активирует выделенную кнопку (дефолт Deny) — согласованное
+  изменение из DESIGN_PHILOSOPHY §6. Безопаснее, чем безусловный approve.
+- Hover перемещает selection на кнопку под курсором — интуитивный UX.
+- `confirm_button_areas` проверяются в `hit_test` первыми — модал поверх всего.
+- Кнопки: `[ Approve (a) ]` / `[ Deny (d) ]`, inversion (fg↔bg) для выбранной,
+  `theme.surface` bg для невыбранной. 3 пробела между кнопками.
+- Рамка: `BorderType::Rounded`, `danger` для destructive, `warning` иначе.
+- Title: ` Confirm command ` (ASCII-safe, без `⚠`).
+
+**Тесты:** 16 новых в `app.rs`: confirm_selected defaults, Tab/Left/Right toggle,
+  Enter activates selected (default deny, after tab approve), letter hotkeys
+  (a/d, Russian ф/в), Ctrl+C denies+quits, confirm_selected resets on new
+  request, mouse click Approve/Deny, mouse hover updates selected, hit_test
+  confirm button overrides chat. Total: 81 tui tests.
+
+**Публичные контракты:** `App` получил 2 новых поля: `confirm_selected: bool`,
+  `hovered_button: Option<bool>`. Новый модуль `ui::confirm`.
+  `render_confirm` в `input.rs` больше не рисует диалог — только muted placeholder.
+  Help-bar текст для Confirming изменён.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -709,3 +709,11 @@ PR: #28
   `hovered_button: Option<bool>`. Новый модуль `ui::confirm`.
   `render_confirm` в `input.rs` больше не рисует диалог — только muted placeholder.
   Help-bar текст для Confirming изменён.
+- **Review fixes (CodeRabbit PR #28):**
+  - Fixed stale hit-test state: `respond_to_confirmation` now clears
+    `confirm_button_areas` and `hovered_button` so old button rects don't
+    swallow clicks after modal closes. Added regression test.
+  - Fixed modal sizing: `estimate_wrapped_rows` helper computes wrapped line
+    count so `Constraint::Length` doesn't clip long text. Min width 30 → 32.
+  - Fixed title color: hardcoded `danger` → `border_color` (warning for
+    non-destructive commands).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -154,6 +154,10 @@ pub struct App {
     pub status_bar_area: Rect,
     /// Help bar area (set during render, for hit-testing).
     pub help_bar_area: Rect,
+    /// Currently selected confirm button: `false` = Deny (safe default), `true` = Approve.
+    pub confirm_selected: bool,
+    /// Button under mouse cursor during hover (`Some(true)` = Approve, `Some(false)` = Deny).
+    pub hovered_button: Option<bool>,
 }
 
 impl App {
@@ -193,6 +197,8 @@ impl App {
             indicator_area: Rect::default(),
             status_bar_area: Rect::default(),
             help_bar_area: Rect::default(),
+            confirm_selected: false,
+            hovered_button: None,
         }
     }
 
@@ -423,8 +429,15 @@ impl App {
                 }
             }
             AppMode::Confirming => match key.code {
-                KeyCode::Enter
-                | KeyCode::Char('a') | KeyCode::Char('y') | KeyCode::Char('e')
+                KeyCode::Enter => {
+                    // Enter activates the selected button (default Deny — safe).
+                    self.respond_to_confirmation(self.confirm_selected);
+                }
+                KeyCode::Tab | KeyCode::Left | KeyCode::Right => {
+                    // Toggle between Approve and Deny.
+                    self.confirm_selected = !self.confirm_selected;
+                }
+                KeyCode::Char('a') | KeyCode::Char('y') | KeyCode::Char('e')
                 | KeyCode::Char('ф') | KeyCode::Char('н') | KeyCode::Char('у') => {
                     self.respond_to_confirmation(true);
                 }
@@ -600,6 +613,9 @@ impl App {
                 HitZone::Input if self.mode == AppMode::Normal => {
                     self.set_cursor_from_click(m.column, m.row);
                 }
+                HitZone::ConfirmButton(approve) => {
+                    self.respond_to_confirmation(approve);
+                }
                 _ => {}
             },
             // --- Drag ---
@@ -612,6 +628,15 @@ impl App {
             MouseEventKind::Up(MouseButton::Left) => {
                 self.mouse_drag = None;
             }
+            // --- Hover (track which button is under cursor) ---
+            MouseEventKind::Moved => {
+                if let HitZone::ConfirmButton(approve) = zone {
+                    self.hovered_button = Some(approve);
+                    self.confirm_selected = approve;
+                } else {
+                    self.hovered_button = None;
+                }
+            }
             _ => {}
         }
     }
@@ -621,7 +646,18 @@ impl App {
     /// Uses the last-known areas (filled during render).  The caller is
     /// responsible for acting on the result.
     fn hit_test(&self, col: u16, row: u16) -> HitZone {
-        // --- ↓ N new indicator (check first — it overlays the chat area) ---
+        // --- Confirm buttons (check first — modal overlays everything) ---
+        for (rect, approved) in &self.confirm_button_areas {
+            if col >= rect.x
+                && col < rect.x + rect.width
+                && row >= rect.y
+                && row < rect.y + rect.height
+            {
+                return HitZone::ConfirmButton(*approved);
+            }
+        }
+
+        // --- ↓ N new indicator (overlays the chat area) ---
         if self.indicator_area.width > 0
             && col >= self.indicator_area.x
             && col < self.indicator_area.x + self.indicator_area.width
@@ -696,16 +732,7 @@ impl App {
             return HitZone::HelpBar;
         }
 
-        // --- Confirm buttons (future — areas not yet populated) ---
-        for (rect, approved) in &self.confirm_button_areas {
-            if col >= rect.x
-                && col < rect.x + rect.width
-                && row >= rect.y
-                && row < rect.y + rect.height
-            {
-                return HitZone::ConfirmButton(*approved);
-            }
-        }
+        // --- Confirm buttons (checked at top of hit_test — see above) ---
 
         HitZone::Outside
     }
@@ -788,6 +815,8 @@ impl App {
                     respond_to,
                 });
                 self.mode = AppMode::Confirming;
+                // Reset selection to safe default (Deny).
+                self.confirm_selected = false;
             }
             AgentEvent::CommandExecuted {
                 command,
@@ -1596,5 +1625,257 @@ mod tests {
             27,
         ));
         assert_eq!(app.cursor_pos, 0); // no change in Thinking mode
+    }
+
+    // ----- Confirm modal tests (issue #17) -----
+
+    /// Helper: set up an app in Confirming mode with a pending confirmation.
+    fn make_confirm_app(destructive: bool) -> App {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let (_tx, rx) = oneshot::channel::<bool>();
+        // We need the tx to stay alive so respond_to doesn't fail silently;
+        // but for tests we just check mode/message changes.
+        // Use a fresh sender that we drop to simulate a real channel.
+        let (tx, _rx2) = oneshot::channel::<bool>();
+        app.pending_confirm = Some(PendingConfirm {
+            command: "rm -rf /tmp/test".into(),
+            explanation: "cleanup".into(),
+            destructive,
+            respond_to: tx,
+        });
+        app.mode = AppMode::Confirming;
+        app.confirm_selected = false; // safe default
+        app
+    }
+
+    /// Helper: create a key event.
+    fn key_event(code: crossterm::event::KeyCode) -> crossterm::event::KeyEvent {
+        crossterm::event::KeyEvent::new(code, crossterm::event::KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn confirm_selected_defaults_to_deny() {
+        let app = make_confirm_app(false);
+        assert!(!app.confirm_selected, "default should be Deny (false)");
+    }
+
+    #[test]
+    fn tab_toggles_confirm_selected() {
+        let mut app = make_confirm_app(false);
+        assert!(!app.confirm_selected);
+        app.handle_key(key_event(crossterm::event::KeyCode::Tab));
+        assert!(app.confirm_selected, "Tab should toggle to Approve");
+        app.handle_key(key_event(crossterm::event::KeyCode::Tab));
+        assert!(!app.confirm_selected, "Tab should toggle back to Deny");
+    }
+
+    #[test]
+    fn left_arrow_toggles_confirm_selected() {
+        let mut app = make_confirm_app(false);
+        app.handle_key(key_event(crossterm::event::KeyCode::Left));
+        assert!(app.confirm_selected);
+        app.handle_key(key_event(crossterm::event::KeyCode::Left));
+        assert!(!app.confirm_selected);
+    }
+
+    #[test]
+    fn right_arrow_toggles_confirm_selected() {
+        let mut app = make_confirm_app(false);
+        app.handle_key(key_event(crossterm::event::KeyCode::Right));
+        assert!(app.confirm_selected);
+    }
+
+    #[test]
+    fn enter_activates_selected_default_deny() {
+        let mut app = make_confirm_app(false);
+        // Default is Deny → Enter should deny.
+        app.handle_key(key_event(crossterm::event::KeyCode::Enter));
+        assert_eq!(app.mode, AppMode::Thinking);
+        assert!(app.pending_confirm.is_none());
+        // Last message should be a Command with approved=false.
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(!*approved, "Enter on default Deny should deny");
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn enter_after_tab_activates_approve() {
+        let mut app = make_confirm_app(false);
+        app.handle_key(key_event(crossterm::event::KeyCode::Tab));
+        assert!(app.confirm_selected);
+        app.handle_key(key_event(crossterm::event::KeyCode::Enter));
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(*approved, "Enter after Tab should approve");
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn letter_a_approves_directly() {
+        let mut app = make_confirm_app(false);
+        app.handle_key(key_event(crossterm::event::KeyCode::Char('a')));
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(*approved);
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn letter_d_denies_directly() {
+        let mut app = make_confirm_app(false);
+        app.handle_key(key_event(crossterm::event::KeyCode::Char('d')));
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(!*approved);
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn russian_layout_approve() {
+        let mut app = make_confirm_app(false);
+        // ф = a in ЙЦУКЕН layout
+        app.handle_key(key_event(crossterm::event::KeyCode::Char('ф')));
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(*approved);
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn russian_layout_deny() {
+        let mut app = make_confirm_app(false);
+        // в = d in ЙЦУКЕН layout
+        app.handle_key(key_event(crossterm::event::KeyCode::Char('в')));
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(!*approved);
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn ctrl_c_denies_and_quits() {
+        let mut app = make_confirm_app(false);
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('c'),
+            crossterm::event::KeyModifiers::CONTROL,
+        ));
+        assert!(app.should_quit);
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(!*approved, "Ctrl+C should deny");
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn confirm_selected_resets_on_new_request() {
+        let mut app = make_confirm_app(false);
+        // Toggle to Approve.
+        app.handle_key(key_event(crossterm::event::KeyCode::Tab));
+        assert!(app.confirm_selected);
+        // Simulate a new confirmation request.
+        let (tx, _rx) = oneshot::channel::<bool>();
+        app.handle_agent_event(AgentEvent::ConfirmationRequest {
+            command: "ls".into(),
+            explanation: "list".into(),
+            destructive: false,
+            respond_to: tx,
+        });
+        assert!(!app.confirm_selected, "new request should reset to Deny");
+    }
+
+    #[test]
+    fn mouse_click_approve_button() {
+        let mut app = make_confirm_app(false);
+        // Simulate button areas (set during render).
+        // Approve button at col 20-34, row 10.
+        app.confirm_button_areas.push((Rect::new(20, 10, 15, 1), true));
+        // Deny button at col 38-50, row 10.
+        app.confirm_button_areas.push((Rect::new(38, 10, 13, 1), false));
+        // Click on Approve.
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            25,
+            10,
+        ));
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(*approved, "clicking Approve should approve");
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn mouse_click_deny_button() {
+        let mut app = make_confirm_app(false);
+        app.confirm_button_areas.push((Rect::new(20, 10, 15, 1), true));
+        app.confirm_button_areas.push((Rect::new(38, 10, 13, 1), false));
+        // Click on Deny.
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            42,
+            10,
+        ));
+        assert_eq!(app.mode, AppMode::Thinking);
+        if let Some(ChatBlock::Command { approved, .. }) = app.messages.last() {
+            assert!(!*approved, "clicking Deny should deny");
+        } else {
+            panic!("expected Command block");
+        }
+    }
+
+    #[test]
+    fn mouse_hover_updates_selected() {
+        let mut app = make_confirm_app(false);
+        app.confirm_button_areas.push((Rect::new(20, 10, 15, 1), true));
+        app.confirm_button_areas.push((Rect::new(38, 10, 13, 1), false));
+        // Hover over Approve.
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Moved,
+            25,
+            10,
+        ));
+        assert_eq!(app.hovered_button, Some(true));
+        assert!(app.confirm_selected, "hover on Approve should move selection");
+        // Hover over Deny.
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Moved,
+            42,
+            10,
+        ));
+        assert_eq!(app.hovered_button, Some(false));
+        assert!(!app.confirm_selected);
+        // Hover outside buttons.
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Moved,
+            0,
+            0,
+        ));
+        assert_eq!(app.hovered_button, None);
+    }
+
+    #[test]
+    fn hit_test_confirm_button_overrides_chat() {
+        let mut app = make_hit_test_app();
+        app.mode = AppMode::Confirming;
+        // Place a confirm button over the chat area.
+        app.confirm_button_areas.push((Rect::new(5, 5, 15, 1), true));
+        // Hit-test at a point inside the button — should be ConfirmButton, not Chat.
+        let zone = app.hit_test(7, 5);
+        assert_eq!(zone, HitZone::ConfirmButton(true));
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -790,6 +790,9 @@ impl App {
                 approved,
             });
             self.mode = AppMode::Thinking;
+            // Clear modal hit-test state so stale button areas don't swallow clicks.
+            self.confirm_button_areas.clear();
+            self.hovered_button = None;
         }
     }
 
@@ -1877,5 +1880,28 @@ mod tests {
         // Hit-test at a point inside the button — should be ConfirmButton, not Chat.
         let zone = app.hit_test(7, 5);
         assert_eq!(zone, HitZone::ConfirmButton(true));
+    }
+
+    #[test]
+    fn confirm_state_cleared_after_response() {
+        let mut app = make_confirm_app(false);
+        // Populate button areas as if rendered.
+        app.confirm_button_areas.push((Rect::new(20, 10, 15, 1), true));
+        app.confirm_button_areas.push((Rect::new(38, 10, 13, 1), false));
+        app.hovered_button = Some(true);
+
+        // Deny via keyboard.
+        app.handle_key(key_event(crossterm::event::KeyCode::Char('d')));
+
+        // After response, modal state should be cleared.
+        assert!(app.confirm_button_areas.is_empty(), "button areas should be cleared");
+        assert_eq!(app.hovered_button, None, "hovered_button should be cleared");
+
+        // Hit-test in the former button area should NOT return ConfirmButton.
+        let zone = app.hit_test(25, 10);
+        assert!(
+            !matches!(zone, HitZone::ConfirmButton(_)),
+            "stale button area should not swallow clicks after modal closes"
+        );
     }
 }

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -48,7 +48,7 @@ pub(crate) fn render_help_bar(f: &mut Frame, app: &mut App, area: Rect) {
     let help_text = match app.mode {
         AppMode::Normal => " Enter=Send | !=Shell | Ctrl+T=Terminal | Ctrl+P=Password | Ctrl+C=Quit",
         AppMode::Thinking => " Ctrl+C=Quit | PgUp/PgDn=Scroll",
-        AppMode::Confirming => " a/y/e=Approve | d/n=Deny | Ctrl+C=Quit",
+        AppMode::Confirming => " Tab=Switch | Enter=Confirm | a/y=Approve | d/n=Deny | Ctrl+C=Quit",
         AppMode::Interactive => " Ctrl+T=Agent mode | (terminal input is forwarded)",
         AppMode::PasswordInput => " Enter=Send password | Esc=Cancel | Ctrl+C=Cancel",
     };

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -48,17 +48,33 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
         )));
     }
 
+    let command_text = format!("$ {}", confirm.command);
     lines.push(Line::from(Span::styled(
-        format!("$ {}", confirm.command),
+        command_text.as_str(),
         app.theme.warning_fg(),
     )));
 
     lines.push(Line::from(""));
 
-    let content_lines = lines.len() as u16;
+    // --- Estimate modal dimensions ---
+    // Minimum width 32 so buttons fit inside borders (30 chars + 2 borders).
+    let modal_width = 70u16.min(area.width.saturating_sub(8)).max(32);
+    let inner_width = (modal_width.saturating_sub(2)) as usize; // -2 borders
+
+    // Estimate how many rendered rows each text segment will occupy after
+    // wrapping, so the content area is tall enough to show everything.
+    let explanation_rows = if !confirm.explanation.is_empty() {
+        estimate_wrapped_rows(&confirm.explanation, inner_width)
+    } else {
+        0
+    };
+    let warning_rows = if confirm.destructive { 1 } else { 0 };
+    let command_rows = estimate_wrapped_rows(&command_text, inner_width);
+    let empty_rows = 1; // separator line
+
+    let content_height = (explanation_rows + warning_rows + command_rows + empty_rows) as u16;
     // +2 for borders, +1 for buttons line
-    let modal_height = content_lines + 1 + 2;
-    let modal_width = 70u16.min(area.width.saturating_sub(8)).max(30);
+    let modal_height = content_height + 1 + 2;
 
     // Center within the area.
     let modal_x = area.x + (area.width.saturating_sub(modal_width)) / 2;
@@ -81,7 +97,7 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
         .title(Span::styled(
             " Confirm command ",
             Style::default()
-                .fg(app.theme.danger)
+                .fg(border_color)
                 .add_modifier(Modifier::BOLD),
         ))
         .border_style(Style::default().fg(border_color));
@@ -93,7 +109,7 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(content_lines),
+            Constraint::Length(content_height),
             Constraint::Length(1), // buttons line
         ])
         .split(inner);
@@ -167,4 +183,24 @@ fn render_buttons(f: &mut Frame, app: &mut App, area: Rect) {
         Paragraph::new(deny_label).style(deny_style),
         deny_area,
     );
+}
+
+/// Estimate how many terminal rows `text` will occupy after wrapping at
+/// `width` columns.  Uses char count (not byte length) for correctness with
+/// multi-byte glyphs, matching ratatui's `Wrap { trim: false }` behaviour.
+fn estimate_wrapped_rows(text: &str, width: usize) -> usize {
+    if width == 0 {
+        return 1;
+    }
+    text.split('\n')
+        .map(|line| {
+            let chars = line.chars().count();
+            if chars == 0 {
+                1
+            } else {
+                chars.div_ceil(width)
+            }
+        })
+        .sum::<usize>()
+        .max(1)
 }

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -1,0 +1,170 @@
+//! Modal confirmation dialog with clickable buttons.
+//!
+//! Rendered as a centered overlay on top of the chat area when the app is in
+//! [`Confirming`](crate::app::AppMode::Confirming) mode.  The modal contains:
+//! - explanation text (if any),
+//! - a destructive warning (if applicable),
+//! - the command with `$ ` prefix,
+//! - two buttons: `[ Approve (a) ]` and `[ Deny (d) ]`.
+//!
+//! The selected button (default: Deny — safe) is highlighted with inverted
+//! colours.  Tab / ← / → toggle the selection; Enter activates it.
+//! Mouse clicks on a button activate it directly; hover moves the selection.
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
+use ratatui::Frame;
+
+use crate::app::App;
+
+/// Render the confirmation modal centered over `area` (typically the chat area).
+///
+/// Stores button rectangles in [`App::confirm_button_areas`] for hit-testing.
+pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
+    // Clear previous button areas (populated during this render).
+    app.confirm_button_areas.clear();
+    app.hovered_button = None;
+
+    let Some(confirm) = &app.pending_confirm else {
+        return;
+    };
+
+    // --- Build content lines (everything except buttons) ---
+    let mut lines: Vec<Line> = Vec::new();
+
+    if !confirm.explanation.is_empty() {
+        lines.push(Line::from(Span::styled(
+            confirm.explanation.as_str(),
+            app.theme.fg_style(),
+        )));
+    }
+
+    if confirm.destructive {
+        lines.push(Line::from(Span::styled(
+            "WARNING: This command may be destructive!",
+            app.theme.danger_fg(),
+        )));
+    }
+
+    lines.push(Line::from(Span::styled(
+        format!("$ {}", confirm.command),
+        app.theme.warning_fg(),
+    )));
+
+    lines.push(Line::from(""));
+
+    let content_lines = lines.len() as u16;
+    // +2 for borders, +1 for buttons line
+    let modal_height = content_lines + 1 + 2;
+    let modal_width = 70u16.min(area.width.saturating_sub(8)).max(30);
+
+    // Center within the area.
+    let modal_x = area.x + (area.width.saturating_sub(modal_width)) / 2;
+    let modal_y = area.y + (area.height.saturating_sub(modal_height)) / 2;
+    let modal_area = Rect::new(modal_x, modal_y, modal_width, modal_height);
+
+    // Clear the area under the modal so chat content doesn't bleed through.
+    f.render_widget(Clear, modal_area);
+
+    // Border colour: danger for destructive, warning otherwise.
+    let border_color = if confirm.destructive {
+        app.theme.danger
+    } else {
+        app.theme.warning
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(Span::styled(
+            " Confirm command ",
+            Style::default()
+                .fg(app.theme.danger)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::default().fg(border_color));
+
+    let inner = block.inner(modal_area);
+    f.render_widget(&block, modal_area);
+
+    // Split inner area: content + buttons.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(content_lines),
+            Constraint::Length(1), // buttons line
+        ])
+        .split(inner);
+
+    // Render content (explanation, warning, command, empty line).
+    let content = Paragraph::new(lines).wrap(Wrap { trim: false });
+    f.render_widget(content, chunks[0]);
+
+    // Render buttons.
+    render_buttons(f, app, chunks[1]);
+}
+
+/// Render the Approve and Deny buttons, storing their areas for hit-testing.
+fn render_buttons(f: &mut Frame, app: &mut App, area: Rect) {
+    let approve_label = "[ Approve (a) ]";
+    let deny_label = "[ Deny (d) ]";
+    let spacing = "   ";
+
+    let approve_len = approve_label.chars().count() as u16;
+    let deny_len = deny_label.chars().count() as u16;
+    let spacing_len = spacing.chars().count() as u16;
+    let total_len = approve_len + spacing_len + deny_len;
+
+    let start_x = area.x + (area.width.saturating_sub(total_len)) / 2;
+
+    let approve_area = Rect::new(start_x, area.y, approve_len, 1);
+    let deny_area = Rect::new(
+        start_x + approve_len + spacing_len,
+        area.y,
+        deny_len,
+        1,
+    );
+
+    // Store for hit-testing.
+    app.confirm_button_areas.push((approve_area, true));
+    app.confirm_button_areas.push((deny_area, false));
+
+    // Styles: selected button gets inverted colours (fg↔bg), unselected gets
+    // surface background with coloured text.
+    let approve_style = if app.confirm_selected {
+        Style::default()
+            .fg(app.theme.surface)
+            .bg(app.theme.success)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(app.theme.success)
+            .bg(app.theme.surface)
+    };
+
+    let deny_style = if !app.confirm_selected {
+        Style::default()
+            .fg(app.theme.surface)
+            .bg(app.theme.danger)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(app.theme.danger)
+            .bg(app.theme.surface)
+    };
+
+    f.render_widget(
+        Paragraph::new(approve_label).style(approve_style),
+        approve_area,
+    );
+    f.render_widget(
+        Paragraph::new(spacing).style(app.theme.muted()),
+        Rect::new(start_x + approve_len, area.y, spacing_len, 1),
+    );
+    f.render_widget(
+        Paragraph::new(deny_label).style(deny_style),
+        deny_area,
+    );
+}

--- a/crates/tui/src/ui/input.rs
+++ b/crates/tui/src/ui/input.rs
@@ -2,7 +2,6 @@
 
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui::Frame;
 
@@ -64,61 +63,20 @@ fn render_thinking(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(paragraph, area);
 }
 
-/// Confirmation dialog for command approval.
+/// Confirmation mode: input panel shows a muted placeholder.
+///
+/// The actual confirmation dialog is rendered as a centered modal overlay
+/// (see [`crate::ui::confirm::render_confirm_modal`]).
 fn render_confirm(f: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .title("Confirm Command")
-        .border_style(
-            Style::default()
-                .fg(app.theme.danger)
-                .add_modifier(Modifier::BOLD),
-        );
+        .title("Input")
+        .border_style(app.theme.muted());
 
-    let mut lines = Vec::new();
-
-    if let Some(confirm) = &app.pending_confirm {
-        if !confirm.explanation.is_empty() {
-            lines.push(Line::from(format!(
-                "  Explanation: {}",
-                confirm.explanation
-            )));
-        }
-        if confirm.destructive {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    "  ! WARNING: ",
-                    app.theme.error_style(),
-                ),
-                Span::styled(
-                    "This command may be destructive!",
-                    app.theme.danger_fg(),
-                ),
-            ]));
-        }
-        lines.push(Line::from(format!("  $ {}", confirm.command)));
-        lines.push(Line::from(""));
-        lines.push(Line::from(vec![
-            Span::styled(
-                " [a]",
-                Style::default()
-                    .fg(app.theme.success)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("pprove  "),
-            Span::styled(
-                "[d]",
-                app.theme.error_style(),
-            ),
-            Span::raw("eny  "),
-            Span::styled("Ctrl+C", app.theme.muted()),
-            Span::raw(" to quit"),
-        ]));
-    }
-
-    let paragraph = Paragraph::new(lines)
+    let text = "waiting for confirmation…";
+    let paragraph = Paragraph::new(text)
         .block(block)
-        .wrap(Wrap { trim: false });
+        .style(app.theme.muted());
     f.render_widget(paragraph, area);
 }
 

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -20,6 +20,7 @@
 
 mod bars;
 mod chat;
+mod confirm;
 mod input;
 pub mod layout_cache;
 mod text;
@@ -55,6 +56,11 @@ pub fn render(f: &mut Frame, app: &mut App) {
     chat::render_chat_history(f, app, chunks[1]);
     input::render_input_area(f, app, chunks[2]);
     bars::render_help_bar(f, app, chunks[3]);
+
+    // Render confirmation modal on top of chat if in Confirming mode.
+    if app.mode == AppMode::Confirming {
+        confirm::render_confirm_modal(f, app, app.chat_area);
+    }
 }
 
 /// Render the interactive terminal mode.


### PR DESCRIPTION
## Summary

Implement issue #17: modal confirmation dialog with clickable buttons.

### Changes

- **New `ui/confirm.rs` module**: centered modal overlay with `Clear` underneath, `BorderType::Rounded` borders (danger for destructive, warning otherwise). Contains explanation, command with `$ ` prefix, and `[ Approve (a) ]` / `[ Deny (d) ]` buttons with 3-space gap.
- **`app.rs`**: new fields `confirm_selected` (bool, default `false` = Deny — safe) and `hovered_button` (Option<bool>). Keyboard: `Tab`/`←`/`→` toggle selection, `Enter` activates selected (was unconditional approve — **safe default change** per DESIGN_PHILOSOPHY §6). Mouse: click on button → `respond_to_confirmation`, `Moved` → hover tracking. `hit_test`: confirm buttons checked first (modal overlays everything). `confirm_selected` resets to Deny on each new `ConfirmationRequest`.
- **`ui/input.rs`**: `render_confirm` now shows muted `waiting for confirmation…` — layout doesn't jump.
- **`ui/bars.rs`**: help bar for Confirming mode updated: `Tab=Switch | Enter=Confirm | a/y=Approve | d/n=Deny | Ctrl+C=Quit`.
- **`ui/mod.rs`**: `mod confirm;`, modal rendered after all zones if `mode == Confirming`.

### Button styling

- Selected button: inverted colours (fg=surface, bg=success/danger) + bold.
- Unselected button: `surface` background, success/danger text.

### Tests

16 new tests (81 total): confirm_selected defaults, Tab/Left/Right toggle, Enter activates selected (default deny, after tab approve), letter hotkeys (a/d, Russian ф/в), Ctrl+C denies+quits, confirm_selected resets on new request, mouse click Approve/Deny, mouse hover updates selected, hit_test confirm button overrides chat.

### Out of scope

- ASCII fallback for `⚠` glyph (Glyphs struct not yet implemented — principle 7 of DESIGN_PHILOSOPHY)
- Text selection via mouse drag (reserved as `DragKind::Selection`)

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation prompts now render as a centered modal with **Approve** / **Deny** buttons.
  * You can switch the selection via **Tab**, **Left/Right**, or by hovering/clicking.
  * **Enter** activates the currently selected option (**Deny** is the default).
* **Bug Fixes**
  * Confirmation button hit-testing now correctly prioritizes the modal over the chat area.
  * Modal UI state is cleared after a decision to prevent stale interactions in subsequent prompts.
* **Documentation**
  * Help bar text updated to reflect the confirmation shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->