### PR TITLE
fix(tui): hover must not change confirm_selected in confirmation dialog

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1138,3 +1138,35 @@ PR: #28
 - В debug-сборке вызвать панику внутри event loop → терминал в нормальном
   состоянии, текст паники читаемо и выделяется мышью.
 - Штатный выход (Ctrl+C) работает как раньше.
+
+---
+
+## Issue #41: TUI: hover не должен менять действие Enter в диалоге подтверждения
+
+**Задача:** Наведение мыши на кнопку подтверждения не должно менять
+`confirm_selected` — safety-дефолт «Enter = Deny» должен сохраняться до
+явного действия пользователя (Tab/←/→ или клик).
+
+**Решение:**
+- В `app.rs::handle_mouse` ветка `Moved`: удалена строка
+  `self.confirm_selected = approve`. Hover обновляет только `hovered_button`
+  (визуальная подсветка).
+- В `ui/confirm.rs::render_buttons`: добавлена визуальная дифференциация —
+  selected (активная для Enter) = инверсия + BOLD, hovered = UNDERLINED,
+  обычная = plain. Убрано преждевременное `hovered_button = None` в начале
+  рендера (состояние hover должно сохраняться между кадрами).
+- Тесты: `mouse_hover_updates_selected` → переименован в
+  `mouse_hover_does_not_change_confirm_selected` (assert: hover не меняет
+  `confirm_selected`); добавлен `repeated_hover_does_not_change_confirm_selected`
+  (многократный hover не меняет выбор).
+
+**Изменённые файлы:**
+- `crates/tui/src/app.rs` — фикс `Moved` + тесты
+- `crates/tui/src/ui/confirm.rs` — hover styling + doc-comment
+
+**Тесты:** 243 passed, 0 failed, 5 ignored.
+
+**Публичные контракты:** без изменений.
+
+**DoD:** наведение мыши не влияет на действие Enter; дефолт Deny сохраняется
+  до явного действия пользователя.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -859,10 +859,12 @@ impl App {
                 self.mouse_drag = None;
             }
             // --- Hover (track which button is under cursor) ---
+            // NOTE: hover only updates visual highlighting — it must NOT
+            // change confirm_selected, so the Enter safety-default (Deny)
+            // is preserved until the user explicitly toggles via keyboard.
             MouseEventKind::Moved => {
                 if let HitZone::ConfirmButton(approve) = zone {
                     self.hovered_button = Some(approve);
-                    self.confirm_selected = approve;
                 } else {
                     self.hovered_button = None;
                 }
@@ -2580,19 +2582,19 @@ mod tests {
     }
 
     #[test]
-    fn mouse_hover_updates_selected() {
+    fn mouse_hover_does_not_change_confirm_selected() {
         let mut app = make_confirm_app(false);
         app.confirm_button_areas.push((Rect::new(20, 10, 15, 1), true));
         app.confirm_button_areas.push((Rect::new(38, 10, 13, 1), false));
-        // Hover over Approve.
+        // Hover over Approve — hovered_button updates but confirm_selected stays Deny.
         app.handle_mouse(mouse_event(
             crossterm::event::MouseEventKind::Moved,
             25,
             10,
         ));
         assert_eq!(app.hovered_button, Some(true));
-        assert!(app.confirm_selected, "hover on Approve should move selection");
-        // Hover over Deny.
+        assert!(!app.confirm_selected, "hover must NOT change confirm_selected");
+        // Hover over Deny — hovered_button updates, confirm_selected unchanged.
         app.handle_mouse(mouse_event(
             crossterm::event::MouseEventKind::Moved,
             42,
@@ -2600,13 +2602,42 @@ mod tests {
         ));
         assert_eq!(app.hovered_button, Some(false));
         assert!(!app.confirm_selected);
-        // Hover outside buttons.
+        // Hover outside buttons — hovered_button clears.
         app.handle_mouse(mouse_event(
             crossterm::event::MouseEventKind::Moved,
             0,
             0,
         ));
         assert_eq!(app.hovered_button, None);
+        assert!(!app.confirm_selected);
+    }
+
+    #[test]
+    fn repeated_hover_does_not_change_confirm_selected() {
+        let mut app = make_confirm_app(false);
+        app.confirm_button_areas.push((Rect::new(20, 10, 15, 1), true));
+        app.confirm_button_areas.push((Rect::new(38, 10, 13, 1), false));
+        // Multiple hovers over Approve — confirm_selected must remain false.
+        for _ in 0..3 {
+            app.handle_mouse(mouse_event(
+                crossterm::event::MouseEventKind::Moved,
+                25,
+                10,
+            ));
+            assert!(!app.confirm_selected);
+        }
+        // Hover over Deny, then back over Approve — still must remain false.
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Moved,
+            42,
+            10,
+        ));
+        app.handle_mouse(mouse_event(
+            crossterm::event::MouseEventKind::Moved,
+            25,
+            10,
+        ));
+        assert!(!app.confirm_selected, "hover must never change confirm_selected");
     }
 
     #[test]

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -9,7 +9,9 @@
 //!
 //! The selected button (default: Deny — safe) is highlighted with inverted
 //! colours.  Tab / ← / → toggle the selection; Enter activates it.
-//! Mouse clicks on a button activate it directly; hover moves the selection.
+//! Mouse clicks on a button activate it directly; hover highlights the button
+//! (underline) without changing the selection — Enter always activates the
+//! keyboard-selected button, preserving the safety default.
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -24,8 +26,9 @@ use crate::app::App;
 /// Stores button rectangles in [`App::confirm_button_areas`] for hit-testing.
 pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     // Clear previous button areas (populated during this render).
+    // NOTE: hovered_button is NOT cleared here — it is transient state set by
+    // mouse Moved events and must persist across renders for hover styling.
     app.confirm_button_areas.clear();
-    app.hovered_button = None;
 
     let Some(confirm) = &app.pending_confirm else {
         return;
@@ -147,24 +150,40 @@ fn render_buttons(f: &mut Frame, app: &mut App, area: Rect) {
     app.confirm_button_areas.push((approve_area, true));
     app.confirm_button_areas.push((deny_area, false));
 
-    // Styles: selected button gets inverted colours (fg↔bg), unselected gets
-    // surface background with coloured text.
-    let approve_style = if app.confirm_selected {
+    // Styles: selected button (active for Enter) gets inverted colours
+    // (fg↔bg) + BOLD.  Hovered-but-not-selected button gets UNDERLINED to
+    // visually distinguish hover from selection.  Unselected, unhovered
+    // buttons get surface background with coloured text.
+    let approve_selected = app.confirm_selected;
+    let approve_hovered = app.hovered_button == Some(true);
+    let approve_style = if approve_selected {
         Style::default()
             .fg(app.theme.surface)
             .bg(app.theme.success)
             .add_modifier(Modifier::BOLD)
+    } else if approve_hovered {
+        Style::default()
+            .fg(app.theme.success)
+            .bg(app.theme.surface)
+            .add_modifier(Modifier::UNDERLINED)
     } else {
         Style::default()
             .fg(app.theme.success)
             .bg(app.theme.surface)
     };
 
-    let deny_style = if !app.confirm_selected {
+    let deny_selected = !app.confirm_selected;
+    let deny_hovered = app.hovered_button == Some(false);
+    let deny_style = if deny_selected {
         Style::default()
             .fg(app.theme.surface)
             .bg(app.theme.danger)
             .add_modifier(Modifier::BOLD)
+    } else if deny_hovered {
+        Style::default()
+            .fg(app.theme.danger)
+            .bg(app.theme.surface)
+            .add_modifier(Modifier::UNDERLINED)
     } else {
         Style::default()
             .fg(app.theme.danger)


### PR DESCRIPTION
Closes #41

## Summary

Наведение мыши на кнопку подтверждения больше не меняет `confirm_selected` — safety-дефолт «Enter = Deny» сохраняется до явного действия пользователя (Tab/←/→ или клик).

**Изменения:**
- `app.rs::handle_mouse` (ветка `Moved`): удалена строка `self.confirm_selected = approve`. Hover обновляет только `hovered_button` (визуальная подсветка).
- `ui/confirm.rs::render_buttons`: добавлена визуальная дифференциация — selected (активная для Enter) = инверсия + BOLD, hovered = UNDERLINED, обычная = plain. Убрано преждевременное `hovered_button = None` в начале рендера.
- Тесты: `mouse_hover_updates_selected` → переименован в `mouse_hover_does_not_change_confirm_selected`; добавлен `repeated_hover_does_not_change_confirm_selected`.

## Tests

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 243 passed, 0 failed, 5 ignored (docker-sshd, требуют ручной проверки)

## Out of scope

Ничего вне рамок issue #41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hovering over confirmation buttons no longer changes the default action for Enter.
  * The selected choice now stays stable until you change it with the keyboard or by clicking.
  * Hover styling persists correctly across redraws, and repeated hover actions no longer alter the selection.
* **Style**
  * Confirmation dialog buttons now show a clearer visual distinction between selected, hovered, and normal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->