### PR TITLE
feat(tui): collapsible command blocks with click-to-expand (#18)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -757,3 +757,14 @@ PR: #28
   `ChatLayoutCache::rebuild()` теперь получает реальные collapsed-данные.
   Заголовок Command блока изменился: `> Command [ok]` → `▾ $ command  ✓`.
   `strip_emoji` whitelist расширен диапазоном 0x2713–0x2717.
+- **Review fixes (CodeRabbit PR #29):**
+  - Truncation marker `… truncated (N more lines)` changed from `OutputToggle`
+    to `Output` region — it's informational, not clickable. Only `▾ collapse`
+    remains as the toggle.
+  - Stale doc comment on `rebuild()` updated: `collapsed` is now populated
+    by `app.collapsed_set()`, not "reserved for task 6".
+  - Extracted `default_collapsed_for()` helper to deduplicate the `> 6 lines`
+    threshold between `collapsed_set()` and `toggle_collapse()`.
+  - Added 4 mouse click routing tests: OutputToggle click toggles, Header click
+    toggles (with output), Header click no-op (without output), Body click
+    no-op. Total: 96 tui tests.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -717,3 +717,43 @@ PR: #28
     count so `Constraint::Length` doesn't clip long text. Min width 30 → 32.
   - Fixed title color: hardcoded `danger` → `border_color` (warning for
     non-destructive commands).
+
+### Issue #18: Сворачиваемые блоки команд по клику (task 6)
+
+**Ветка:** `feat/18-collapsible-command-blocks`
+
+**Что сделано:**
+- Заменён жёсткий лимит 30 строк на collapse/expand: по умолчанию блоки с
+  выводом > 6 строк свёрнуты до 5 строк + строка-переключатель
+  `▸ … N more lines — click to expand`. Развёрнутые длинные блоки показывают
+  `▾ collapse`. Страховочный потолок: 400 строк (`… truncated`).
+- Компактный заголовок команды: `▸ $ command  ✓` (свёрнут) /
+  `▾ $ command  ✓` (развёрнут). `✓` = success, `✗` = danger для denied.
+  Если вывода нет (`output: None`) — стрелка не показывается.
+  Команда перенесена из отдельной output-строки в заголовок.
+- `collapsed_overrides: HashMap<usize, bool>` в `App` — пользовательские
+  переопределения. Блоки не в map используют дефолт (> 6 строк → свёрнут).
+- Клик по строке `OutputToggle` или по заголовку `Command` (с output)
+  переключает collapse/expand. `message_rev` инкрементируется → кэш
+  перестраивается.
+- `collapsed_set()` в `App` вычисляет множество свёрнутых индексов из
+  overrides + дефолтов, передаётся в `layout_cache.rebuild()`.
+- `strip_emoji`: добавлен диапазон 0x2713–0x2717 (Dingbats: ✓ ✗).
+
+**Файлы:**
+- `crates/tui/src/app.rs` — `collapsed_overrides`, `collapsed_set()`,
+  `toggle_collapse()`, handle_mouse Chat zone (OutputToggle + Header click)
+- `crates/tui/src/ui/layout_cache.rs` — новый заголовок, collapse/expand логика,
+  400-строк потолок
+- `crates/tui/src/ui/chat.rs` — передаёт `app.collapsed_set()` вместо `HashSet::new()`
+- `crates/tui/src/ui/text.rs` — whitelist 0x2713–0x2717
+
+**Тесты:** 10 новых (92 tui total): collapsed_set defaults/overrides (4),
+  toggle collapse (2), layout_cache collapsed shows 5 lines + expand toggle,
+  expanded shows collapse toggle, short output no toggle, header arrow+status,
+  no-output no arrow.
+
+**Публичные контракты:** `App` получил `collapsed_overrides: HashMap<usize, bool>`.
+  `ChatLayoutCache::rebuild()` теперь получает реальные collapsed-данные.
+  Заголовок Command блока изменился: `> Command [ok]` → `▾ $ command  ✓`.
+  `strip_emoji` whitelist расширен диапазоном 0x2713–0x2717.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -824,24 +824,25 @@ impl App {
         }
     }
 
+    /// Compute the default collapse state for a chat block.
+    /// A Command block is collapsed by default if its output has more than 6 lines.
+    fn default_collapsed_for(msg: &ChatBlock) -> bool {
+        matches!(msg, ChatBlock::Command { output: Some(out), .. } if out.lines().count() > 6)
+    }
+
     /// Compute the set of collapsed block indices from `collapsed_overrides`
-    /// and defaults.  A Command block is collapsed by default if its output
-    /// has more than 6 lines; `collapsed_overrides` can force either state.
+    /// and defaults.  `collapsed_overrides` can force either state.
     pub fn collapsed_set(&self) -> HashSet<usize> {
         self.messages
             .iter()
             .enumerate()
-            .filter_map(|(idx, msg)| match msg {
-                ChatBlock::Command { output: Some(out), .. } => {
-                    let line_count = out.lines().count();
-                    let is_collapsed = self
-                        .collapsed_overrides
-                        .get(&idx)
-                        .copied()
-                        .unwrap_or(line_count > 6);
-                    if is_collapsed { Some(idx) } else { None }
-                }
-                _ => None,
+            .filter_map(|(idx, msg)| {
+                let is_collapsed = self
+                    .collapsed_overrides
+                    .get(&idx)
+                    .copied()
+                    .unwrap_or_else(|| Self::default_collapsed_for(msg));
+                if is_collapsed { Some(idx) } else { None }
             })
             .collect()
     }
@@ -854,13 +855,9 @@ impl App {
             .get(&block_idx)
             .copied()
             .unwrap_or_else(|| {
-                if let Some(ChatBlock::Command { output: Some(out), .. }) =
-                    self.messages.get(block_idx)
-                {
-                    out.lines().count() > 6
-                } else {
-                    false
-                }
+                self.messages
+                    .get(block_idx)
+                    .is_some_and(Self::default_collapsed_for)
             });
         self.collapsed_overrides.insert(block_idx, !is_collapsed);
         self.message_rev = self.message_rev.wrapping_add(1);
@@ -2038,5 +2035,116 @@ mod tests {
         assert!(!app.collapsed_set().contains(&0));
         app.collapsed_overrides.insert(0, true);
         assert!(app.collapsed_set().contains(&0));
+    }
+
+    // ---- Mouse click routing tests (issue #18 review) ----
+
+    #[test]
+    fn mouse_click_output_toggle_toggles_collapse() {
+        let mut app = make_command_app(50);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = vec![
+            crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("header"),
+                block_index: Some(0),
+                region: crate::ui::layout_cache::LineRegion::Header,
+            },
+            crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("toggle"),
+                block_index: Some(0),
+                region: crate::ui::layout_cache::LineRegion::OutputToggle,
+            },
+        ];
+        // Click the OutputToggle line (row 3 → line_idx 1).
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            5,
+            3,
+        ));
+        assert!(
+            app.collapsed_overrides.contains_key(&0),
+            "OutputToggle click should toggle collapse"
+        );
+    }
+
+    #[test]
+    fn mouse_click_command_header_with_output_toggles_collapse() {
+        let mut app = make_command_app(50);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = vec![
+            crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("header"),
+                block_index: Some(0),
+                region: crate::ui::layout_cache::LineRegion::Header,
+            },
+        ];
+        // Click the Header line (row 2 → line_idx 0).
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            5,
+            2,
+        ));
+        assert!(
+            app.collapsed_overrides.contains_key(&0),
+            "Header click should toggle collapse for Command with output"
+        );
+    }
+
+    #[test]
+    fn mouse_click_command_header_without_output_no_toggle() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.messages.clear();
+        app.messages.push(ChatBlock::Command {
+            command: "pending".into(),
+            explanation: "".into(),
+            output: None,
+            approved: false,
+        });
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = vec![
+            crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("header"),
+                block_index: Some(0),
+                region: crate::ui::layout_cache::LineRegion::Header,
+            },
+        ];
+        // Click the Header line — should NOT toggle (no output).
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            5,
+            2,
+        ));
+        assert!(
+            !app.collapsed_overrides.contains_key(&0),
+            "Header click should not toggle for Command without output"
+        );
+    }
+
+    #[test]
+    fn mouse_click_body_does_not_toggle_collapse() {
+        let mut app = make_command_app(50);
+        app.chat_area = Rect::new(0, 1, 80, 24);
+        app.layout_cache.lines = vec![
+            crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("header"),
+                block_index: Some(0),
+                region: crate::ui::layout_cache::LineRegion::Header,
+            },
+            crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("body"),
+                block_index: Some(0),
+                region: crate::ui::layout_cache::LineRegion::Body,
+            },
+        ];
+        // Click the Body line (row 3 → line_idx 1).
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            5,
+            3,
+        ));
+        assert!(
+            !app.collapsed_overrides.contains_key(&0),
+            "Body click should not toggle collapse"
+        );
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -13,7 +13,7 @@ use crate::terminal::{key_to_bytes, TerminalModel};
 use crate::ui::layout_cache::ChatLayoutCache;
 use crate::ui::Theme;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 // ---------------------------------------------------------------------------
@@ -158,6 +158,9 @@ pub struct App {
     pub confirm_selected: bool,
     /// Button under mouse cursor during hover (`Some(true)` = Approve, `Some(false)` = Deny).
     pub hovered_button: Option<bool>,
+    /// User-set collapse overrides: block index → is_collapsed.
+    /// Blocks not in this map use the default (collapsed if output > 6 lines).
+    pub collapsed_overrides: HashMap<usize, bool>,
 }
 
 impl App {
@@ -199,6 +202,7 @@ impl App {
             help_bar_area: Rect::default(),
             confirm_selected: false,
             hovered_button: None,
+            collapsed_overrides: HashMap::new(),
         }
     }
 
@@ -616,6 +620,30 @@ impl App {
                 HitZone::ConfirmButton(approve) => {
                     self.respond_to_confirmation(approve);
                 }
+                HitZone::Chat { line_idx } => {
+                    // Click on OutputToggle or Command header → toggle collapse.
+                    if let Some(rl) = self.layout_cache.lines.get(line_idx) {
+                        match rl.region {
+                            crate::ui::layout_cache::LineRegion::OutputToggle => {
+                                if let Some(block_idx) = rl.block_index {
+                                    self.toggle_collapse(block_idx);
+                                }
+                            }
+                            crate::ui::layout_cache::LineRegion::Header => {
+                                if let Some(block_idx) = rl.block_index {
+                                    // Only toggle for Command blocks with output.
+                                    if matches!(
+                                        self.messages.get(block_idx),
+                                        Some(ChatBlock::Command { output: Some(_), .. })
+                                    ) {
+                                        self.toggle_collapse(block_idx);
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 _ => {}
             },
             // --- Drag ---
@@ -794,6 +822,48 @@ impl App {
             self.confirm_button_areas.clear();
             self.hovered_button = None;
         }
+    }
+
+    /// Compute the set of collapsed block indices from `collapsed_overrides`
+    /// and defaults.  A Command block is collapsed by default if its output
+    /// has more than 6 lines; `collapsed_overrides` can force either state.
+    pub fn collapsed_set(&self) -> HashSet<usize> {
+        self.messages
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, msg)| match msg {
+                ChatBlock::Command { output: Some(out), .. } => {
+                    let line_count = out.lines().count();
+                    let is_collapsed = self
+                        .collapsed_overrides
+                        .get(&idx)
+                        .copied()
+                        .unwrap_or(line_count > 6);
+                    if is_collapsed { Some(idx) } else { None }
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Toggle the collapse state of a command block.
+    /// Bumps `message_rev` so the layout cache rebuilds.
+    fn toggle_collapse(&mut self, block_idx: usize) {
+        let is_collapsed = self
+            .collapsed_overrides
+            .get(&block_idx)
+            .copied()
+            .unwrap_or_else(|| {
+                if let Some(ChatBlock::Command { output: Some(out), .. }) =
+                    self.messages.get(block_idx)
+                {
+                    out.lines().count() > 6
+                } else {
+                    false
+                }
+            });
+        self.collapsed_overrides.insert(block_idx, !is_collapsed);
+        self.message_rev = self.message_rev.wrapping_add(1);
     }
 
     /// Handle an agent event.
@@ -1903,5 +1973,70 @@ mod tests {
             !matches!(zone, HitZone::ConfirmButton(_)),
             "stale button area should not swallow clicks after modal closes"
         );
+    }
+
+    // ---- Collapse / expand tests (issue #18) ----
+
+    fn make_command_app(output_lines: usize) -> App {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.messages.clear();
+        let output = (0..output_lines)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        app.messages.push(ChatBlock::Command {
+            command: "test".into(),
+            explanation: "".into(),
+            output: Some(output),
+            approved: true,
+        });
+        app
+    }
+
+    #[test]
+    fn collapsed_set_defaults_long_output_collapsed() {
+        let app = make_command_app(50);
+        let collapsed = app.collapsed_set();
+        assert!(collapsed.contains(&0), "50-line output should be collapsed by default");
+    }
+
+    #[test]
+    fn collapsed_set_defaults_short_output_not_collapsed() {
+        let app = make_command_app(3);
+        let collapsed = app.collapsed_set();
+        assert!(!collapsed.contains(&0), "3-line output should not be collapsed by default");
+    }
+
+    #[test]
+    fn collapsed_set_respects_expand_override() {
+        let mut app = make_command_app(50);
+        app.collapsed_overrides.insert(0, false);
+        let collapsed = app.collapsed_set();
+        assert!(!collapsed.contains(&0), "override=false should expand even long output");
+    }
+
+    #[test]
+    fn collapsed_set_respects_collapse_override() {
+        let mut app = make_command_app(3);
+        app.collapsed_overrides.insert(0, true);
+        let collapsed = app.collapsed_set();
+        assert!(collapsed.contains(&0), "override=true should collapse even short output");
+    }
+
+    #[test]
+    fn toggle_collapse_from_default_collapsed_to_expanded() {
+        let mut app = make_command_app(50);
+        assert!(app.collapsed_set().contains(&0));
+        // Simulate toggle via the private method's logic.
+        app.collapsed_overrides.insert(0, false);
+        assert!(!app.collapsed_set().contains(&0));
+    }
+
+    #[test]
+    fn toggle_collapse_from_default_expanded_to_collapsed() {
+        let mut app = make_command_app(3);
+        assert!(!app.collapsed_set().contains(&0));
+        app.collapsed_overrides.insert(0, true);
+        assert!(app.collapsed_set().contains(&0));
     }
 }

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -1,7 +1,5 @@
 //! Chat history rendering.
 
-use std::collections::HashSet;
-
 use ratatui::layout::Rect;
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
@@ -26,11 +24,12 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
         .layout_cache
         .needs_rebuild(&app.messages, inner_width, app.message_rev)
     {
+        let collapsed = app.collapsed_set();
         app.layout_cache.rebuild(
             &app.messages,
             inner_width,
             &app.theme,
-            &HashSet::new(), // no collapsed blocks yet (task 6)
+            &collapsed,
             app.message_rev,
         );
     }

--- a/crates/tui/src/ui/layout_cache.rs
+++ b/crates/tui/src/ui/layout_cache.rs
@@ -91,8 +91,8 @@ impl ChatLayoutCache {
 
     /// Rebuild the cache from scratch.
     ///
-    /// `collapsed` contains indices of blocks whose output is collapsed
-    /// (reserved for task 6 — currently always empty).
+    /// `collapsed` contains indices of blocks whose output is collapsed,
+    /// computed by `App::collapsed_set()` from user overrides and defaults.
     pub fn rebuild(
         &mut self,
         messages: &[ChatBlock],
@@ -208,7 +208,7 @@ impl ChatLayoutCache {
                             }
                             if total > MAX_EXPANDED_LINES {
                                 let remaining = total - MAX_EXPANDED_LINES;
-                                self.push_output_toggle(
+                                self.push_output(
                                     idx,
                                     format!(
                                         "  … truncated ({} more lines)",

--- a/crates/tui/src/ui/layout_cache.rs
+++ b/crates/tui/src/ui/layout_cache.rs
@@ -145,40 +145,83 @@ impl ChatLayoutCache {
                     output,
                     approved,
                 } => {
+                    let is_collapsed = collapsed.contains(&idx);
+
+                    // Status glyph: ✓ for approved, ✗ for denied.
                     let status = if *approved {
-                        Span::styled(" [ok] ", theme.success_fg())
+                        Span::styled("  ✓", theme.success_fg())
                     } else {
-                        Span::styled(" [no] ", theme.danger_fg())
+                        Span::styled("  ✗", theme.danger_fg())
                     };
 
+                    // Arrow indicator: ▸ collapsed, ▾ expanded, spaces if no output.
+                    let arrow = if output.is_some() {
+                        if is_collapsed { "▸ " } else { "▾ " }
+                    } else {
+                        "  "
+                    };
+
+                    // Compact header: `▸ $ command  ✓` / `▾ $ command  ✓`
                     self.push_header(idx, vec![
-                        Span::styled("> ", theme.warning_fg()),
-                        Span::styled("Command", theme.command_style()),
+                        Span::styled(arrow, theme.warning_fg()),
+                        Span::styled("$ ", theme.warning_fg()),
+                        Span::styled(command.clone(), theme.command_style()),
                         status,
                     ]);
 
+                    // Explanation (if any) — shown in both states.
                     if !explanation.is_empty() {
                         for wrapped in wrap_text(&strip_emoji(explanation), output_width) {
                             self.push_output(idx, format!("  | {wrapped}"));
                         }
                     }
-                    for wrapped in wrap_text(&format!("$ {command}"), output_width) {
-                        self.push_output(idx, format!("  | {wrapped}"));
-                    }
 
+                    // Output rendering with collapse/expand.
                     if let Some(out) = output {
-                        for (count, line) in out.lines().enumerate() {
-                            if count >= 30 {
-                                let remaining =
-                                    out.lines().count().saturating_sub(30);
+                        let all_lines: Vec<&str> = out.lines().collect();
+                        let total = all_lines.len();
+
+                        if is_collapsed {
+                            // Collapsed: show first 5 lines + toggle.
+                            for line in all_lines.iter().take(5) {
+                                for wrapped in wrap_text(line, output_width) {
+                                    self.push_output(idx, format!("  | {wrapped}"));
+                                }
+                            }
+                            if total > 5 {
+                                let remaining = total - 5;
                                 self.push_output_toggle(
                                     idx,
-                                    format!("  | ... ({} more lines)", remaining),
+                                    format!(
+                                        "  ▸ … {} more lines — click to expand",
+                                        remaining
+                                    ),
                                 );
-                                break;
                             }
-                            for wrapped in wrap_text(line, output_width) {
-                                self.push_output(idx, format!("  | {wrapped}"));
+                        } else {
+                            // Expanded: show up to 400 lines (safety ceiling).
+                            const MAX_EXPANDED_LINES: usize = 400;
+                            for line in all_lines.iter().take(MAX_EXPANDED_LINES) {
+                                for wrapped in wrap_text(line, output_width) {
+                                    self.push_output(idx, format!("  | {wrapped}"));
+                                }
+                            }
+                            if total > MAX_EXPANDED_LINES {
+                                let remaining = total - MAX_EXPANDED_LINES;
+                                self.push_output_toggle(
+                                    idx,
+                                    format!(
+                                        "  … truncated ({} more lines)",
+                                        remaining
+                                    ),
+                                );
+                            }
+                            // Collapse toggle for long output.
+                            if total > 5 {
+                                self.push_output_toggle(
+                                    idx,
+                                    "  ▾ collapse".to_string(),
+                                );
                             }
                         }
                     }
@@ -367,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn command_block_produces_output_and_toggle_regions() {
+    fn command_block_expanded_shows_collapse_toggle() {
         let theme = Theme::default_dark();
         let collapsed = HashSet::new();
         let mut cache = ChatLayoutCache::new();
@@ -381,10 +424,121 @@ mod tests {
         }];
         cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
 
-        // Should have: Header, Output (expl), Output ($ test), Output x30, OutputToggle, Spacer
+        // Expanded: Header, Output (expl), Output x50, OutputToggle (▾ collapse), Spacer.
         let has_toggle = cache.lines.iter().any(|l| l.region == LineRegion::OutputToggle);
-        assert!(has_toggle, "expected an OutputToggle line for truncated output");
+        assert!(has_toggle, "expected a ▾ collapse toggle for expanded long output");
         let has_output = cache.lines.iter().any(|l| l.region == LineRegion::Output);
         assert!(has_output, "expected Output lines");
+
+        // The toggle text should say "collapse", not "more lines".
+        let toggle = cache.lines.iter().find(|l| l.region == LineRegion::OutputToggle).unwrap();
+        let toggle_text = format!("{}", toggle.line);
+        assert!(toggle_text.contains("collapse"), "toggle should say collapse, got: {toggle_text}");
+    }
+
+    #[test]
+    fn command_block_collapsed_shows_5_lines_and_expand_toggle() {
+        let theme = Theme::default_dark();
+        let mut collapsed = HashSet::new();
+        collapsed.insert(0);
+        let mut cache = ChatLayoutCache::new();
+
+        let long_output = (0..50).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+        let msgs = vec![ChatBlock::Command {
+            command: "test".into(),
+            explanation: "".into(),
+            output: Some(long_output),
+            approved: true,
+        }];
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+
+        // Collapsed: Header, Output x5, OutputToggle (▸ … 45 more lines), Spacer.
+        let output_count = cache.lines.iter().filter(|l| l.region == LineRegion::Output).count();
+        assert_eq!(output_count, 5, "collapsed block should show exactly 5 output lines");
+
+        let toggle = cache.lines.iter().find(|l| l.region == LineRegion::OutputToggle);
+        assert!(toggle.is_some(), "collapsed block should have a toggle line");
+        let toggle_text = format!("{}", toggle.unwrap().line);
+        assert!(toggle_text.contains("more lines"), "toggle should mention more lines, got: {toggle_text}");
+        assert!(toggle_text.contains("45"), "toggle should say 45 more lines, got: {toggle_text}");
+    }
+
+    #[test]
+    fn command_block_short_output_has_no_toggle() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+
+        let short_output = "line 1\nline 2\nline 3";
+        let msgs = vec![ChatBlock::Command {
+            command: "echo".into(),
+            explanation: "".into(),
+            output: Some(short_output.into()),
+            approved: true,
+        }];
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+
+        // Short output: Header, Output x3, Spacer — no toggle.
+        let has_toggle = cache.lines.iter().any(|l| l.region == LineRegion::OutputToggle);
+        assert!(!has_toggle, "short output should not have a toggle line");
+    }
+
+    #[test]
+    fn command_block_header_has_arrow_and_status() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+
+        let msgs = vec![
+            ChatBlock::Command {
+                command: "ls".into(),
+                explanation: "".into(),
+                output: Some("file1\nfile2".into()),
+                approved: true,
+            },
+            ChatBlock::Command {
+                command: "rm".into(),
+                explanation: "".into(),
+                output: Some("".into()),
+                approved: false,
+            },
+        ];
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+
+        // First header: expanded arrow (▾), $ ls, ✓.
+        let header0 = &cache.lines[0];
+        assert_eq!(header0.region, LineRegion::Header);
+        let header0_text = format!("{}", header0.line);
+        assert!(header0_text.contains('▾'), "expanded header should have ▾, got: {header0_text}");
+        assert!(header0_text.contains("ls"), "header should contain command, got: {header0_text}");
+        assert!(header0_text.contains('✓'), "approved header should have ✓, got: {header0_text}");
+
+        // Find the second header (skip first block's lines + spacer).
+        let header1 = cache.lines.iter().find(|l| {
+            l.region == LineRegion::Header && l.block_index == Some(1)
+        }).unwrap();
+        let header1_text = format!("{}", header1.line);
+        assert!(header1_text.contains('✗'), "denied header should have ✗, got: {header1_text}");
+        assert!(header1_text.contains("rm"), "header should contain command, got: {header1_text}");
+    }
+
+    #[test]
+    fn command_block_no_output_has_no_arrow() {
+        let theme = Theme::default_dark();
+        let collapsed = HashSet::new();
+        let mut cache = ChatLayoutCache::new();
+
+        let msgs = vec![ChatBlock::Command {
+            command: "pending".into(),
+            explanation: "".into(),
+            output: None,
+            approved: false,
+        }];
+        cache.rebuild(&msgs, 80, &theme, &collapsed, 1);
+
+        let header = &cache.lines[0];
+        let header_text = format!("{}", header.line);
+        assert!(!header_text.contains('▸') && !header_text.contains('▾'),
+            "no-output block should not have arrow, got: {header_text}");
     }
 }

--- a/crates/tui/src/ui/text.rs
+++ b/crates/tui/src/ui/text.rs
@@ -19,7 +19,8 @@ pub(crate) fn strip_emoji(s: &str) -> String {
             || (0x2200..=0x22FF).contains(&cp)  // Math operators (≠ ≤ ≥ ±)
             || (0x2500..=0x257F).contains(&cp)  // Box drawing (┃ │ ┌ └)
             || (0x2580..=0x259F).contains(&cp)  // Block elements
-            || (0x25A0..=0x25FF).contains(&cp)  // Geometric shapes (▶ ◆ ● ■)
+            || (0x25A0..=0x25FF).contains(&cp)  // Geometric shapes (▶ ◆ ● ■ ▸ ▾)
+            || (0x2713..=0x2717).contains(&cp)  // Dingbats: ✓ ✗ (command status)
             // Everything else (Misc symbols, Dingbats, Emojis, Flags) is stripped
         })
         .collect()


### PR DESCRIPTION
Closes #18

## Summary

Replace the 30-line hard truncation with interactive collapse/expand for command blocks:

- **Default collapse:** Command blocks with output > 6 lines are collapsed to 5 lines + a toggle line `▸ … N more lines — click to expand`
- **Expanded state:** Shows all output (up to 400-line safety ceiling with `… truncated`) + `▾ collapse` toggle
- **Click to toggle:** Click on the `OutputToggle` line OR the command header to collapse/expand
- **Compact header:** `▸ $ command  ✓` (collapsed) / `▾ $ command  ✓` (expanded). `✓` = approved, `✗` = denied. No arrow when there's no output.
- **State persistence:** `collapsed_overrides: HashMap<usize, bool>` preserves user toggle state across scroll and new messages (indices don't shift)
- **strip_emoji whitelist:** Added 0x2713–0x2717 (Dingbats: ✓ ✗)

## Files changed

- `crates/tui/src/app.rs` — `collapsed_overrides` field, `collapsed_set()`, `toggle_collapse()`, mouse click handling for OutputToggle + Header
- `crates/tui/src/ui/layout_cache.rs` — New header format, collapse/expand logic, 400-line ceiling
- `crates/tui/src/ui/chat.rs` — Pass `app.collapsed_set()` instead of `HashSet::new()`
- `crates/tui/src/ui/text.rs` — Whitelist 0x2713–0x2717

## Tests

- 10 new tests (92 tui total): collapsed_set defaults/overrides, toggle collapse, layout_cache collapsed/expanded/short/no-output, header arrow+status
- `cargo build --workspace` ✅
- `cargo clippy -p filar-tui --no-deps` ✅
- `cargo test -p filar-tui` ✅ (92 passed, 0 failed)
- `#[ignore]` tests (docker-sshd) not run — require manual verification

## Out of scope

- conhost ASCII fallback for ✓/✗ glyphs (Glyphs struct — future task)
- Visual redesign of chat layout (issue #20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Command output blocks in the TUI can now be collapsed/expanded per command, with clickable toggles in both the command header and output area.
  - Long outputs default to a compact preview and can be expanded for full viewing, with very large outputs safely capped.

- **Bug Fixes**
  - Improved command status display with clearer approval/denial icons and collapse/expand indicators.
  - Emoji/symbol handling now preserves checkmark and cross symbols instead of stripping them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->