### PR TITLE
feat(agent): AgentEvent + EventSink, ChatResponse struct

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1262,3 +1262,17 @@ PR: #28
 - CHANGED: `filar_agent::ChatResponse` — enum → struct (`text` + `tool_calls`)
 - CHANGED: `filar_tui::event::TuiEvent` (was `AgentEvent`) — wrapping `filar_agent::AgentEvent`
 - REMOVED: дубликаты TUI event-вариантов (Started, TextDelta, CommandExecuted, Finished, Error)
+
+### Review fixes (PR #51, CodeRabbit)
+
+- **TextDelta через оба хука**: `on_text_delta` и `event_sink` теперь работают
+  одновременно — раньше `on_text_delta` полностью перекрывал sink.
+- **Blocked ≠ denied**: для `ConfirmDecision::Blocked` больше не эмитится
+  `CommandFinished` — blocked не является user denial, и TUI не должен показывать
+  блок команды. Причина блокировки отправляется только в LLM как tool context.
+- **println! в smoke-тестах**: удалены отладочные `println!` (AGENTS.md).
+- **CommandProposed explanation**: TUI теперь сохраняет metadata из `CommandProposed`
+  и использует её в `CommandFinished` для auto-approved команд (которые не прошли
+  через `ConfirmationRequest`). Новое поле `App::pending_proposal`.
+- **Double terminal event в shell escape**: `Finished` больше не эмитится после
+  `Error` — только один терминальный event на запуск.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1195,3 +1195,70 @@ PR: #28
   - `sse_flush_empty_buffer_noop` — пустой хвост не меняет поведение
 
 **Публичные контракты:** без изменений (`SseState` — private).
+
+---
+
+## Issue #43: Engine 0.1 — публичные события агента (AgentEvent + sink)
+
+**Задача:** Создать UI-агностический `AgentEvent` enum + `EventSink` в `filar-agent`,
+эмитить события во всех ключевых точках `Agent::run`. TUI должен использовать
+`filar_agent::AgentEvent` без собственной копии. Дополнительно: `ChatResponse`
+изменён с enum (Text XOR ToolCalls) на struct (text + tool_calls) чтобы
+сохранять preamble-текст в истории при наличии tool calls.
+
+**Решение:**
+
+### Часть A: AgentEvent + EventSink
+- **`crates/agent/src/events.rs`** (новый): `AgentEvent` enum (`#[non_exhaustive]`)
+  с вариантами: `Started`, `TextDelta(String)`, `CommandProposed { command, explanation,
+  destructive }`, `CommandFinished { command, output, denied }`, `Finished(String)`,
+  `Error(String)`. `EventSink = Arc<dyn Fn(AgentEvent) + Send + Sync>`.
+- **`crates/agent/src/lib.rs`**: модуль `events` публичный, реэкспорт `AgentEvent` + `EventSink`.
+- **`crates/agent/src/agent.rs`**: `AgentBuilder::event_sink(sink)` — опциональный sink.
+  `run()` рефакторен в `run()` + `run_loop()`: внешний `run()` эмитит `Started` →
+  `run_loop()` → `Finished`/`Error`. `process_tool_call()` эмитит `CommandProposed`
+  перед подтверждением и `CommandFinished` для всех исходов (blocked/denied/error/success).
+- **TUI:** `event.rs` — старый `AgentEvent` enum заменён на `TuiEvent` с вариантами:
+  `Agent(filar_agent::AgentEvent)`, `Thinking`, `ConfirmationRequest { ... }`,
+  `TransportChanged { ... }`. `runner.rs::spawn_agent` — `EventSink` форвардит
+  `AgentEvent` → `TuiEvent::Agent(...)`. `TuiExecutor` лишён `event_tx` — события
+  команд идут через sink. `app.rs::handle_agent_event` — match на `TuiEvent::Agent`
+  с вложенным match на `filar_agent::AgentEvent`.
+
+### Часть B: ChatResponse → struct
+- **`crates/agent/src/lib.rs`**: `ChatResponse` — struct с `text: String` и
+  `tool_calls: Vec<ToolCall>` (оба поля всегда присутствуют). Конструкторы
+  `text()` и `tool_calls(text, calls)`, метод `has_tool_calls()`.
+- **`crates/agent/src/glm.rs`**: `try_into_chat_response()` и `into_response()`
+  собирают оба поля. Тесты обновлены.
+
+**Решения дизайна:**
+- `run()`/`run_loop()` split — гарантирует ровно один `Finished`/`Error` на всех
+  путях (включая max-iterations).
+- `CommandFinished { denied: true }` — TUI handler пропускает update command block
+  для denied команд, сохраняя старое поведение (блок уже добавлен в `ConfirmationRequest`).
+- Shell escape (`!cmd`) — runner строит `CommandFinished` вручную из `CommandResult`,
+  т.к. агент не запущен.
+
+**Изменённые файлы:**
+- `crates/agent/src/events.rs` — новый: `AgentEvent` + `EventSink`
+- `crates/agent/src/lib.rs` — `ChatResponse` struct, модуль `events`
+- `crates/agent/src/glm.rs` — обновлён под struct API
+- `crates/agent/src/agent.rs` — `event_sink()`, `run()`/`run_loop()`, emit, 2 теста
+- `crates/tui/src/event.rs` — `TuiEvent` (замена `AgentEvent`)
+- `crates/tui/src/runner.rs` — `EventSink` bridge, `TuiExecutor` без `event_tx`
+- `crates/tui/src/app.rs` — `handle_agent_event` на `TuiEvent`
+- `crates/tui/src/confirmer.rs` — `TuiEvent` вместо `AgentEvent`
+- `crates/tui/src/lib.rs` — реэкспорт `TuiEvent`
+
+**Тесты:** 249 passed, 0 failed, 5 ignored.
+  - `event_sink_sequence_tool_call` (DoD): mock LLM с одним tool call → sink получает
+    Started → CommandProposed → CommandFinished → Finished
+  - `event_sink_denied_command`: CommandFinished с `denied: true`
+
+**Публичные контракты:**
+- NEW: `filar_agent::AgentEvent` (enum, `#[non_exhaustive]`), `filar_agent::EventSink` (type alias)
+- NEW: `AgentBuilder::event_sink(sink: EventSink) -> Self`
+- CHANGED: `filar_agent::ChatResponse` — enum → struct (`text` + `tool_calls`)
+- CHANGED: `filar_tui::event::TuiEvent` (was `AgentEvent`) — wrapping `filar_agent::AgentEvent`
+- REMOVED: дубликаты TUI event-вариантов (Started, TextDelta, CommandExecuted, Finished, Error)

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -15,9 +15,10 @@ use filar_core::{CommandConfirmMode, CoreError, Result};
 use filar_transport::CommandExecutor;
 
 use crate::{
+    events::{AgentEvent, EventSink},
     security::{self, CommandConfirmer, ConfirmDecision},
     tools::{self},
-    ChatMessage, ChatRequest, ChatResponse, LlmClient, MessageRole, ToolCall,
+    ChatMessage, ChatRequest, LlmClient, ToolCall,
 };
 
 // ---------------------------------------------------------------------------
@@ -119,6 +120,8 @@ pub struct Agent {
     system_prompt: String,
     /// Optional callback invoked for each text delta during LLM streaming.
     on_text_delta: Option<Arc<dyn Fn(String) + Send + Sync>>,
+    /// Optional event sink for emitting AgentEvents to frontends.
+    event_sink: Option<EventSink>,
 }
 
 /// Builder for [`Agent`].
@@ -131,6 +134,7 @@ pub struct AgentBuilder {
     max_output_chars: usize,
     system_prompt: Option<String>,
     on_text_delta: Option<Arc<dyn Fn(String) + Send + Sync>>,
+    event_sink: Option<EventSink>,
 }
 
 impl AgentBuilder {
@@ -145,6 +149,7 @@ impl AgentBuilder {
             max_output_chars: DEFAULT_MAX_OUTPUT_CHARS,
             system_prompt: None,
             on_text_delta: None,
+            event_sink: None,
         }
     }
 
@@ -196,6 +201,17 @@ impl AgentBuilder {
         self
     }
 
+    /// Set the event sink for emitting [`AgentEvent`]s to a frontend.
+    ///
+    /// If set, the agent emits events at key points in the processing loop:
+    /// [`AgentEvent::Started`], [`AgentEvent::TextDelta`],
+    /// [`AgentEvent::CommandProposed`], [`AgentEvent::CommandFinished`],
+    /// [`AgentEvent::Finished`], and [`AgentEvent::Error`].
+    pub fn event_sink(mut self, sink: EventSink) -> Self {
+        self.event_sink = Some(sink);
+        self
+    }
+
     /// Convenience: set the system prompt for local execution.
     pub fn local_mode(self) -> Self {
         self.system_prompt(build_system_prompt(true, None, cfg!(windows)))
@@ -219,6 +235,7 @@ impl AgentBuilder {
                 build_system_prompt(false, None, cfg!(windows))
             ),
             on_text_delta: self.on_text_delta,
+            event_sink: self.event_sink,
         })
     }
 }
@@ -235,11 +252,39 @@ impl Agent {
         AgentBuilder::new()
     }
 
+    /// Emit an event to the sink (if set).
+    fn emit(&self, event: AgentEvent) {
+        if let Some(ref sink) = self.event_sink {
+            sink(event);
+        }
+    }
+
     /// Run the agent loop with a user prompt and optional conversation history.
     ///
     /// Returns the final text response from the LLM, or an error if the
     /// loop exceeds the maximum iterations or encounters a failure.
+    ///
+    /// Events emitted via the [`EventSink`] (if set):
+    /// [`AgentEvent::Started`] → [`AgentEvent::TextDelta`] (streaming) →
+    /// [`AgentEvent::CommandProposed`] / [`AgentEvent::CommandFinished`] (tool calls) →
+    /// [`AgentEvent::Finished`] (success) or [`AgentEvent::Error`] (failure).
     pub async fn run(&self, user_prompt: &str, history: &[ChatMessage]) -> Result<String> {
+        self.emit(AgentEvent::Started);
+        match self.run_loop(user_prompt, history).await {
+            Ok(text) => {
+                self.emit(AgentEvent::Finished(text.clone()));
+                Ok(text)
+            }
+            Err(e) => {
+                self.emit(AgentEvent::Error(e.to_string()));
+                Err(e)
+            }
+        }
+    }
+
+    /// Inner agent loop — does NOT emit `Started`/`Finished`/`Error` events.
+    /// The caller ([`run`](Self::run)) wraps this to emit those events.
+    async fn run_loop(&self, user_prompt: &str, history: &[ChatMessage]) -> Result<String> {
         // Build initial message history: system prompt + prior context + new user message.
         let mut messages: Vec<ChatMessage> = vec![ChatMessage::system(&self.system_prompt)];
         messages.extend_from_slice(history);
@@ -258,35 +303,40 @@ impl Agent {
             };
 
             // Use streaming if a callback is set, otherwise fall back to non-streaming.
+            // If an event sink is set, wrap it as the on_delta callback so that
+            // TextDelta events are emitted during streaming.
             let response = if let Some(ref cb) = self.on_text_delta {
                 self.llm.chat_stream(&request, cb.as_ref()).await?
+            } else if let Some(ref sink) = self.event_sink {
+                let sink_clone = sink.clone();
+                self.llm
+                    .chat_stream(&request, &move |delta: String| {
+                        sink_clone(AgentEvent::TextDelta(delta));
+                    })
+                    .await?
             } else {
                 self.llm.chat(&request).await?
             };
 
-            match response {
-                ChatResponse::Text(text) => {
-                    info!(iteration, "agent produced final text response");
-                    return Ok(text);
-                }
-                ChatResponse::ToolCalls(tool_calls) => {
-                    info!(iteration, count = tool_calls.len(), "LLM requested tool calls");
+            if response.has_tool_calls() {
+                let tool_calls = response.tool_calls.clone();
+                info!(iteration, count = tool_calls.len(), "LLM requested tool calls");
 
-                    // Add the assistant message with tool calls to history.
-                    let assistant_msg = ChatMessage {
-                        role: MessageRole::Assistant,
-                        content: String::new(),
-                        tool_calls: tool_calls.clone(),
-                        tool_call_id: None,
-                    };
-                    messages.push(assistant_msg);
+                // Add the assistant message with tool calls (and any preamble text) to history.
+                let assistant_msg = ChatMessage::assistant_with_tools(
+                    &response.text,
+                    tool_calls.clone(),
+                );
+                messages.push(assistant_msg);
 
-                    // Process each tool call.
-                    for tc in &tool_calls {
-                        let result = self.process_tool_call(tc).await?;
-                        messages.push(result);
-                    }
+                // Process each tool call.
+                for tc in &tool_calls {
+                    let result = self.process_tool_call(tc).await?;
+                    messages.push(result);
                 }
+            } else {
+                info!(iteration, "agent produced final text response");
+                return Ok(response.text);
             }
         }
 
@@ -300,6 +350,9 @@ impl Agent {
 
     /// Process a single tool call: parse, confirm, execute, and return the
     /// tool result message.
+    ///
+    /// Emits [`AgentEvent::CommandProposed`] before confirmation and
+    /// [`AgentEvent::CommandFinished`] after execution (or denial).
     async fn process_tool_call(&self, tc: &ToolCall) -> Result<ChatMessage> {
         // Parse the tool call.
         let parsed = match tools::parse_tool_call(&tc.id, &tc.name, &tc.arguments) {
@@ -324,9 +377,21 @@ impl Agent {
 
         let destructive = security::is_destructive(&parsed.command);
 
+        // Emit CommandProposed before any confirmation logic.
+        self.emit(AgentEvent::CommandProposed {
+            command: parsed.command.clone(),
+            explanation: parsed.explanation.clone(),
+            destructive,
+        });
+
         match decision {
             ConfirmDecision::Blocked(reason) => {
                 warn!(command = %parsed.command, reason = %reason, "command blocked by security");
+                self.emit(AgentEvent::CommandFinished {
+                    command: parsed.command.clone(),
+                    output: format!("blocked by security policy: {reason}"),
+                    denied: true,
+                });
                 return Ok(ChatMessage::tool(
                     &tc.id,
                     format!("Error: command blocked by security policy: {reason}"),
@@ -343,6 +408,11 @@ impl Agent {
 
                 if !approved {
                     info!(command = %parsed.command, "command denied by user");
+                    self.emit(AgentEvent::CommandFinished {
+                        command: parsed.command.clone(),
+                        output: String::new(),
+                        denied: true,
+                    });
                     return Ok(ChatMessage::tool(
                         &tc.id,
                         "Command denied by user. Try a different approach.".to_string(),
@@ -357,6 +427,11 @@ impl Agent {
             Ok(o) => o,
             Err(e) => {
                 warn!(command = %parsed.command, error = %e, "tool execution failed");
+                self.emit(AgentEvent::CommandFinished {
+                    command: parsed.command.clone(),
+                    output: format!("Error: {e}"),
+                    denied: false,
+                });
                 return Ok(ChatMessage::tool(
                     &tc.id,
                     format!("Error executing command: {e}"),
@@ -366,6 +441,12 @@ impl Agent {
 
         // Truncate output if too long.
         let truncated = self.truncate_output(&output);
+
+        self.emit(AgentEvent::CommandFinished {
+            command: parsed.command.clone(),
+            output: truncated.clone(),
+            denied: false,
+        });
 
         Ok(ChatMessage::tool(&tc.id, truncated))
     }
@@ -392,6 +473,7 @@ impl Agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ChatResponse;
     use filar_transport::CommandResult;
     use std::time::Duration;
 
@@ -420,7 +502,7 @@ mod tests {
             if idx < self.responses.len() {
                 Ok(self.responses[idx].clone())
             } else {
-                Ok(ChatResponse::Text("No more responses.".into()))
+                Ok(ChatResponse::text("No more responses."))
             }
         }
     }
@@ -465,7 +547,7 @@ mod tests {
 
     #[tokio::test]
     async fn agent_text_response() {
-        let llm = Arc::new(MockLlm::new(vec![ChatResponse::Text("Hello!".into())]));
+        let llm = Arc::new(MockLlm::new(vec![ChatResponse::text("Hello!")]));
         let executor = Arc::new(MockExecutor {
             last_command: std::sync::Mutex::new(String::new()),
         });
@@ -485,7 +567,7 @@ mod tests {
     #[tokio::test]
     async fn agent_tool_call_then_text() {
         // First response: tool call. Second response: text.
-        let tool_call = ChatResponse::ToolCalls(vec![ToolCall {
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
             id: "call_1".into(),
             name: "run_command".into(),
             arguments: serde_json::json!({
@@ -496,7 +578,7 @@ mod tests {
 
         let llm = Arc::new(MockLlm::new(vec![
             tool_call,
-            ChatResponse::Text("Done! The output was: output of: echo hello".into()),
+            ChatResponse::text("Done! The output was: output of: echo hello"),
         ]));
 
         let executor = Arc::new(MockExecutor {
@@ -518,7 +600,7 @@ mod tests {
 
     #[tokio::test]
     async fn agent_tool_call_denied() {
-        let tool_call = ChatResponse::ToolCalls(vec![ToolCall {
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
             id: "call_1".into(),
             name: "run_command".into(),
             arguments: serde_json::json!({
@@ -529,7 +611,7 @@ mod tests {
 
         let llm = Arc::new(MockLlm::new(vec![
             tool_call,
-            ChatResponse::Text("Okay, I won't delete anything.".into()),
+            ChatResponse::text("Okay, I won't delete anything."),
         ]));
 
         let executor = Arc::new(MockExecutor {
@@ -552,7 +634,7 @@ mod tests {
     #[tokio::test]
     async fn agent_tool_call_auto_approved() {
         // In Allowlist mode, read-only commands are auto-approved (no confirmer call).
-        let tool_call = ChatResponse::ToolCalls(vec![ToolCall {
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
             id: "call_1".into(),
             name: "run_command".into(),
             arguments: serde_json::json!({
@@ -563,7 +645,7 @@ mod tests {
 
         let llm = Arc::new(MockLlm::new(vec![
             tool_call,
-            ChatResponse::Text("Files listed.".into()),
+            ChatResponse::text("Files listed."),
         ]));
 
         let executor = Arc::new(MockExecutor {
@@ -587,7 +669,7 @@ mod tests {
     #[tokio::test]
     async fn agent_max_iterations() {
         // Always return a tool call — never produce text.
-        let tool_call = ChatResponse::ToolCalls(vec![ToolCall {
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
             id: "call_1".into(),
             name: "run_command".into(),
             arguments: serde_json::json!({
@@ -697,5 +779,112 @@ mod tests {
             prompt.contains("must NOT be translated"),
             "Prompt should state that command output is not translated, got: {prompt}"
         );
+    }
+
+    // ── Event sink tests ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn event_sink_sequence_tool_call() {
+        // DoD test: mock-LLM with one tool call → sink receives
+        // Started → CommandProposed → CommandFinished → Finished.
+        use std::sync::Mutex;
+
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
+            id: "call_1".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({
+                "command": "echo hello",
+                "explanation": "Print hello"
+            }),
+        }]);
+
+        let llm = Arc::new(MockLlm::new(vec![
+            tool_call,
+            ChatResponse::text("Done!"),
+        ]));
+
+        let executor = Arc::new(MockExecutor {
+            last_command: Mutex::new(String::new()),
+        });
+        let confirmer = Arc::new(MockConfirmer { approve: true });
+
+        // Collect events via an EventSink.
+        let events: Arc<Mutex<Vec<AgentEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let sink: EventSink = Arc::new(move |event: AgentEvent| {
+            events_clone.lock().unwrap().push(event);
+        });
+
+        let agent = Agent::builder()
+            .llm(llm)
+            .executor(executor)
+            .confirmer(confirmer)
+            .confirm_mode(CommandConfirmMode::Never)
+            .event_sink(sink)
+            .build()
+            .unwrap();
+
+        let result = agent.run("say hello", &[]).await.unwrap();
+        assert_eq!(result, "Done!");
+
+        let received = events.lock().unwrap();
+        assert_eq!(received.len(), 4, "expected 4 events, got {received:?}");
+
+        // Verify the event sequence.
+        assert!(matches!(&received[0], AgentEvent::Started), "first event should be Started, got {:?}", received[0]);
+        assert!(matches!(&received[1], AgentEvent::CommandProposed { command, .. } if command == "echo hello"),
+            "second event should be CommandProposed, got {:?}", received[1]);
+        assert!(matches!(&received[2], AgentEvent::CommandFinished { command, denied, .. } if command == "echo hello" && !denied),
+            "third event should be CommandFinished (not denied), got {:?}", received[2]);
+        assert!(matches!(&received[3], AgentEvent::Finished(text) if text == "Done!"),
+            "fourth event should be Finished, got {:?}", received[3]);
+    }
+
+    #[tokio::test]
+    async fn event_sink_denied_command() {
+        // When a command is denied, sink should receive CommandFinished with denied=true.
+        use std::sync::Mutex;
+
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
+            id: "call_1".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({
+                "command": "rm -rf /tmp",
+                "explanation": "Delete temp files"
+            }),
+        }]);
+
+        let llm = Arc::new(MockLlm::new(vec![
+            tool_call,
+            ChatResponse::text("Okay, I won't delete anything."),
+        ]));
+
+        let executor = Arc::new(MockExecutor {
+            last_command: Mutex::new(String::new()),
+        });
+        let confirmer = Arc::new(MockConfirmer { approve: false }); // Deny!
+
+        let events: Arc<Mutex<Vec<AgentEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let sink: EventSink = Arc::new(move |event: AgentEvent| {
+            events_clone.lock().unwrap().push(event);
+        });
+
+        let agent = Agent::builder()
+            .llm(llm)
+            .executor(executor)
+            .confirmer(confirmer)
+            .confirm_mode(CommandConfirmMode::Always)
+            .event_sink(sink)
+            .build()
+            .unwrap();
+
+        let _ = agent.run("delete temp files", &[]).await.unwrap();
+
+        let received = events.lock().unwrap();
+        // Started → CommandProposed → CommandFinished(denied=true) → Finished
+        assert_eq!(received.len(), 4, "expected 4 events, got {received:?}");
+        assert!(matches!(&received[2], AgentEvent::CommandFinished { denied: true, .. }),
+            "third event should be CommandFinished with denied=true, got {:?}", received[2]);
     }
 }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -302,16 +302,19 @@ impl Agent {
                 tools: tool_defs.clone(),
             };
 
-            // Use streaming if a callback is set, otherwise fall back to non-streaming.
-            // If an event sink is set, wrap it as the on_delta callback so that
-            // TextDelta events are emitted during streaming.
-            let response = if let Some(ref cb) = self.on_text_delta {
-                self.llm.chat_stream(&request, cb.as_ref()).await?
-            } else if let Some(ref sink) = self.event_sink {
-                let sink_clone = sink.clone();
+            // Use streaming if either callback is set, otherwise fall back to non-streaming.
+            // Both on_text_delta and event_sink can fire simultaneously.
+            let response = if self.on_text_delta.is_some() || self.event_sink.is_some() {
+                let cb = self.on_text_delta.clone();
+                let sink = self.event_sink.clone();
                 self.llm
                     .chat_stream(&request, &move |delta: String| {
-                        sink_clone(AgentEvent::TextDelta(delta));
+                        if let Some(ref cb) = cb {
+                            cb(delta.clone());
+                        }
+                        if let Some(ref sink) = sink {
+                            sink(AgentEvent::TextDelta(delta));
+                        }
                     })
                     .await?
             } else {
@@ -387,11 +390,9 @@ impl Agent {
         match decision {
             ConfirmDecision::Blocked(reason) => {
                 warn!(command = %parsed.command, reason = %reason, "command blocked by security");
-                self.emit(AgentEvent::CommandFinished {
-                    command: parsed.command.clone(),
-                    output: format!("blocked by security policy: {reason}"),
-                    denied: true,
-                });
+                // No CommandFinished event for blocked commands: blocked is not a
+                // user denial, and the TUI should not show a command block for it.
+                // The block reason is sent back to the LLM as tool context.
                 return Ok(ChatMessage::tool(
                     &tc.id,
                     format!("Error: command blocked by security policy: {reason}"),

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -1,0 +1,63 @@
+//! UI-agnostic agent events for external frontends.
+//!
+//! The [`AgentEvent`] enum is the public event contract between the agent
+//! loop and any frontend (TUI, Telegram bot, mobile app).  It is emitted via
+//! an [`EventSink`] — a simple callback closure set on [`AgentBuilder`].
+//!
+//! Frontends MUST handle the `_` catch-all arm because the enum is
+//! `#[non_exhaustive]` — new variants may be added in future versions
+//! without a breaking change.
+
+use std::sync::Arc;
+
+/// Events emitted by the agent during its processing loop.
+///
+/// This enum is **public API** — external frontends (Telegram bot, mobile
+/// app) depend on it.  The `#[non_exhaustive]` attribute ensures that
+/// frontends handle unknown variants gracefully.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum AgentEvent {
+    /// The agent started processing a user prompt.
+    Started,
+
+    /// A text chunk arrived during LLM streaming.
+    ///
+    /// The frontend should append this to the current streaming text block.
+    TextDelta(String),
+
+    /// The agent wants to execute a command and may need user confirmation.
+    ///
+    /// Emitted **before** the confirmer is called.  The frontend can use
+    /// this to show a pending command block or update UI state.
+    CommandProposed {
+        /// The command to execute.
+        command: String,
+        /// Human-readable explanation of what the command does.
+        explanation: String,
+        /// Whether the command is flagged as destructive.
+        destructive: bool,
+    },
+
+    /// A command was executed (or denied by the user).
+    CommandFinished {
+        /// The command that was processed.
+        command: String,
+        /// Command output (empty if denied).
+        output: String,
+        /// `true` if the user denied the command.
+        denied: bool,
+    },
+
+    /// The agent finished and produced a final answer.
+    Finished(String),
+
+    /// The agent encountered an error (network, LLM, transport).
+    Error(String),
+}
+
+/// A callback for delivering [`AgentEvent`]s to a frontend.
+///
+/// Set via [`AgentBuilder::event_sink`](crate::AgentBuilder::event_sink).
+/// If not set, events are silently dropped (no-op).
+pub type EventSink = Arc<dyn Fn(AgentEvent) + Send + Sync>;

--- a/crates/agent/src/glm.rs
+++ b/crates/agent/src/glm.rs
@@ -562,13 +562,16 @@ impl ApiResponse {
                         }
                     })
                     .collect();
-                return Ok(ChatResponse::ToolCalls(parsed));
+                return Ok(ChatResponse::tool_calls(
+                    choice.message.content.unwrap_or_default(),
+                    parsed,
+                ));
             }
         }
 
         // Otherwise, return the text content.
         let text = choice.message.content.unwrap_or_default();
-        Ok(ChatResponse::Text(text))
+        Ok(ChatResponse::text(text))
     }
 }
 
@@ -727,9 +730,9 @@ impl SseState {
                     }
                 })
                 .collect();
-            Ok(ChatResponse::ToolCalls(calls))
+            Ok(ChatResponse::tool_calls(self.full_text, calls))
         } else {
-            Ok(ChatResponse::Text(self.full_text))
+            Ok(ChatResponse::text(self.full_text))
         }
     }
 }
@@ -805,10 +808,8 @@ mod tests {
         });
         let resp: ApiResponse = serde_json::from_value(raw).unwrap();
         let result = resp.try_into_chat_response().unwrap();
-        match result {
-            ChatResponse::Text(text) => assert_eq!(text, "Hello! How can I help?"),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!result.has_tool_calls(), "expected Text response");
+        assert_eq!(result.text, "Hello! How can I help?");
     }
 
     #[test]
@@ -832,15 +833,12 @@ mod tests {
         });
         let resp: ApiResponse = serde_json::from_value(raw).unwrap();
         let result = resp.try_into_chat_response().unwrap();
-        match result {
-            ChatResponse::ToolCalls(calls) => {
-                assert_eq!(calls.len(), 1);
-                assert_eq!(calls[0].id, "call_abc123");
-                assert_eq!(calls[0].name, "run_command");
-                assert_eq!(calls[0].arguments["command"], "ls -la");
-            }
-            _ => panic!("expected ToolCalls response"),
-        }
+        assert!(result.has_tool_calls(), "expected ToolCalls response");
+        let calls = &result.tool_calls;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_abc123");
+        assert_eq!(calls[0].name, "run_command");
+        assert_eq!(calls[0].arguments["command"], "ls -la");
     }
 
     #[test]
@@ -868,14 +866,11 @@ mod tests {
         });
         let resp: ApiResponse = serde_json::from_value(raw).unwrap();
         let result = resp.try_into_chat_response().unwrap();
-        match result {
-            ChatResponse::ToolCalls(calls) => {
-                assert_eq!(calls.len(), 2);
-                assert_eq!(calls[0].name, "list_dir");
-                assert_eq!(calls[1].name, "run_command");
-            }
-            _ => panic!("expected ToolCalls response"),
-        }
+        assert!(result.has_tool_calls(), "expected ToolCalls response");
+        let calls = &result.tool_calls;
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "list_dir");
+        assert_eq!(calls[1].name, "run_command");
     }
 
     #[test]
@@ -908,13 +903,9 @@ mod tests {
         };
 
         let response = client.chat(&request).await.expect("chat request failed");
-        match response {
-            ChatResponse::Text(text) => {
-                assert!(!text.is_empty(), "response text should not be empty");
-                println!("Smoke test text response: {text}");
-            }
-            _ => panic!("expected Text response, got ToolCalls"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response, got ToolCalls");
+        assert!(!response.text.is_empty(), "response text should not be empty");
+        println!("Smoke test text response: {}", response.text);
     }
 
     #[cfg(feature = "smoke")]
@@ -950,15 +941,12 @@ mod tests {
         };
 
         let response = client.chat(&request).await.expect("chat request failed");
-        match response {
-            ChatResponse::ToolCalls(calls) => {
-                assert!(!calls.is_empty(), "expected at least one tool call");
-                println!("Smoke test tool call: {} → {}", calls[0].name, calls[0].arguments);
-            }
-            ChatResponse::Text(text) => {
-                // Some models may answer in text instead of calling a tool.
-                println!("Model responded with text instead of tool call: {text}");
-            }
+        if response.has_tool_calls() {
+            assert!(!response.tool_calls.is_empty(), "expected at least one tool call");
+            println!("Smoke test tool call: {} → {}", response.tool_calls[0].name, response.tool_calls[0].arguments);
+        } else {
+            // Some models may answer in text instead of calling a tool.
+            println!("Model responded with text instead of tool call: {}", response.text);
         }
     }
 
@@ -989,10 +977,8 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         assert!(state.done);
 
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert_eq!(text, "Hello world"),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert_eq!(response.text, "Hello world");
     }
 
     #[test]
@@ -1015,15 +1001,12 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         state.process_chunk("data: [DONE]\n\n");
 
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::ToolCalls(calls) => {
-                assert_eq!(calls.len(), 1);
-                assert_eq!(calls[0].id, "call_1");
-                assert_eq!(calls[0].name, "run_command");
-                assert_eq!(calls[0].arguments["command"], "ls");
-            }
-            _ => panic!("expected ToolCalls response"),
-        }
+        assert!(response.has_tool_calls(), "expected ToolCalls response");
+        let calls = &response.tool_calls;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].name, "run_command");
+        assert_eq!(calls[0].arguments["command"], "ls");
     }
 
     #[test]
@@ -1039,16 +1022,13 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         state.process_chunk("data: [DONE]\n\n");
 
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::ToolCalls(calls) => {
-                assert_eq!(calls.len(), 2);
-                assert_eq!(calls[0].id, "c1");
-                assert_eq!(calls[0].name, "run_command");
-                assert_eq!(calls[1].id, "c2");
-                assert_eq!(calls[1].name, "list_dir");
-            }
-            _ => panic!("expected ToolCalls response"),
-        }
+        assert!(response.has_tool_calls(), "expected ToolCalls response");
+        let calls = &response.tool_calls;
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].id, "c1");
+        assert_eq!(calls[0].name, "run_command");
+        assert_eq!(calls[1].id, "c2");
+        assert_eq!(calls[1].name, "list_dir");
     }
 
     #[test]
@@ -1066,25 +1046,22 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         );
         state.process_chunk("data: [DONE]\n\n");
 
-        // Final response is ToolCalls (tool_calls take precedence).
+        // Final response has tool_calls (tool_calls take precedence).
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::ToolCalls(calls) => {
-                assert_eq!(calls.len(), 1);
-                assert_eq!(calls[0].name, "run_command");
-            }
-            _ => panic!("expected ToolCalls response"),
-        }
+        assert!(response.has_tool_calls(), "expected ToolCalls response");
+        let calls = &response.tool_calls;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "run_command");
+        // The text preamble should be preserved.
+        assert_eq!(response.text, "Let me check.");
     }
 
     #[test]
     fn sse_parse_empty_stream() {
         let state = SseState::new();
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert!(text.is_empty()),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert!(response.text.is_empty());
     }
 
     #[test]
@@ -1111,10 +1088,8 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         state.process_chunk("data: not-json\n\n");
         state.process_chunk("data: [DONE]\n\n");
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert!(text.is_empty()),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert!(response.text.is_empty());
     }
 
     #[test]
@@ -1126,10 +1101,8 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         assert!(d1.is_empty(), "no complete line yet");
         state.process_chunk("\"}}]}\n\n");
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert_eq!(text, "Hi"),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert_eq!(response.text, "Hi");
     }
 
     #[test]
@@ -1151,10 +1124,8 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         let d3 = state.flush();
         assert_eq!(&d3, &["end".to_string()]);
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert_eq!(text, "Helloend"),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert_eq!(response.text, "Helloend");
     }
 
     #[test]
@@ -1171,10 +1142,8 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         assert!(deltas.is_empty(), "[DONE] produces no text deltas");
         assert!(state.done, "flush should set done flag");
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert_eq!(text, "ok"),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert_eq!(response.text, "ok");
     }
 
     #[test]
@@ -1184,10 +1153,8 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         let deltas = state.flush();
         assert!(deltas.is_empty());
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert!(text.is_empty()),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert!(response.text.is_empty());
     }
 
     #[test]
@@ -1224,9 +1191,7 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
 
         assert_eq!(&collected_deltas, &["end".to_string()]);
         let response = state.into_response().unwrap();
-        match response {
-            ChatResponse::Text(text) => assert_eq!(text, "end"),
-            _ => panic!("expected Text response"),
-        }
+        assert!(!response.has_tool_calls(), "expected Text response");
+        assert_eq!(response.text, "end");
     }
 }

--- a/crates/agent/src/glm.rs
+++ b/crates/agent/src/glm.rs
@@ -905,7 +905,6 @@ mod tests {
         let response = client.chat(&request).await.expect("chat request failed");
         assert!(!response.has_tool_calls(), "expected Text response, got ToolCalls");
         assert!(!response.text.is_empty(), "response text should not be empty");
-        println!("Smoke test text response: {}", response.text);
     }
 
     #[cfg(feature = "smoke")]
@@ -943,10 +942,6 @@ mod tests {
         let response = client.chat(&request).await.expect("chat request failed");
         if response.has_tool_calls() {
             assert!(!response.tool_calls.is_empty(), "expected at least one tool call");
-            println!("Smoke test tool call: {} → {}", response.tool_calls[0].name, response.tool_calls[0].arguments);
-        } else {
-            // Some models may answer in text instead of calling a tool.
-            println!("Model responded with text instead of tool call: {}", response.text);
         }
     }
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -7,12 +7,14 @@
 //! - Security layer: confirmation, destructive command detection (Stage 5).
 
 pub mod agent;
+pub mod events;
 pub mod glm;
 pub mod security;
 pub mod tools;
 
 // Re-export key types for convenience.
 pub use agent::{Agent, AgentBuilder};
+pub use events::{AgentEvent, EventSink};
 pub use security::{CliConfirmer, CommandConfirmer, ConfirmDecision};
 pub use tools::{tool_definitions, ToolKind};
 
@@ -162,13 +164,41 @@ pub struct ToolDef {
     pub parameters: serde_json::Value,
 }
 
-/// The model's response — either text or one or more tool calls.
+/// The model's response, containing both text and optional tool calls.
+///
+/// Both fields are always present — `text` may be empty when the model only
+/// requests tool calls, and `tool_calls` is empty for a plain text response.
+/// This ensures the streaming preamble is preserved in conversation history
+/// even when the model follows it with tool calls.
 #[derive(Debug, Clone)]
-pub enum ChatResponse {
-    /// The model produced a text response.
-    Text(String),
-    /// The model wants to call one or more tools.
-    ToolCalls(Vec<ToolCall>),
+pub struct ChatResponse {
+    /// Text content of the response (may be empty for pure tool calls).
+    pub text: String,
+    /// Tool calls requested by the model (empty for a final text response).
+    pub tool_calls: Vec<ToolCall>,
+}
+
+impl ChatResponse {
+    /// Create a text-only response.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            tool_calls: Vec::new(),
+        }
+    }
+
+    /// Create a tool-call response with optional preamble text.
+    pub fn tool_calls(text: impl Into<String>, tool_calls: Vec<ToolCall>) -> Self {
+        Self {
+            text: text.into(),
+            tool_calls,
+        }
+    }
+
+    /// Returns `true` if the response contains tool calls.
+    pub fn has_tool_calls(&self) -> bool {
+        !self.tool_calls.is_empty()
+    }
 }
 
 // Re-export async_trait.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -233,6 +233,11 @@ pub struct App {
     /// Whether the agent is currently streaming a text response.
     /// When true, `TextDelta` events append to the last `Agent` block.
     pub streaming: bool,
+    /// Pending command proposal metadata from `CommandProposed`:
+    /// `(command, explanation)`. Used to preserve the explanation when
+    /// `CommandFinished` arrives for auto-approved commands (which never
+    /// triggered a `ConfirmationRequest` dialog).
+    pub pending_proposal: Option<(String, String)>,
     /// Spinner animation tick counter — incremented each render frame
     /// while in `Thinking` mode.
     pub tick: u64,
@@ -298,6 +303,7 @@ impl App {
             hovered_button: None,
             collapsed_overrides: HashMap::new(),
             streaming: false,
+            pending_proposal: None,
             tick: 0,
             helpbar_zones: Vec::new(),
             input_scroll_offset: 0,
@@ -1426,15 +1432,24 @@ impl App {
                     // If the user scrolled up, don’t yank them down.
                     auto_scroll = self.scroll == 0;
                 }
-                filar_agent::AgentEvent::CommandProposed { .. } => {
-                    // Informational — the TUI shows commands via
-                    // ConfirmationRequest or CommandFinished. No action needed.
+                filar_agent::AgentEvent::CommandProposed { command, explanation, .. } => {
+                    // Store proposal metadata so CommandFinished can preserve
+                    // the explanation for auto-approved commands (which never
+                    // go through ConfirmationRequest).
+                    self.pending_proposal = Some((command, explanation));
                 }
                 filar_agent::AgentEvent::CommandFinished { command, output, denied } => {
                     if !denied {
                         // Finalize any streaming text before showing command output.
                         self.streaming = false;
                         auto_scroll = self.scroll == 0;
+                        // Retrieve stored explanation from CommandProposed (if any).
+                        let explanation = self
+                            .pending_proposal
+                            .as_ref()
+                            .filter(|(cmd, _)| *cmd == command)
+                            .map(|(_, expl)| expl.clone())
+                            .unwrap_or_default();
                         // Try to update the last matching Command block with output.
                         let mut updated = false;
                         if let Some(ChatBlock::Command {
@@ -1455,12 +1470,14 @@ impl App {
                         if !updated {
                             self.push_message(ChatBlock::Command {
                                 command,
-                                explanation: String::new(),
+                                explanation,
                                 output: Some(output),
                                 approved: true,
                             });
                         }
                     }
+                    // Clear the pending proposal regardless — the command is done.
+                    self.pending_proposal = None;
                     // For denied commands, the command block was already pushed
                     // by respond_to_confirmation (if confirmation was needed).
                     // For blocked commands, no block is shown — matching old behavior.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -8,7 +8,7 @@ use tokio::sync::oneshot;
 use filar_core::{ChatBlock, CommandConfirmMode};
 use ratatui::layout::Rect;
 
-use crate::event::AgentEvent;
+use crate::event::TuiEvent;
 use crate::terminal::{key_to_bytes, TerminalModel};
 use crate::ui::layout_cache::ChatLayoutCache;
 use crate::ui::Theme;
@@ -1401,34 +1401,106 @@ impl App {
         frames[(self.tick as usize) % frames.len()]
     }
 
-    /// Handle an agent event.
-    pub fn handle_agent_event(&mut self, event: AgentEvent) {
+    /// Handle a TUI event (forwarded agent event or TUI-specific event).
+    pub fn handle_agent_event(&mut self, event: TuiEvent) {
         let mut auto_scroll = true;
         match event {
-            AgentEvent::Started | AgentEvent::Thinking => {
-                self.mode = AppMode::Thinking;
-            }
-            AgentEvent::TextDelta(s) => {
-                // Append to the last Agent block if streaming, else create new.
-                if self.streaming {
-                    if let Some(ChatBlock::Agent(ref mut text)) = self.messages.last_mut() {
-                        text.push_str(&s);
+            TuiEvent::Agent(agent_event) => match agent_event {
+                filar_agent::AgentEvent::Started => {
+                    self.mode = AppMode::Thinking;
+                }
+                filar_agent::AgentEvent::TextDelta(s) => {
+                    // Append to the last Agent block if streaming, else create new.
+                    if self.streaming {
+                        if let Some(ChatBlock::Agent(ref mut text)) = self.messages.last_mut() {
+                            text.push_str(&s);
+                        } else {
+                            self.push_message(ChatBlock::Agent(s));
+                        }
                     } else {
                         self.push_message(ChatBlock::Agent(s));
+                        self.streaming = true;
                     }
-                } else {
-                    self.push_message(ChatBlock::Agent(s));
-                    self.streaming = true;
+                    self.message_rev = self.message_rev.wrapping_add(1);
+                    // Only auto-scroll if already at bottom.
+                    // If the user scrolled up, don’t yank them down.
+                    auto_scroll = self.scroll == 0;
                 }
-                self.message_rev = self.message_rev.wrapping_add(1);
-                // Only auto-scroll if already at bottom.
-                // If the user scrolled up, don’t yank them down.
-                auto_scroll = self.scroll == 0;
+                filar_agent::AgentEvent::CommandProposed { .. } => {
+                    // Informational — the TUI shows commands via
+                    // ConfirmationRequest or CommandFinished. No action needed.
+                }
+                filar_agent::AgentEvent::CommandFinished { command, output, denied } => {
+                    if !denied {
+                        // Finalize any streaming text before showing command output.
+                        self.streaming = false;
+                        auto_scroll = self.scroll == 0;
+                        // Try to update the last matching Command block with output.
+                        let mut updated = false;
+                        if let Some(ChatBlock::Command {
+                            command: ref cmd,
+                            output: ref mut o,
+                            approved: ref mut a,
+                            ..
+                        }) = self.messages.last_mut()
+                        {
+                            if *cmd == command && o.is_none() {
+                                *o = Some(output.clone());
+                                *a = true;
+                                updated = true;
+                                // Bump rev so the cache rebuilds with updated output.
+                                self.message_rev = self.message_rev.wrapping_add(1);
+                            }
+                        }
+                        if !updated {
+                            self.push_message(ChatBlock::Command {
+                                command,
+                                explanation: String::new(),
+                                output: Some(output),
+                                approved: true,
+                            });
+                        }
+                    }
+                    // For denied commands, the command block was already pushed
+                    // by respond_to_confirmation (if confirmation was needed).
+                    // For blocked commands, no block is shown — matching old behavior.
+                }
+                filar_agent::AgentEvent::Finished(text) => {
+                    // Finalize streaming block with authoritative text.
+                    if self.streaming {
+                        if !text.is_empty() {
+                            if let Some(ChatBlock::Agent(ref mut existing)) = self.messages.last_mut() {
+                                *existing = text;
+                                self.message_rev = self.message_rev.wrapping_add(1);
+                            } else {
+                                self.push_message(ChatBlock::Agent(text));
+                            }
+                        }
+                        self.streaming = false;
+                        auto_scroll = self.scroll == 0;
+                    } else if !text.is_empty() {
+                        self.push_message(ChatBlock::Agent(text));
+                    }
+                    self.mode = AppMode::Normal;
+                    self.agent_running = false;
+                }
+                filar_agent::AgentEvent::Error(err) => {
+                    // If streaming was interrupted, mark it.
+                    if self.streaming {
+                        self.push_message(ChatBlock::System("response interrupted".into()));
+                        self.streaming = false;
+                        auto_scroll = self.scroll == 0;
+                    }
+                    self.push_message(ChatBlock::Error(err));
+                    self.mode = AppMode::Normal;
+                    self.agent_running = false;
+                }
+                _ => {} // non_exhaustive: ignore unknown agent events
             }
-            AgentEvent::TextResponse(text) => {
-                self.push_message(ChatBlock::Agent(text));
+            TuiEvent::Thinking => {
+                self.mode = AppMode::Thinking;
             }
-            AgentEvent::ConfirmationRequest {
+            TuiEvent::ConfirmationRequest {
                 command,
                 explanation,
                 destructive,
@@ -1447,71 +1519,7 @@ impl App {
                 // Reset selection to safe default (Deny).
                 self.confirm_selected = false;
             }
-            AgentEvent::CommandExecuted {
-                command,
-                output,
-                approved,
-            } => {
-                // Finalize any streaming text before showing command output.
-                self.streaming = false;
-                auto_scroll = self.scroll == 0;
-                // Try to update the last matching Command block with output.
-                let mut updated = false;
-                if let Some(ChatBlock::Command {
-                    command: ref cmd,
-                    output: ref mut o,
-                    approved: ref mut a,
-                    ..
-                }) = self.messages.last_mut()
-                {
-                    if *cmd == command && o.is_none() {
-                        *o = Some(output.clone());
-                        *a = approved;
-                        updated = true;
-                        // Bump rev so the cache rebuilds with updated output.
-                        self.message_rev = self.message_rev.wrapping_add(1);
-                    }
-                }
-                if !updated {
-                    self.push_message(ChatBlock::Command {
-                        command,
-                        explanation: String::new(),
-                        output: Some(output),
-                        approved,
-                    });
-                }
-            }
-            AgentEvent::Finished(text) => {
-                // Finalize streaming block with authoritative text.
-                if self.streaming {
-                    if !text.is_empty() {
-                        if let Some(ChatBlock::Agent(ref mut existing)) = self.messages.last_mut() {
-                            *existing = text;
-                            self.message_rev = self.message_rev.wrapping_add(1);
-                        } else {
-                            self.push_message(ChatBlock::Agent(text));
-                        }
-                    }
-                    self.streaming = false;
-                    auto_scroll = self.scroll == 0;
-                } else if !text.is_empty() {
-                    self.push_message(ChatBlock::Agent(text));
-                }
-                self.mode = AppMode::Normal;
-                self.agent_running = false;
-            }
-            AgentEvent::Error(err) => {
-                // If streaming was interrupted, mark it.
-                if self.streaming {
-                    self.push_message(ChatBlock::System("response interrupted".into()));
-                    self.streaming = false;
-                    auto_scroll = self.scroll == 0;
-                }
-                self.push_message(ChatBlock::Error(err));
-                self.mode = AppMode::Normal;
-                self.agent_running = false;
-            }
-            AgentEvent::TransportChanged { .. } => {
+            TuiEvent::TransportChanged { .. } => {
                 // Handled by the runner before reaching here — no-op.
             }
         }
@@ -1859,7 +1867,7 @@ mod tests {
     fn agent_text_response_bumps_message_rev() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let rev_before = app.message_rev;
-        app.handle_agent_event(AgentEvent::TextResponse("hello".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished("hello".into())));
         assert!(app.message_rev > rev_before);
     }
 
@@ -1867,7 +1875,7 @@ mod tests {
     fn agent_error_bumps_message_rev() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let rev_before = app.message_rev;
-        app.handle_agent_event(AgentEvent::Error("oops".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Error("oops".into())));
         assert!(app.message_rev > rev_before);
         assert_eq!(app.mode, AppMode::Normal);
     }
@@ -1884,11 +1892,11 @@ mod tests {
             approved: false,
         });
         let rev_before = app.message_rev;
-        app.handle_agent_event(AgentEvent::CommandExecuted {
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::CommandFinished {
             command: "ls".into(),
             output: "file1\nfile2".into(),
-            approved: true,
-        });
+            denied: false,
+        }));
         assert!(app.message_rev > rev_before, "in-place update must bump rev");
         // Verify the block was updated in-place, not duplicated.
         assert_eq!(app.messages.len(), 2); // system + command (updated)
@@ -2531,7 +2539,7 @@ mod tests {
         assert!(app.confirm_selected);
         // Simulate a new confirmation request.
         let (tx, _rx) = oneshot::channel::<bool>();
-        app.handle_agent_event(AgentEvent::ConfirmationRequest {
+        app.handle_agent_event(TuiEvent::ConfirmationRequest {
             command: "ls".into(),
             explanation: "list".into(),
             destructive: false,
@@ -2858,7 +2866,7 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(AgentEvent::TextDelta("Hello".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Hello".into())));
 
         assert!(app.streaming);
         assert_eq!(app.messages.len(), 1);
@@ -2874,8 +2882,8 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(AgentEvent::TextDelta("Hello".into()));
-        app.handle_agent_event(AgentEvent::TextDelta(" world".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Hello".into())));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta(" world".into())));
 
         assert!(app.streaming);
         assert_eq!(app.messages.len(), 1);
@@ -2892,14 +2900,14 @@ mod tests {
         app.mode = AppMode::Thinking;
 
         // Stream some text.
-        app.handle_agent_event(AgentEvent::TextDelta("Partial".into()));
-        app.handle_agent_event(AgentEvent::TextDelta(" response".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Partial".into())));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta(" response".into())));
         assert!(app.streaming);
 
         // Finished replaces with authoritative text.
-        app.handle_agent_event(AgentEvent::Finished(
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished(
             "Partial response — finalized".into(),
-        ));
+        )));
 
         assert!(!app.streaming);
         assert_eq!(app.mode, AppMode::Normal);
@@ -2916,8 +2924,8 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(AgentEvent::TextDelta("Streamed text".into()));
-        app.handle_agent_event(AgentEvent::Finished(String::new()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Streamed text".into())));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished(String::new())));
 
         assert!(!app.streaming);
         assert_eq!(app.messages.len(), 1);
@@ -2933,10 +2941,10 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(AgentEvent::TextDelta("Partial".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Partial".into())));
         assert!(app.streaming);
 
-        app.handle_agent_event(AgentEvent::Error("network error".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Error("network error".into())));
 
         assert!(!app.streaming);
         assert_eq!(app.mode, AppMode::Normal);
@@ -2952,11 +2960,11 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(AgentEvent::TextDelta("Let me check...".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Let me check...".into())));
         assert!(app.streaming);
 
         let (tx, _rx) = oneshot::channel::<bool>();
-        app.handle_agent_event(AgentEvent::ConfirmationRequest {
+        app.handle_agent_event(TuiEvent::ConfirmationRequest {
             command: "ls".into(),
             explanation: "list files".into(),
             destructive: false,
@@ -2974,7 +2982,7 @@ mod tests {
         app.mode = AppMode::Thinking;
         app.scroll = 5; // User scrolled up.
 
-        app.handle_agent_event(AgentEvent::TextDelta("new text".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("new text".into())));
 
         // Scroll should NOT be reset to 0 — user is reading history.
         assert_eq!(app.scroll, 5);
@@ -2987,7 +2995,7 @@ mod tests {
         app.mode = AppMode::Thinking;
         app.scroll = 0;
 
-        app.handle_agent_event(AgentEvent::TextDelta("new text".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("new text".into())));
 
         // Scroll stays at 0 (bottom).
         assert_eq!(app.scroll, 0);
@@ -3015,13 +3023,13 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(AgentEvent::TextDelta("First".into()));
-        app.handle_agent_event(AgentEvent::Finished("First".into()));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("First".into())));
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished("First".into())));
         assert!(!app.streaming);
 
         // New run.
-        app.handle_agent_event(AgentEvent::Thinking);
-        app.handle_agent_event(AgentEvent::TextDelta("Second".into()));
+        app.handle_agent_event(TuiEvent::Thinking);
+        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Second".into())));
 
         assert!(app.streaming);
         assert_eq!(app.messages.len(), 2);

--- a/crates/tui/src/confirmer.rs
+++ b/crates/tui/src/confirmer.rs
@@ -10,16 +10,16 @@ use tracing::debug;
 use filar_agent::CommandConfirmer;
 use filar_core::{CoreError, Result};
 
-use crate::event::AgentEvent;
+use crate::event::TuiEvent;
 
 /// A [`CommandConfirmer`] that delegates to the TUI via channels.
 pub struct TuiConfirmer {
-    event_tx: mpsc::UnboundedSender<AgentEvent>,
+    event_tx: mpsc::UnboundedSender<TuiEvent>,
 }
 
 impl TuiConfirmer {
     /// Create a new TUI confirmer that sends events to the given channel.
-    pub fn new(event_tx: mpsc::UnboundedSender<AgentEvent>) -> Self {
+    pub fn new(event_tx: mpsc::UnboundedSender<TuiEvent>) -> Self {
         Self { event_tx }
     }
 }
@@ -37,7 +37,7 @@ impl CommandConfirmer for TuiConfirmer {
         let (respond_tx, respond_rx) = oneshot::channel();
 
         self.event_tx
-            .send(AgentEvent::ConfirmationRequest {
+            .send(TuiEvent::ConfirmationRequest {
                 command: command.to_string(),
                 explanation: explanation.to_string(),
                 destructive,

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -1,26 +1,25 @@
-//! Event types for communication between the agent and the TUI.
+﻿//! Event types for communication between the agent and the TUI.
 //!
 //! The agent runs in a separate tokio task and communicates with the UI
-//! via [`AgentEvent`] sent through an mpsc channel. Confirmation requests
-//! carry a [`oneshot::Sender`] so the UI can send back the user's decision.
+//! via [`TuiEvent`] sent through an mpsc channel. Agent events are forwarded
+//! from [`filar_agent::AgentEvent`] (emitted via the agent's `EventSink`),
+//! while TUI-specific events (confirmation requests, transport changes) are
+//! sent directly by TUI components.
 
 use tokio::sync::oneshot;
 
-/// Events sent from the agent task to the TUI.
+/// Events sent to the TUI.
+///
+/// Agent-originated events arrive as [`TuiEvent::Agent`] wrapping a
+/// [`filar_agent::AgentEvent`]. TUI-specific variants handle concerns that
+/// don't belong in the engine crate (oneshot channels, spinner state).
 #[derive(Debug)]
-pub enum AgentEvent {
-    /// The agent started processing a user prompt.
-    Started,
+pub enum TuiEvent {
+    /// Forwarded agent event (from the `EventSink`).
+    Agent(filar_agent::AgentEvent),
 
-    /// The agent is calling the LLM (thinking).
+    /// The agent is calling the LLM (thinking). TUI-specific: drives the spinner.
     Thinking,
-
-    /// A text chunk arrived during streaming.
-    /// The UI should append this to the current streaming agent block.
-    TextDelta(String),
-
-    /// The agent produced a text response.
-    TextResponse(String),
 
     /// The agent wants to execute a command and needs user confirmation.
     ///
@@ -32,19 +31,6 @@ pub enum AgentEvent {
         destructive: bool,
         respond_to: oneshot::Sender<bool>,
     },
-
-    /// A command was executed and produced output.
-    CommandExecuted {
-        command: String,
-        output: String,
-        approved: bool,
-    },
-
-    /// The agent finished and produced a final answer.
-    Finished(String),
-
-    /// The agent encountered an error.
-    Error(String),
 
     /// The transport was switched (e.g. from local to SSH).
     /// The runner uses this to update the system prompt for future agent calls.

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -17,7 +17,7 @@ pub mod ui;
 // Re-export key types.
 pub use app::{App, AppMode};
 pub use confirmer::TuiConfirmer;
-pub use event::AgentEvent;
+pub use event::TuiEvent;
 pub use runner::{run, TuiConfig};
 pub use terminal::{key_to_bytes, TerminalModel};
 pub use filar_core::ChatBlock;

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -23,7 +23,7 @@ use filar_transport::{CommandExecutor, InteractiveTerminal, LocalInteractive, Ss
 
 use crate::app::{App, AppMode};
 use crate::confirmer::TuiConfirmer;
-use crate::event::AgentEvent;
+use crate::event::TuiEvent;
 use crate::terminal::TerminalModel;
 use crate::ui;
 use filar_core::ChatBlock;
@@ -32,14 +32,15 @@ use filar_core::ChatBlock;
 // TuiExecutor — wraps an executor and emits events
 // ---------------------------------------------------------------------------
 
-/// A [`CommandExecutor`] wrapper that sends [`AgentEvent::CommandExecuted`]
-/// events to the TUI whenever a command is executed.
+/// A [`CommandExecutor`] wrapper that handles secret substitution and
+/// output sanitization.
 ///
 /// The inner executor is swappable at runtime, allowing the transport
 /// to switch from local to SSH (or vice versa) without restarting the app.
+/// Command execution events are emitted by the agent via `EventSink`, not
+/// by this wrapper.
 struct TuiExecutor {
     inner: Arc<tokio::sync::RwLock<Arc<dyn CommandExecutor>>>,
-    event_tx: mpsc::UnboundedSender<AgentEvent>,
     /// Shared secret variables for command substitution.
     secrets: Arc<Mutex<HashMap<String, String>>>,
 }
@@ -87,25 +88,6 @@ impl CommandExecutor for TuiExecutor {
                 }
             }
         }
-
-        // Build output string for the UI (also sanitized).
-        let mut output = result.stdout.clone();
-        if !result.stderr.is_empty() {
-            output.push_str("\n[stderr] ");
-            output.push_str(&result.stderr);
-        }
-        if let Some(code) = result.exit_code {
-            if code != 0 {
-                output.push_str(&format!("\n[exit code: {code}]"));
-            }
-        }
-
-        // Display the ORIGINAL command (with $FILAR_SECRET_N) in the UI.
-        let _ = self.event_tx.send(AgentEvent::CommandExecuted {
-            command: command.to_string(),
-            output,
-            approved: true,
-        });
 
         Ok(result)
     }
@@ -237,7 +219,7 @@ async fn run_app(
     };
 
     // Channel for agent → UI events.
-    let (agent_tx, mut agent_rx) = mpsc::unbounded_channel::<AgentEvent>();
+    let (agent_tx, mut agent_rx) = mpsc::unbounded_channel::<TuiEvent>();
 
     // Build SSH info string for the system prompt (e.g. "user@host:port").
     let mut ssh_info = config.ssh_target.as_ref().map(|t| {
@@ -251,7 +233,6 @@ async fn run_app(
     let confirmer = Arc::new(TuiConfirmer::new(agent_tx.clone()));
     let tui_executor = Arc::new(TuiExecutor {
         inner: Arc::new(tokio::sync::RwLock::new(executor)),
-        event_tx: agent_tx.clone(),
         secrets: shared_secrets,
     });
 
@@ -360,13 +341,39 @@ async fn run_app(
                             let exec = tui_executor.clone();
                             let tx = agent_tx.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = exec.run(&cmd).await {
-                                    let _ = tx.send(AgentEvent::Error(
-                                        format!("Shell command failed: {e}")
-                                    ));
+                                match exec.run(&cmd).await {
+                                    Ok(result) => {
+                                        // Build display output from CommandResult.
+                                        let mut output = result.stdout.clone();
+                                        if !result.stderr.is_empty() {
+                                            output.push_str("\n[stderr] ");
+                                            output.push_str(&result.stderr);
+                                        }
+                                        if let Some(code) = result.exit_code {
+                                            if code != 0 {
+                                                output.push_str(&format!("\n[exit code: {code}]"));
+                                            }
+                                        }
+                                        let _ = tx.send(TuiEvent::Agent(
+                                            filar_agent::AgentEvent::CommandFinished {
+                                                command: cmd.clone(),
+                                                output,
+                                                denied: false,
+                                            }
+                                        ));
+                                    }
+                                    Err(e) => {
+                                        let _ = tx.send(TuiEvent::Agent(
+                                            filar_agent::AgentEvent::Error(
+                                                format!("Shell command failed: {e}")
+                                            )
+                                        ));
+                                    }
                                 }
                                 // Signal completion to return to Normal mode.
-                                let _ = tx.send(AgentEvent::Finished(String::new()));
+                                let _ = tx.send(TuiEvent::Agent(
+                                    filar_agent::AgentEvent::Finished(String::new())
+                                ));
                             });
                         } else {
                             // Empty command after ! — just return to normal.
@@ -394,7 +401,7 @@ async fn run_app(
                         let tx = agent_tx.clone();
                         let exec_clone = tui_executor.clone();
                         tokio::spawn(async move {
-                            let _ = tx.send(AgentEvent::Thinking);
+                            let _ = tx.send(TuiEvent::Thinking);
                             let target = filar_core::SshTarget {
                                 name: "dynamic".into(),
                                 host: host.clone(),
@@ -414,19 +421,23 @@ async fn run_app(
                                         .await;
                                     // Notify runner to update system prompt info.
                                     let new_ssh_info = format!("{user}@{host}:{port}");
-                                    let _ = tx.send(AgentEvent::TransportChanged {
+                                    let _ = tx.send(TuiEvent::TransportChanged {
                                         is_local: false,
                                         ssh_info: Some(new_ssh_info),
                                     });
-                                    let _ = tx.send(AgentEvent::Finished(format!(
-                                        "Connected to {user}@{host}:{port} via SSH. \
-                                         You are now operating on the remote machine."
-                                    )));
+                                    let _ = tx.send(TuiEvent::Agent(
+                                        filar_agent::AgentEvent::Finished(format!(
+                                            "Connected to {user}@{host}:{port} via SSH. \
+                                             You are now operating on the remote machine."
+                                        ))
+                                    ));
                                 }
                                 Err(e) => {
-                                    let _ = tx.send(AgentEvent::Error(format!(
-                                        "SSH connection failed: {e}"
-                                    )));
+                                    let _ = tx.send(TuiEvent::Agent(
+                                        filar_agent::AgentEvent::Error(format!(
+                                            "SSH connection failed: {e}"
+                                        ))
+                                    ));
                                 }
                             }
                         });
@@ -441,14 +452,14 @@ async fn run_app(
             // Agent event (only when not in interactive mode).
             maybe_agent_event = async {
                 if in_interactive {
-                    std::future::pending::<Option<AgentEvent>>().await
+                    std::future::pending::<Option<TuiEvent>>().await
                 } else {
                     agent_rx.recv().await
                 }
             } => {
                 if let Some(event) = maybe_agent_event {
                     // Intercept TransportChanged to update system prompt info.
-                    if let AgentEvent::TransportChanged { is_local: new_local, ssh_info: new_ssh } = &event {
+                    if let TuiEvent::TransportChanged { is_local: new_local, ssh_info: new_ssh } = &event {
                         is_local = *new_local;
                         ssh_info = new_ssh.clone();
                         app.target_name = new_ssh.clone().unwrap_or_else(|| "local".into());
@@ -556,16 +567,15 @@ fn spawn_agent(
     confirm_mode: CommandConfirmMode,
     user_input: String,
     chat_history: Vec<ChatBlock>,
-    event_tx: mpsc::UnboundedSender<AgentEvent>,
+    event_tx: mpsc::UnboundedSender<TuiEvent>,
     is_local: bool,
     ssh_info: Option<String>,
 ) {
     let tx = event_tx.clone();
 
     tokio::spawn(async move {
-        // Notify UI that the agent started.
-        let _ = tx.send(AgentEvent::Started);
-        let _ = tx.send(AgentEvent::Thinking);
+        // TUI-specific: show spinner before the first text delta arrives.
+        let _ = tx.send(TuiEvent::Thinking);
 
         // Convert chat history (ChatBlock) to LLM messages (ChatMessage).
         // Only User and Agent blocks are included — command blocks and system
@@ -600,41 +610,41 @@ fn spawn_agent(
             })
             .collect();
 
+        // Set up EventSink: forward agent events to the TUI channel.
+        // The agent emits Started, TextDelta, CommandProposed, CommandFinished,
+        // Finished, and Error via this sink.
+        let tx_for_sink = tx.clone();
+        let sink: filar_agent::EventSink = Arc::new(move |event: filar_agent::AgentEvent| {
+            let _ = tx_for_sink.send(TuiEvent::Agent(event));
+        });
+
         // Build the agent with appropriate system prompt.
         let mut builder = AgentBuilder::new()
             .llm(llm)
             .executor(executor)
             .confirmer(confirmer)
-            .confirm_mode(confirm_mode);
+            .confirm_mode(confirm_mode)
+            .event_sink(sink);
         if is_local {
             builder = builder.local_mode();
         } else {
             builder = builder.ssh_mode(ssh_info.as_deref());
         }
 
-        // Set up streaming callback: send TextDelta events to the TUI.
-        let tx_for_delta = tx.clone();
-        let on_text_delta: Arc<dyn Fn(String) + Send + Sync> = Arc::new(move |delta: String| {
-            let _ = tx_for_delta.send(AgentEvent::TextDelta(delta));
-        });
-        builder = builder.on_text_delta(on_text_delta);
-
         let agent = match builder.build() {
             Ok(a) => a,
             Err(e) => {
-                let _ = tx.send(AgentEvent::Error(e.to_string()));
+                let _ = tx.send(TuiEvent::Agent(
+                    filar_agent::AgentEvent::Error(e.to_string())
+                ));
                 return;
             }
         };
 
-        // Run the agent loop.
-        match agent.run(&user_input, &history).await {
-            Ok(result) => {
-                let _ = tx.send(AgentEvent::Finished(result));
-            }
-            Err(e) => {
-                let _ = tx.send(AgentEvent::Error(e.to_string()));
-            }
-        }
+        // Run the agent loop. All events (Started, TextDelta, CommandProposed,
+        // CommandFinished, Finished, Error) are emitted via the EventSink.
+        // The run() wrapper emits Finished on Ok and Error on Err, so we
+        // don't need to send them again here.
+        let _ = agent.run(&user_input, &history).await;
     });
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -341,7 +341,7 @@ async fn run_app(
                             let exec = tui_executor.clone();
                             let tx = agent_tx.clone();
                             tokio::spawn(async move {
-                                match exec.run(&cmd).await {
+                                let succeeded = match exec.run(&cmd).await {
                                     Ok(result) => {
                                         // Build display output from CommandResult.
                                         let mut output = result.stdout.clone();
@@ -361,6 +361,7 @@ async fn run_app(
                                                 denied: false,
                                             }
                                         ));
+                                        true
                                     }
                                     Err(e) => {
                                         let _ = tx.send(TuiEvent::Agent(
@@ -368,12 +369,16 @@ async fn run_app(
                                                 format!("Shell command failed: {e}")
                                             )
                                         ));
+                                        false
                                     }
+                                };
+                                // Signal completion only on success — Error is
+                                // already a terminal event for the TUI handler.
+                                if succeeded {
+                                    let _ = tx.send(TuiEvent::Agent(
+                                        filar_agent::AgentEvent::Finished(String::new())
+                                    ));
                                 }
-                                // Signal completion to return to Normal mode.
-                                let _ = tx.send(TuiEvent::Agent(
-                                    filar_agent::AgentEvent::Finished(String::new())
-                                ));
                             });
                         } else {
                             // Empty command after ! — just return to normal.


### PR DESCRIPTION
## Summary

Closes #43

Implements UI-agnostic `AgentEvent` + `EventSink` in `filar-agent` and changes `ChatResponse` from enum to struct.

### Part A: AgentEvent + EventSink

- **New `AgentEvent` enum** (`#[non_exhaustive]`) in `filar_agent::events` with variants: `Started`, `TextDelta`, `CommandProposed`, `CommandFinished`, `Finished`, `Error`
- **`EventSink`** type alias (`Arc<dyn Fn(AgentEvent) + Send + Sync>`) + `AgentBuilder::event_sink()` builder method
- **`Agent::run()`** refactored into `run()` + `run_loop()` — outer `run()` emits `Started` → `run_loop()` → `Finished`/`Error`, guaranteeing exactly one terminal event on all paths
- **`process_tool_call()`** emits `CommandProposed` before confirmation and `CommandFinished` for all outcomes (blocked/denied/error/success)
- **TUI** uses `filar_agent::AgentEvent` via `TuiEvent::Agent(...)` wrapper — no duplicate copy. `runner.rs::spawn_agent` bridges the sink to the TUI channel. `TuiExecutor` no longer carries `event_tx`.

### Part B: ChatResponse → struct

- `ChatResponse` changed from enum (`Text` XOR `ToolCalls`) to struct (`text: String` + `tool_calls: Vec<ToolCall>`) — both fields always present, preserving streaming preamble text in conversation history when tool calls follow text.

## Tests

- **249 passed, 0 failed, 5 ignored** (ignored tests require docker-sshd — manual verification only)
- `cargo build --workspace` ✅
- `cargo clippy --workspace` ✅ (no warnings)
- New tests:
  - `event_sink_sequence_tool_call` (DoD): mock LLM with one tool call → sink receives Started → CommandProposed → CommandFinished → Finished
  - `event_sink_denied_command`: CommandFinished with `denied: true`

## Public contract changes

- **NEW:** `filar_agent::AgentEvent` (enum, `#[non_exhaustive]`), `filar_agent::EventSink` (type alias)
- **NEW:** `AgentBuilder::event_sink(sink: EventSink) -> Self`
- **CHANGED:** `filar_agent::ChatResponse` — enum → struct (`text` + `tool_calls`)
- **CHANGED:** `filar_tui::event::TuiEvent` (was `AgentEvent`) — now wraps `filar_agent::AgentEvent`
- **REMOVED:** duplicate TUI event variants (Started, TextDelta, CommandExecuted, Finished, Error)

## Out of scope

Nothing — changes map directly to issue #43 requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public, lifecycle-aware agent events (streaming text, command proposed/finished, finished/error) with optional event forwarding for UIs.
  * Enhanced TUI live updates: improved command prompts, confirmations, and transport status handling.
* **Bug Fixes**
  * Preserved assistant preamble text when tool calls are present.
  * Corrected command workflow/denial behavior and improved streaming/error state handling.
* **Refactor**
  * Unified event routing between the agent engine and the TUI using a dedicated event wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->