### PR TITLE
feat(tui): mouse support in interactive terminal mode (#22)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -984,3 +984,68 @@ PR: #28
 - `DragKind::Selection` — новый вариант.
 - `App`: новые поля `selection: Option<Selection>`, `toast: Option<(String, Instant)>`.
 - `App::toast_text()` — новый public метод.
+
+---
+
+## Issue #22: Мышь в интерактивном режиме терминала
+
+**Задача:** Скролл истории терминала колесом и проброс мыши в приложения
+(vim, htop, mc) в режиме Interactive (Ctrl+T).
+
+### Что сделано
+
+1. **TerminalModel API** (`crates/tui/src/terminal.rs`):
+   - `scroll_display(delta: i32)` — скролл scrollback-истории через
+     `term.scroll_display(Scroll::Delta(delta))`.
+   - `scroll_to_bottom()` — сброс скролла в низ через `Scroll::Bottom`.
+   - `mouse_mode() -> bool` — проверка `TermMode::MOUSE_MODE | SGR_MOUSE`
+     (REPORT_CLICK / DRAG / MOTION + SGR).
+   - `is_alt_screen() -> bool` — проверка `TermMode::ALT_SCREEN`.
+   - Импорт `Scroll` из `alacritty_terminal::grid`.
+
+2. **handle_interactive_mouse** (`crates/tui/src/app.rs`):
+   - Если `mouse_mode() == true`: кодирование события в SGR-последовательность
+     (`\x1b[<{button};{x};{y}M/m`, координаты 1-based относительно области
+     терминала) и отправка в `pending_term_input`.
+   - Иначе в alt-screen: колесо → стрелки `↑↑↑`/`↓↓↓` (по 3 на тик) —
+     стандартное поведение для `less`/`man`.
+   - Иначе (primary screen): колесо → `scroll_display(±3)`.
+   - События вне `terminal_area` игнорируются.
+
+3. **SGR mouse encoding** (`encode_sgr_mouse`):
+   - Поддержка: Left/Right/Middle click, release (M/m), drag (32+button),
+     motion (35), scroll (64/65).
+   - Модификаторы: Shift(4), Alt(8), Ctrl(16).
+
+4. **Сброс скролла при вводе** — клавиатурный ввод в Interactive вызывает
+   `scroll_to_bottom()` перед отправкой байтов.
+
+5. **terminal_area** — новое поле `App`, заполняется в `render_interactive`
+   для hit-testing мышью.
+
+6. **Help-bar** — добавлен `wheel scroll` в Interactive mode.
+
+### Изменённые файлы
+
+- `crates/tui/src/terminal.rs` — `scroll_display`, `scroll_to_bottom`,
+  `mouse_mode`, `is_alt_screen`, импорт `Scroll`
+- `crates/tui/src/app.rs` — `handle_interactive_mouse`, `encode_sgr_mouse`,
+  `push_term_input`, поле `terminal_area`, сброс скролла при keyboard input,
+  19 новых тестов
+- `crates/tui/src/ui/mod.rs` — сохранение `terminal_area` в `render_interactive`
+- `crates/tui/src/ui/bars.rs` — `wheel scroll` в Interactive help-bar
+
+**Тесты:** 19 новых: scroll up/down (primary), alt-screen arrow translation,
+  mouse outside area, SGR encoding (click/release/scroll/modifiers/right/
+  middle drag/motion), mouse_mode default/enabled, alt_screen default/enabled,
+  scroll_display, scroll_to_bottom, push_term_input (append/new).
+
+**Публичные контракты:**
+- `TerminalModel::scroll_display(i32)`, `scroll_to_bottom()`,
+  `mouse_mode() -> bool`, `is_alt_screen() -> bool` — новые public методы.
+- `App::terminal_area: Rect` — новое public поле.
+
+**DoD (требует ручной проверки):**
+- Колесо скроллит историю в интерактивном режиме.
+- В `htop`/`mc` по SSH клики и колесо доходят до приложения.
+- В `less` колесо листает (трансляция в стрелки).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -896,12 +896,22 @@ impl App {
         let y = (m.row - area.y + 1) as usize;
 
         let mouse_mode = self.terminal.as_ref().is_some_and(|t| t.mouse_mode());
+        let sgr_mouse = self.terminal.as_ref().is_some_and(|t| t.sgr_mouse());
         let alt_screen = self.terminal.as_ref().is_some_and(|t| t.is_alt_screen());
 
         if mouse_mode {
-            // Forward mouse events as SGR sequences to the terminal.
-            if let Some(seq) = encode_sgr_mouse(&m, x, y) {
-                self.push_term_input(&seq);
+            // Forward mouse events to the terminal.
+            if sgr_mouse {
+                // SGR encoding: \x1b[<{button};{x};{y}M/m
+                if let Some(seq) = encode_sgr_mouse(&m, x, y) {
+                    self.push_term_input(&seq);
+                }
+            } else {
+                // Legacy encoding: \x1b[M followed by 3 bytes (button+32, x+32, y+32).
+                // Coordinates are clamped to 255 (max for legacy format).
+                if let Some(seq) = encode_legacy_mouse(&m, x, y) {
+                    self.push_term_input(&seq);
+                }
             }
             return;
         }
@@ -1721,6 +1731,50 @@ fn encode_sgr_mouse(m: &crossterm::event::MouseEvent, x: usize, y: usize) -> Opt
     let suffix = if is_release { b'm' } else { b'M' };
     Some(format!("\x1b[<{code};{x};{y}").into_bytes())
         .map(|mut v| { v.push(suffix); v })
+}
+
+/// Encode a crossterm mouse event using the legacy (pre-SGR) encoding.
+///
+/// Format: `\x1b[M` followed by 3 bytes: `(button_code + 32)`,
+/// `(x + 32)`, `(y + 32)`.  Coordinates are 1-based and clamped to 255.
+///
+/// Returns `None` for event types that don't have a standard encoding.
+fn encode_legacy_mouse(m: &crossterm::event::MouseEvent, x: usize, y: usize) -> Option<Vec<u8>> {
+    use crossterm::event::{MouseButton, MouseEventKind, KeyModifiers};
+
+    // Base button code (same as SGR for the low bits).
+    let button = match m.kind {
+        MouseEventKind::Down(MouseButton::Left) => 0,
+        MouseEventKind::Down(MouseButton::Right) => 2,
+        MouseEventKind::Down(MouseButton::Middle) => 1,
+        MouseEventKind::Up(_) => 3, // Release is button 3 in legacy mode.
+        MouseEventKind::Drag(MouseButton::Left) => 32,
+        MouseEventKind::Drag(MouseButton::Right) => 34,
+        MouseEventKind::Drag(MouseButton::Middle) => 33,
+        MouseEventKind::Moved => 35,
+        MouseEventKind::ScrollUp => 64,
+        MouseEventKind::ScrollDown => 65,
+        _ => return None,
+    };
+
+    // Add modifier flags.
+    let mut code = button;
+    if m.modifiers.contains(KeyModifiers::SHIFT) {
+        code |= 4;
+    }
+    if m.modifiers.contains(KeyModifiers::ALT) {
+        code |= 8;
+    }
+    if m.modifiers.contains(KeyModifiers::CONTROL) {
+        code |= 16;
+    }
+
+    // Clamp coordinates to legacy max (255 - 32 = 223 usable).
+    let bx = (code + 32).min(255) as u8;
+    let sx = ((x - 1) + 32).min(255) as u8;
+    let sy = ((y - 1) + 32).min(255) as u8;
+
+    Some(vec![0x1b, b'[', b'M', bx, sx, sy])
 }
 
 #[cfg(test)]
@@ -3541,6 +3595,25 @@ mod tests {
         // Enable SGR mouse + click reporting.
         model.feed(b"\x1b[?1006h\x1b[?1002h");
         assert!(model.mouse_mode());
+        assert!(model.sgr_mouse());
+    }
+
+    #[test]
+    fn terminal_model_mouse_mode_sgr_only_not_tracking() {
+        let mut model = TerminalModel::new(80, 24);
+        // Enable SGR encoding only — no tracking mode.
+        model.feed(b"\x1b[?1006h");
+        assert!(!model.mouse_mode()); // SGR alone is not tracking.
+        assert!(model.sgr_mouse());
+    }
+
+    #[test]
+    fn terminal_model_mouse_mode_legacy_tracking() {
+        let mut model = TerminalModel::new(80, 24);
+        // Enable click tracking without SGR.
+        model.feed(b"\x1b[?1000h");
+        assert!(model.mouse_mode());
+        assert!(!model.sgr_mouse());
     }
 
     #[test]
@@ -3594,5 +3667,97 @@ mod tests {
         app.push_term_input(b"hello");
         assert_eq!(app.take_term_input().unwrap(), b"hello");
         assert!(app.take_term_input().is_none());
+    }
+
+    // --- Legacy mouse encoding tests ---
+
+    #[test]
+    fn interactive_legacy_mouse_forwarded() {
+        let mut app = make_interactive_app();
+        // Enable click tracking WITHOUT SGR (legacy mode 1000).
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1000h");
+        }
+        assert!(app.terminal.as_ref().unwrap().mouse_mode());
+        assert!(!app.terminal.as_ref().unwrap().sgr_mouse());
+
+        // Left click at (col=10, row=5) → x=11, y=4 (1-based).
+        // Legacy: \x1b[M + (0+32), (10+32), (3+32) = \x1b[M \x20 \x2a \x23
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let input = app.take_term_input().unwrap();
+        // button=0+32=32, x=(11-1)+32=42, y=(4-1)+32=35
+        assert_eq!(input, vec![0x1b, b'[', b'M', 32, 42, 35]);
+    }
+
+    #[test]
+    fn interactive_legacy_mouse_release() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1000h");
+        }
+        // Release → button 3 in legacy mode.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left),
+            column: 5,
+            row: 3,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let input = app.take_term_input().unwrap();
+        // button=3+32=35, x=(6-1)+32=37, y=(2-1)+32=33
+        assert_eq!(input, vec![0x1b, b'[', b'M', 35, 37, 33]);
+    }
+
+    #[test]
+    fn encode_legacy_mouse_right_click() {
+        let m = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Right),
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        // x=5, y=3 → x byte = 4+32=36, y byte = 2+32=34
+        let result = encode_legacy_mouse(&m, 5, 3).unwrap();
+        // button=2+32=34
+        assert_eq!(result, vec![0x1b, b'[', b'M', 34, 36, 34]);
+    }
+
+    #[test]
+    fn encode_legacy_mouse_scroll() {
+        let m = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        // x=1, y=1 → x byte = 0+32=32, y byte = 0+32=32
+        let result = encode_legacy_mouse(&m, 1, 1).unwrap();
+        // button=64+32=96
+        assert_eq!(result, vec![0x1b, b'[', b'M', 96, 32, 32]);
+    }
+
+    #[test]
+    fn sgr_only_without_tracking_uses_scrollback() {
+        let mut app = make_interactive_app();
+        // Enable SGR encoding only — no tracking mode.
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1006h");
+        }
+        assert!(!app.terminal.as_ref().unwrap().mouse_mode());
+        assert!(app.terminal.as_ref().unwrap().sgr_mouse());
+
+        // Scroll up → should NOT be forwarded as SGR, should use scrollback.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollUp,
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        // No pending term input — scroll was internal.
+        assert!(app.pending_term_input.is_none());
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -209,6 +209,8 @@ pub struct App {
     pub message_rev: u64,
     /// Actual chat area on screen (filled during render, for hit-testing).
     pub chat_area: Rect,
+    /// Terminal grid area in interactive mode (filled during render).
+    pub terminal_area: Rect,
     /// Actual input area on screen (filled during render, for hit-testing).
     pub input_area: Rect,
     /// Confirm button areas (filled later, for mouse click detection).
@@ -285,6 +287,7 @@ impl App {
             layout_cache: ChatLayoutCache::new(),
             message_rev: 0,
             chat_area: Rect::default(),
+            terminal_area: Rect::default(),
             input_area: Rect::default(),
             confirm_button_areas: Vec::new(),
             mouse_drag: None,
@@ -574,6 +577,10 @@ impl App {
                 // Convert the key event to terminal input bytes.
                 let bytes = key_to_bytes(key);
                 if !bytes.is_empty() {
+                    // Reset scrollback to bottom on keyboard input.
+                    if let Some(t) = self.terminal.as_mut() {
+                        t.scroll_to_bottom();
+                    }
                     // Append to pending input (multiple keys may arrive per loop iteration).
                     match &mut self.pending_term_input {
                         Some(existing) => existing.extend_from_slice(&bytes),
@@ -700,8 +707,14 @@ impl App {
             }
         }
 
-        // Other mouse events are not used in interactive/password modes.
-        if self.mode == AppMode::Interactive || self.mode == AppMode::PasswordInput {
+        // Mouse events in Interactive mode are handled separately.
+        if self.mode == AppMode::Interactive {
+            self.handle_interactive_mouse(m);
+            return;
+        }
+
+        // No mouse events in PasswordInput mode.
+        if self.mode == AppMode::PasswordInput {
             return;
         }
 
@@ -855,6 +868,72 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Handle a mouse event in Interactive terminal mode.
+    ///
+    /// If the terminal application has requested mouse events (SGR mode),
+    /// all mouse events are encoded as SGR sequences and forwarded to the
+    /// terminal input.  Otherwise, the scroll wheel either scrolls the
+    /// scrollback history (primary screen) or translates to arrow keys
+    /// (alternate screen, e.g. `less`, `man`).
+    fn handle_interactive_mouse(&mut self, m: crossterm::event::MouseEvent) {
+        use crossterm::event::MouseEventKind;
+
+        // Ignore events outside the terminal area.
+        let area = self.terminal_area;
+        if m.column < area.x
+            || m.column >= area.x + area.width
+            || m.row < area.y
+            || m.row >= area.y + area.height
+        {
+            return;
+        }
+
+        // 1-based coordinates relative to the terminal area (SGR convention).
+        let x = (m.column - area.x + 1) as usize;
+        let y = (m.row - area.y + 1) as usize;
+
+        let mouse_mode = self.terminal.as_ref().is_some_and(|t| t.mouse_mode());
+        let alt_screen = self.terminal.as_ref().is_some_and(|t| t.is_alt_screen());
+
+        if mouse_mode {
+            // Forward mouse events as SGR sequences to the terminal.
+            if let Some(seq) = encode_sgr_mouse(&m, x, y) {
+                self.push_term_input(&seq);
+            }
+            return;
+        }
+
+        // No mouse mode — handle scroll wheel only.
+        match m.kind {
+            MouseEventKind::ScrollUp => {
+                if alt_screen {
+                    // Translate wheel to arrow keys (3 per tick).
+                    let arrows = b"\x1b[A\x1b[A\x1b[A";
+                    self.push_term_input(arrows);
+                } else if let Some(t) = self.terminal.as_mut() {
+                    t.scroll_display(3);
+                }
+            }
+            MouseEventKind::ScrollDown => {
+                if alt_screen {
+                    let arrows = b"\x1b[B\x1b[B\x1b[B";
+                    self.push_term_input(arrows);
+                } else if let Some(t) = self.terminal.as_mut() {
+                    t.scroll_display(-3);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Append bytes to the pending terminal input buffer.
+    fn push_term_input(&mut self, bytes: &[u8]) {
+        match &mut self.pending_term_input {
+            Some(existing) => existing.extend_from_slice(bytes),
+            None => self.pending_term_input = Some(bytes.to_vec()),
         }
     }
 
@@ -1595,6 +1674,53 @@ fn is_interactive_command(cmd: &str) -> bool {
         | "bash" | "sh" | "zsh" | "fish" | "dash"
         | "su" | "sudo"  // sudo can be interactive (e.g. sudo -i)
     )
+}
+
+// ---------------------------------------------------------------------------
+// SGR mouse encoding for interactive terminal mode
+// ---------------------------------------------------------------------------
+
+/// Encode a crossterm mouse event as an SGR mouse sequence.
+///
+/// Returns `None` for event types that don't have a standard SGR encoding.
+///
+/// Format: `\x1b[<{button};{x};{y}M` for press/motion, `\x1b[<{button};{x};{y}m`
+/// for release.  Coordinates are 1-based.
+fn encode_sgr_mouse(m: &crossterm::event::MouseEvent, x: usize, y: usize) -> Option<Vec<u8>> {
+    use crossterm::event::{MouseButton, MouseEventKind, KeyModifiers};
+
+    // Base button code.
+    let (button, is_release) = match m.kind {
+        MouseEventKind::Down(MouseButton::Left) => (0, false),
+        MouseEventKind::Down(MouseButton::Right) => (2, false),
+        MouseEventKind::Down(MouseButton::Middle) => (1, false),
+        MouseEventKind::Up(MouseButton::Left) => (0, true),
+        MouseEventKind::Up(MouseButton::Right) => (2, true),
+        MouseEventKind::Up(MouseButton::Middle) => (1, true),
+        MouseEventKind::Drag(MouseButton::Left) => (32, false),
+        MouseEventKind::Drag(MouseButton::Right) => (34, false),
+        MouseEventKind::Drag(MouseButton::Middle) => (33, false),
+        MouseEventKind::Moved => (35, false),
+        MouseEventKind::ScrollUp => (64, false),
+        MouseEventKind::ScrollDown => (65, false),
+        _ => return None,
+    };
+
+    // Add modifier flags.
+    let mut code = button;
+    if m.modifiers.contains(KeyModifiers::SHIFT) {
+        code |= 4;
+    }
+    if m.modifiers.contains(KeyModifiers::ALT) {
+        code |= 8;
+    }
+    if m.modifiers.contains(KeyModifiers::CONTROL) {
+        code |= 16;
+    }
+
+    let suffix = if is_release { b'm' } else { b'M' };
+    Some(format!("\x1b[<{code};{x};{y}").into_bytes())
+        .map(|mut v| { v.push(suffix); v })
 }
 
 #[cfg(test)]
@@ -3198,5 +3324,275 @@ mod tests {
         // Should fall through to selection, not return early.
         assert!(app.selection.is_some());
         assert_eq!(app.mouse_drag, Some(DragKind::Selection));
+    }
+
+    // --- Interactive mouse tests ---
+
+    fn make_interactive_app() -> App {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.mode = AppMode::Interactive;
+        app.terminal = Some(TerminalModel::new(80, 24));
+        app.terminal_area = Rect::new(0, 2, 80, 20);
+        app
+    }
+
+    #[test]
+    fn interactive_scroll_up_primary_screen() {
+        let mut app = make_interactive_app();
+        // Feed enough lines to create scrollback history.
+        if let Some(t) = app.terminal.as_mut() {
+            for _ in 0..30 {
+                t.feed(b"line\n");
+            }
+        }
+        // Scroll up — should scroll through scrollback.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollUp,
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        // No pending term input — scroll is internal.
+        assert!(app.pending_term_input.is_none());
+    }
+
+    #[test]
+    fn interactive_scroll_down_primary_screen() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            for _ in 0..30 {
+                t.feed(b"line\n");
+            }
+            t.scroll_display(10);
+        }
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollDown,
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        assert!(app.pending_term_input.is_none());
+    }
+
+    #[test]
+    fn interactive_scroll_alt_screen_translates_to_arrows() {
+        let mut app = make_interactive_app();
+        // Enter alt screen mode via ESC sequence.
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1049h");
+        }
+        assert!(app.terminal.as_ref().unwrap().is_alt_screen());
+        // Scroll up → should produce arrow key bytes.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollUp,
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let input = app.take_term_input().unwrap();
+        assert_eq!(input, b"\x1b[A\x1b[A\x1b[A");
+
+        // Scroll down → should produce down arrow bytes.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollDown,
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let input = app.take_term_input().unwrap();
+        assert_eq!(input, b"\x1b[B\x1b[B\x1b[B");
+    }
+
+    #[test]
+    fn interactive_mouse_outside_area_ignored() {
+        let mut app = make_interactive_app();
+        // Click below terminal area (row 23 > 2+20=22).
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollUp,
+            column: 10,
+            row: 23,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        assert!(app.pending_term_input.is_none());
+    }
+
+    #[test]
+    fn interactive_sgr_mouse_mode_forwarded() {
+        let mut app = make_interactive_app();
+        // Enable SGR mouse mode via ESC sequence.
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1006h\x1b[?1002h"); // SGR + REPORT_CLICK
+        }
+        assert!(app.terminal.as_ref().unwrap().mouse_mode());
+
+        // Left click at (col=10, row=5) → SGR: x=11, y=4 (1-based).
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let input = app.take_term_input().unwrap();
+        // SGR format: \x1b[<0;11;4M
+        assert_eq!(input, b"\x1b[<0;11;4M");
+    }
+
+    #[test]
+    fn interactive_sgr_mouse_release() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1006h\x1b[?1002h");
+        }
+        // Left button release at (col=20, row=10) → x=21, y=9.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left),
+            column: 20,
+            row: 10,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let input = app.take_term_input().unwrap();
+        // Release uses lowercase 'm'.
+        assert_eq!(input, b"\x1b[<0;21;9m");
+    }
+
+    #[test]
+    fn interactive_sgr_mouse_scroll() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1006h\x1b[?1002h");
+        }
+        // Scroll up → button code 64.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollUp,
+            column: 15,
+            row: 7,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let input = app.take_term_input().unwrap();
+        // x=16, y=6.
+        assert_eq!(input, b"\x1b[<64;16;6M");
+    }
+
+    #[test]
+    fn interactive_sgr_mouse_with_modifiers() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1006h\x1b[?1002h");
+        }
+        // Ctrl+Shift+Left click at (col=5, row=3) → x=6, y=2.
+        // code = 0 + 4 (shift) + 16 (ctrl) = 20.
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: 5,
+            row: 3,
+            modifiers: crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::CONTROL,
+        });
+        let input = app.take_term_input().unwrap();
+        assert_eq!(input, b"\x1b[<20;6;2M");
+    }
+
+    #[test]
+    fn encode_sgr_mouse_right_click() {
+        let m = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Right),
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        let result = encode_sgr_mouse(&m, 5, 3).unwrap();
+        assert_eq!(result, b"\x1b[<2;5;3M");
+    }
+
+    #[test]
+    fn encode_sgr_mouse_middle_drag() {
+        let m = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Middle),
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        let result = encode_sgr_mouse(&m, 10, 10).unwrap();
+        assert_eq!(result, b"\x1b[<33;10;10M");
+    }
+
+    #[test]
+    fn encode_sgr_mouse_motion_no_button() {
+        let m = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Moved,
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        let result = encode_sgr_mouse(&m, 1, 1).unwrap();
+        assert_eq!(result, b"\x1b[<35;1;1M");
+    }
+
+    // --- TerminalModel new methods tests ---
+
+    #[test]
+    fn terminal_model_mouse_mode_default_off() {
+        let model = TerminalModel::new(80, 24);
+        assert!(!model.mouse_mode());
+    }
+
+    #[test]
+    fn terminal_model_mouse_mode_sgr_enabled() {
+        let mut model = TerminalModel::new(80, 24);
+        // Enable SGR mouse + click reporting.
+        model.feed(b"\x1b[?1006h\x1b[?1002h");
+        assert!(model.mouse_mode());
+    }
+
+    #[test]
+    fn terminal_model_alt_screen_default_off() {
+        let model = TerminalModel::new(80, 24);
+        assert!(!model.is_alt_screen());
+    }
+
+    #[test]
+    fn terminal_model_alt_screen_enabled() {
+        let mut model = TerminalModel::new(80, 24);
+        model.feed(b"\x1b[?1049h");
+        assert!(model.is_alt_screen());
+    }
+
+    #[test]
+    fn terminal_model_scroll_display_up() {
+        let mut model = TerminalModel::new(80, 5);
+        for _ in 0..20 {
+            model.feed(b"line\n");
+        }
+        model.scroll_display(3);
+        // Should not panic — display offset changed.
+        // We can't directly read display_offset from the public API,
+        // but the method should complete successfully.
+    }
+
+    #[test]
+    fn terminal_model_scroll_to_bottom() {
+        let mut model = TerminalModel::new(80, 5);
+        for _ in 0..20 {
+            model.feed(b"line\n");
+        }
+        model.scroll_display(5);
+        model.scroll_to_bottom();
+        // Should not panic.
+    }
+
+    #[test]
+    fn push_term_input_appends() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.push_term_input(b"abc");
+        app.push_term_input(b"def");
+        let input = app.take_term_input().unwrap();
+        assert_eq!(input, b"abcdef");
+    }
+
+    #[test]
+    fn push_term_input_new_buffer() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.push_term_input(b"hello");
+        assert_eq!(app.take_term_input().unwrap(), b"hello");
+        assert!(app.take_term_input().is_none());
     }
 }

--- a/crates/tui/src/terminal.rs
+++ b/crates/tui/src/terminal.rs
@@ -7,7 +7,7 @@
 //! terminal input bytes via [`key_to_bytes`].
 
 use alacritty_terminal::event::VoidListener;
-use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Column, Line};
 use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::term::{Config, Term, TermMode};
@@ -106,6 +106,37 @@ impl TerminalModel {
         let col = point.column.0.min(u16::MAX as usize) as u16;
         let row = point.line.0.max(0) as u16;
         Some((col, row))
+    }
+
+    /// Scroll the terminal display by `delta` lines (negative = up).
+    ///
+    /// This scrolls through the scrollback history without sending input
+    /// to the PTY/SSH channel.
+    pub fn scroll_display(&mut self, delta: i32) {
+        self.term.scroll_display(Scroll::Delta(delta));
+    }
+
+    /// Reset scrollback to the bottom (latest output).
+    pub fn scroll_to_bottom(&mut self) {
+        self.term.scroll_display(Scroll::Bottom);
+    }
+
+    /// Check whether the application in the terminal has requested mouse
+    /// events (SGR, click, drag, or motion mode).
+    ///
+    /// When this returns `true`, mouse events should be encoded as SGR
+    /// sequences and forwarded to the terminal input.
+    pub fn mouse_mode(&self) -> bool {
+        self.term.mode().intersects(TermMode::MOUSE_MODE | TermMode::SGR_MOUSE)
+    }
+
+    /// Check whether the terminal is in alternate screen mode.
+    ///
+    /// In alt-screen (used by `less`, `vim`, `htop`, etc.) scrollback
+    /// scrolling doesn't apply — the wheel should be translated to arrow
+    /// keys instead.
+    pub fn is_alt_screen(&self) -> bool {
+        self.term.mode().contains(TermMode::ALT_SCREEN)
     }
 
     /// Render the terminal grid to a ratatui frame.

--- a/crates/tui/src/terminal.rs
+++ b/crates/tui/src/terminal.rs
@@ -122,12 +122,21 @@ impl TerminalModel {
     }
 
     /// Check whether the application in the terminal has requested mouse
-    /// events (SGR, click, drag, or motion mode).
+    /// tracking (click, drag, or motion mode).
     ///
-    /// When this returns `true`, mouse events should be encoded as SGR
-    /// sequences and forwarded to the terminal input.
+    /// This checks `MOUSE_MODE` only (REPORT_CLICK | MOTION | DRAG), not
+    /// `SGR_MOUSE`, which is an encoding flag rather than a tracking flag.
     pub fn mouse_mode(&self) -> bool {
-        self.term.mode().intersects(TermMode::MOUSE_MODE | TermMode::SGR_MOUSE)
+        self.term.mode().intersects(TermMode::MOUSE_MODE)
+    }
+
+    /// Check whether the application has requested SGR mouse encoding (1006).
+    ///
+    /// When `true`, mouse events should be encoded as SGR sequences
+    /// (`\x1b[<{button};{x};{y}M/m`).  When `false` but `mouse_mode()` is
+    /// `true`, legacy encoding (`\x1b[M{b}{x}{y}`) should be used instead.
+    pub fn sgr_mouse(&self) -> bool {
+        self.term.mode().contains(TermMode::SGR_MOUSE)
     }
 
     /// Check whether the terminal is in alternate screen mode.

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -40,6 +40,7 @@ fn help_items(mode: AppMode) -> Vec<HelpItem> {
         ],
         AppMode::Interactive => vec![
             HelpItem { key: "ctrl+t", desc: "agent mode", action: Some(HelpAction::Terminal) },
+            HelpItem { key: "wheel", desc: "scroll", action: None },
         ],
         AppMode::PasswordInput => vec![
             HelpItem { key: "enter", desc: "send password", action: Some(HelpAction::SendPassword) },

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -104,6 +104,9 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
     bars::render_status_bar(f, app, chunks[0]);
     bars::render_separator(f, app, chunks[1]);
 
+    // Store terminal area for mouse hit-testing in interactive mode.
+    app.terminal_area = chunks[2];
+
     // Render the terminal model grid.
     if let Some(ref term) = app.terminal {
         term.render(f, chunks[2]);


### PR DESCRIPTION
## Summary

Closes #22

Реализована поддержка мыши в интерактивном режиме терминала (Ctrl+T):

1. **TerminalModel API** — `scroll_display(delta)`, `scroll_to_bottom()`, `mouse_mode()`, `is_alt_screen()`
2. **SGR mouse forwarding** — когда приложение в терминале запросило мышь (vim, htop, mc), события кодируются в SGR-последовательности и отправляются в терминал
3. **Scrollback scroll** — на primary screen колесо скроллит историю терминала (±3 строки)
4. **Alt-screen arrow translation** — в alt-screen (less, man) колесо транслируется в стрелки ↑↑↑/↓↓↓
5. **Keyboard scroll reset** — любой клавиатурный ввод сбрасывает скролл в низ
6. **Help-bar** — добавлен `wheel scroll` в Interactive mode

## Tests

- `cargo build --workspace` — зелёный
- `cargo clippy --all-targets -- -D warnings` — зелёный
- `cargo test --workspace` — 42 agent + 165 tui = 207 passed, 0 failed
- 19 новых тестов: scroll up/down, alt-screen arrows, SGR encoding (click/release/scroll/modifiers/drag/motion), mouse_mode, alt_screen, push_term_input

## Ручная проверка (DoD)

Требует docker-sshd (не запускается агентом):
- [ ] Колесо скроллит историю локального PowerShell в интерактивном режиме
- [ ] В `htop`/`mc` по SSH клики и колесо доходят до приложения
- [ ] В `less` колесо листает (трансляция в стрелки)

## Не вошло в скоуп

- Изменения вне Interactive mode не вносились
- Тесты с docker-sshd требуют ручной проверки

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive terminal mode now supports mouse wheel scrolling and more accurate mouse interaction limited to the terminal area.
  * Mouse clicks/drags/releases can be forwarded to terminal applications when mouse reporting is enabled (using SGR encoding when available, otherwise legacy encoding).
  * The help bar now includes a wheel (“scroll”) hint for interactive mode.
* **Bug Fixes**
  * Mouse events outside the terminal area are ignored.
  * In interactive mode, keyboard input keeps the terminal view pinned to the latest output.
* **Documentation**
  * Updated progress notes with the new interactive mouse behavior requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->