### PR TITLE
fix(tui): panic-hook restores terminal state on panic

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1109,3 +1109,32 @@ PR: #28
   сессия сохранена.
 - Ресайз 40×10 — нет паник.
 - Запуск без mouse capture — работает.
+
+---
+
+## 25. Issue #40: TUI panic-hook — восстановление терминала при панике
+
+**Milestone:** Engine v0.3.0. **Ветка:** `fix/40-panic-hook-terminal-restore`.
+
+**Что сделано:**
+- Добавлен `PanicHookGuard` — RAII-структура в `runner.rs`, устанавливающая
+  panic-hook ДО `enable_raw_mode()`. Хук восстанавливает терминал (DisableMouseCapture,
+  LeaveAlternateScreen, disable_raw_mode) ПЕРЕД печатью паники — текст виден и
+  выделяется мышью.
+- Hook снимается через `drop(_hook_guard)` ДО штатного teardown (для чистоты,
+  чтобы избежать двойного DisableMouseCapture). На error-path снимается
+  автоматически через Drop.
+- Штатный путь выхода (Ctrl+C) не изменился.
+
+**Изменённые файлы:**
+- `crates/tui/src/runner.rs` — `PanicHookGuard` + установка в `run()`
+
+**Тесты:** без изменений (242 passed, 0 failed, 5 ignored). Поведение проверяется
+  ручным тестом (panic в debug-сборке → терминал восстановлен).
+
+**Публичные контракты:** без изменений (`PanicHookGuard` — private).
+
+**DoD (требует ручной проверки):**
+- В debug-сборке вызвать панику внутри event loop → терминал в нормальном
+  состоянии, текст паники читаемо и выделяется мышью.
+- Штатный выход (Ctrl+C) работает как раньше.

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -117,6 +117,49 @@ impl CommandExecutor for TuiExecutor {
 }
 
 // ---------------------------------------------------------------------------
+// Panic hook guard
+// ---------------------------------------------------------------------------
+
+/// RAII guard that restores the default panic hook when dropped.
+///
+/// Installs a custom panic hook that restores the terminal state
+/// (disables raw mode, leaves alternate screen, disables mouse capture)
+/// *before* printing the panic message. This ensures the user can read
+/// the panic text and select it with the mouse even if a panic occurs
+/// inside the event loop or rendering code.
+///
+/// When the guard is dropped (either after normal teardown or on early
+/// return), the original panic hook is restored via `take_hook()`, so
+/// code running after the TUI is unaffected.
+struct PanicHookGuard;
+
+impl PanicHookGuard {
+    /// Install the terminal-restoring panic hook and return a guard.
+    fn install() -> Self {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            // Restore terminal state BEFORE printing the panic message
+            // so the user can read it and select the text.
+            let _ = crossterm::execute!(
+                std::io::stdout(),
+                crossterm::event::DisableMouseCapture,
+                crossterm::terminal::LeaveAlternateScreen
+            );
+            let _ = crossterm::terminal::disable_raw_mode();
+            default_hook(info);
+        }));
+        Self
+    }
+}
+
+impl Drop for PanicHookGuard {
+    fn drop(&mut self) {
+        // Restore the original panic hook.
+        let _ = std::panic::take_hook();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
 
@@ -139,6 +182,11 @@ pub async fn run(
     executor: Arc<dyn CommandExecutor>,
     config: TuiConfig,
 ) -> Result<()> {
+    // Install panic hook to restore terminal state on panic.
+    // The hook is automatically uninstalled when _hook_guard is dropped
+    // (on normal return, early error, or panic).
+    let _hook_guard = PanicHookGuard::install();
+
     // Set up terminal.
     enable_raw_mode().map_err(|e| CoreError::Other(format!("failed to enable raw mode: {e}")))?;
     let mut stdout = io::stdout();
@@ -157,6 +205,12 @@ pub async fn run(
         .map_err(|e| CoreError::Other(format!("failed to create terminal: {e}")))?;
 
     let result = run_app(&mut terminal, llm, executor, config).await;
+
+    // Restore the original panic hook before terminal teardown.
+    // The custom hook is no longer needed — teardown uses .ok() and
+    // cannot panic. Removing the hook here avoids a redundant double
+    // DisableMouseCapture if the default hook fires during teardown.
+    drop(_hook_guard);
 
     // Restore terminal.
     disable_raw_mode().ok();


### PR DESCRIPTION
Closes #40

## Summary

Установка panic-hook в `runner.rs::run` для восстановления терминала при панике.

### Changes

- **`PanicHookGuard`** — RAII-структура, устанавливающая panic-hook ДО `enable_raw_mode()`. Хук восстанавливает терминал (`DisableMouseCapture`, `LeaveAlternateScreen`, `disable_raw_mode`) ПЕРЕД печатью паники — текст виден и выделяется мышью.
- Hook снимается через `drop(_hook_guard)` ДО штатного teardown (для чистоты, чтобы избежать двойного `DisableMouseCapture`).
- На error-path (`enable_raw_mode` / `EnterAlternateScreen` failure) hook снимается автоматически через `Drop`.
- Штатный путь выхода (Ctrl+C) не изменился.

### Tests

- `cargo clippy --all-targets -- -D warnings` — чисто
- `cargo test --workspace` — **242 passed, 0 failed, 5 ignored**
- Ignored tests (docker-sshd): `transport::ssh::tests::*` (5 tests) — требуют ручной проверки

### Manual verification required

- В debug-сборке вызвать панику внутри event loop → терминал в нормальном состоянии, текст паники читаемо и выделяется мышью.
- Штатный выход (Ctrl+C) работает как раньше.

### Out of scope

- Публичные контракты не изменены (`PanicHookGuard` — private)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal recovery if the app panics, restoring normal terminal behavior before the error is shown.
  * Kept mouse capture, raw mode, and alternate screen handling in a safe state so panic output is readable.
  * Preserved normal exit behavior for standard shutdown actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->