### PR TITLE
fix(agent): flush SSE tail buffer on stream end to avoid losing final delta

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1170,3 +1170,28 @@ PR: #28
 
 **DoD:** наведение мыши не влияет на действие Enter; дефолт Deny сохраняется
   до явного действия пользователя.
+
+---
+
+## Issue #42: SSE — не терять хвост потока без завершающего перевода строки
+
+**Задача:** При завершении потока (`stream.next() == None`) остатки `raw_buffer`
+и `SseState.buffer` молча выбрасывались. Если сервер закрыл соединение без
+завершающего `\n` — терялась финальная дельта или `[DONE]`.
+
+**Решение:**
+- В `chat_stream` ветка `None`: если `raw_buffer` непуст — декодировать остаток,
+  прогнать через `state.process_chunk(&(leftover + "\n"))`, эмитнуть дельты.
+- `SseState::flush()`: новый метод, обрабатывающий незавершённую строку в
+  `self.buffer` как полную (добавляет `\n` и вызывает `process_chunk`).
+- Вызывается после flush `raw_buffer` и до `into_response()`.
+
+**Изменённые файлы:**
+- `crates/agent/src/glm.rs` — `flush()` + flush в `chat_stream` + 3 теста
+
+**Тесты:** 246 passed, 0 failed, 5 ignored.
+  - `sse_flush_partial_line_without_newline` — дельта "end" не теряется
+  - `sse_flush_done_without_newline` — `[DONE]` без `\n` обрабатывается
+  - `sse_flush_empty_buffer_noop` — пустой хвост не меняет поведение
+
+**Публичные контракты:** без изменений (`SseState` — private).

--- a/crates/agent/src/glm.rs
+++ b/crates/agent/src/glm.rs
@@ -209,6 +209,21 @@ impl LlmClient for GlmClient {
                 }
                 None => {
                     debug!("stream ended");
+                    // Flush raw_buffer: if there's leftover data without a
+                    // trailing newline, process it as a final line.
+                    if !raw_buffer.is_empty() {
+                        let leftover = String::from_utf8_lossy(&raw_buffer).into_owned();
+                        let deltas = state.process_chunk(&format!("{}\n", leftover));
+                        for d in deltas {
+                            on_delta(d);
+                        }
+                    }
+                    // Flush SseState buffer: process any remaining partial
+                    // line that was not terminated by a newline.
+                    let deltas = state.flush();
+                    for d in deltas {
+                        on_delta(d);
+                    }
                     return state.into_response();
                 }
             }
@@ -681,6 +696,19 @@ impl SseState {
         new_deltas
     }
 
+    /// Flush any remaining buffered data as a final SSE line.
+    ///
+    /// Called when the stream ends without a trailing newline.  If the buffer
+    /// contains a partial `data:` line, it is processed as if a newline were
+    /// appended.  Returns any text deltas produced.
+    fn flush(&mut self) -> Vec<String> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+        // Append a newline so `process_chunk` can handle the trailing line.
+        self.process_chunk("\n")
+    }
+
     /// Build the final [`ChatResponse`] from accumulated state.
     fn into_response(self) -> Result<ChatResponse> {
         if !self.tool_calls.is_empty() {
@@ -1100,6 +1128,64 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         let response = state.into_response().unwrap();
         match response {
             ChatResponse::Text(text) => assert_eq!(text, "Hi"),
+            _ => panic!("expected Text response"),
+        }
+    }
+
+    #[test]
+    fn sse_flush_partial_line_without_newline() {
+        // Stream ends with a data line that has no trailing newline.
+        // flush() should recover the final delta.
+        let mut state = SseState::new();
+        // First event complete.
+        let d1 = state.process_chunk(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+        );
+        assert_eq!(&d1, &["Hello".to_string()]);
+        // Second event — no trailing newline.
+        let d2 = state.process_chunk(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"end\"}}]}",
+        );
+        assert!(d2.is_empty(), "no complete line yet");
+        // flush should process the remaining buffer.
+        let d3 = state.flush();
+        assert_eq!(&d3, &["end".to_string()]);
+        let response = state.into_response().unwrap();
+        match response {
+            ChatResponse::Text(text) => assert_eq!(text, "Helloend"),
+            _ => panic!("expected Text response"),
+        }
+    }
+
+    #[test]
+    fn sse_flush_done_without_newline() {
+        // Stream ends with `data: [DONE]` but no trailing newline.
+        let mut state = SseState::new();
+        state.process_chunk(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+        );
+        // [DONE] without newline.
+        state.process_chunk("data: [DONE]");
+        assert!(!state.done, "done should not be set until line is processed");
+        let deltas = state.flush();
+        assert!(deltas.is_empty(), "[DONE] produces no text deltas");
+        assert!(state.done, "flush should set done flag");
+        let response = state.into_response().unwrap();
+        match response {
+            ChatResponse::Text(text) => assert_eq!(text, "ok"),
+            _ => panic!("expected Text response"),
+        }
+    }
+
+    #[test]
+    fn sse_flush_empty_buffer_noop() {
+        // Flushing an empty buffer should be a no-op.
+        let mut state = SseState::new();
+        let deltas = state.flush();
+        assert!(deltas.is_empty());
+        let response = state.into_response().unwrap();
+        match response {
+            ChatResponse::Text(text) => assert!(text.is_empty()),
             _ => panic!("expected Text response"),
         }
     }

--- a/crates/agent/src/glm.rs
+++ b/crates/agent/src/glm.rs
@@ -1189,4 +1189,44 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
             _ => panic!("expected Text response"),
         }
     }
+
+    #[test]
+    fn sse_raw_buffer_flush_on_stream_end() {
+        // Simulate the chat_stream None-branch logic: raw_buffer has
+        // leftover bytes without a trailing newline.  The flush path
+        // should decode, process, and emit the final delta.
+        let mut state = SseState::new();
+        let mut raw_buffer: Vec<u8> =
+            b"data: {\"choices\":[{\"delta\":{\"content\":\"end\"}}]}".to_vec();
+
+        // Normal processing loop — no newline found, nothing processed.
+        let mut collected_deltas: Vec<String> = Vec::new();
+        while let Some(pos) = raw_buffer.iter().position(|&b| b == b'\n') {
+            let line = String::from_utf8_lossy(&raw_buffer[..=pos]).into_owned();
+            raw_buffer = raw_buffer[pos + 1..].to_vec();
+            for d in state.process_chunk(&line) {
+                collected_deltas.push(d);
+            }
+        }
+        assert!(collected_deltas.is_empty(), "no complete line yet");
+
+        // Stream ended — flush raw_buffer (same logic as chat_stream).
+        if !raw_buffer.is_empty() {
+            let leftover = String::from_utf8_lossy(&raw_buffer).into_owned();
+            for d in state.process_chunk(&format!("{}\n", leftover)) {
+                collected_deltas.push(d);
+            }
+        }
+        // Flush SseState buffer.
+        for d in state.flush() {
+            collected_deltas.push(d);
+        }
+
+        assert_eq!(&collected_deltas, &["end".to_string()]);
+        let response = state.into_response().unwrap();
+        match response {
+            ChatResponse::Text(text) => assert_eq!(text, "end"),
+            _ => panic!("expected Text response"),
+        }
+    }
 }


### PR DESCRIPTION
Closes #42

## Summary

При завершении SSE-потока (`stream.next() == None`) остатки `raw_buffer` и `SseState.buffer` больше не теряются. Если сервер закрыл соединение без завершающего `\n`, финальная дельта или `[DONE]` корректно обрабатывается.

**Изменения:**
- `chat_stream` ветка `None`: если `raw_buffer` непуст — декодирует остаток, прогоняет через `process_chunk(&(leftover + "\n"))`, эмитит дельты.
- `SseState::flush()`: новый метод, обрабатывающий незавершённую строку в `self.buffer` как полную (добавляет `\n` и вызывает `process_chunk`).
- 3 новых unit-теста:
  - `sse_flush_partial_line_without_newline` — дельта "end" не теряется
  - `sse_flush_done_without_newline` — `[DONE]` без `\n` обрабатывается
  - `sse_flush_empty_buffer_noop` — пустой хвост не меняет поведение

## Tests

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 246 passed, 0 failed, 5 ignored (docker-sshd, требуют ручной проверки)

## Out of scope

Ничего вне рамок issue #42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming responses so trailing SSE content is preserved when the stream ends without a final newline.
  * Improved end-of-stream handling by flushing any buffered SSE fragments and correctly recognizing termination markers even without a newline.
* **Tests**
  * Added unit tests covering partial final `data:` lines, missing newline endings, empty-buffer flush behavior, and end-of-stream buffer recovery.
* **Documentation**
  * Updated progress notes with the SSE edge-case addressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->