### PR TITLE
test(agent): verify streaming in LlmClient (DoD 2 test) — closes #44

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1276,3 +1276,39 @@ PR: #28
   через `ConfirmationRequest`). Новое поле `App::pending_proposal`.
 - **Double terminal event в shell escape**: `Finished` больше не эмитится после
   `Error` — только один терминальный event на запуск.
+
+---
+
+## Issue #44: Engine 0.2 — стриминг в LlmClient (сверка и закрытие)
+
+**Задача:** Сверить, что стриминг в `LlmClient` полностью реализован, и закрыть
+issue. Если чего-то не хватает — дополнить.
+
+**Результат:** Все 3 шага уже реализованы в предыдущих задачах (#43, SSE flush).
+Добавлен недостающий DoD-тест.
+
+**Сверка по шагам:**
+1. ✅ `LlmClient::chat_stream` с дефолтной реализацией-фолббэком через `chat()`
+   — `crates/agent/src/lib.rs:40-48`
+2. ✅ `GlmClient` реализует SSE-стриминг (`"stream": true`, парсинг `data:`-строк
+   с буферизацией разрывов чанков, аккумуляция tool_calls по index, `[DONE]`)
+   — `crates/agent/src/glm.rs:137-230`
+3. ✅ `Agent::run` использует `chat_stream`, пробрасывая дельты в
+   `AgentEvent::TextDelta` через sink — `crates/agent/src/agent.rs:307-319`
+
+**Сверка по DoD:**
+- ✅ Unit-тест SSE-парсера (разрыв посреди `data:`, tool_calls по кускам) —
+  11 тестов в `glm.rs`, включая `sse_parse_text_stream_chunked`,
+  `sse_parse_tool_calls_stream`, `sse_parse_partial_chunk`
+- ✅ **Добавлен** `event_sink_streaming_text_delta` — мок-LLM со стримом
+  (`MockStreamingLlm`) → sink получает TextDelta до Finished.
+  Последовательность: Started → TextDelta×3 → Finished.
+- ✅ Нестримящие реализации `LlmClient` продолжают работать (фоллбэк) —
+  `MockLlm` реализует только `chat()`, все тесты проходят.
+
+**Изменённые файлы:**
+- `crates/agent/src/agent.rs` — `MockStreamingLlm` + тест `event_sink_streaming_text_delta`
+
+**Тесты:** 250 passed, 0 failed, 5 ignored.
+
+**Публичные контракты:** без изменений (сверка существующей реализации).

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -508,6 +508,35 @@ mod tests {
         }
     }
 
+    // ── Mock streaming LLM client ─────────────────────────────────────
+
+    /// Mock LLM that implements `chat_stream` — calls `on_delta` for each
+    /// text chunk before returning the assembled response.
+    struct MockStreamingLlm {
+        /// Text chunks to emit via `on_delta`.
+        deltas: Vec<String>,
+        /// Final response to return from `chat_stream` / `chat`.
+        final_response: ChatResponse,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for MockStreamingLlm {
+        async fn chat(&self, _request: &ChatRequest) -> Result<ChatResponse> {
+            Ok(self.final_response.clone())
+        }
+
+        async fn chat_stream(
+            &self,
+            _request: &ChatRequest,
+            on_delta: &(dyn Fn(String) + Send + Sync),
+        ) -> Result<ChatResponse> {
+            for d in &self.deltas {
+                on_delta(d.clone());
+            }
+            Ok(self.final_response.clone())
+        }
+    }
+
     // ── Mock executor ────────────────────────────────────────────────────
 
     struct MockExecutor {
@@ -887,5 +916,53 @@ mod tests {
         assert_eq!(received.len(), 4, "expected 4 events, got {received:?}");
         assert!(matches!(&received[2], AgentEvent::CommandFinished { denied: true, .. }),
             "third event should be CommandFinished with denied=true, got {:?}", received[2]);
+    }
+
+    #[tokio::test]
+    async fn event_sink_streaming_text_delta() {
+        // DoD 2: Mock-LLM with streaming → sink receives TextDelta before Finished.
+        use std::sync::Mutex;
+
+        let llm = Arc::new(MockStreamingLlm {
+            deltas: vec!["Hello".into(), " world".into(), "!".into()],
+            final_response: ChatResponse::text("Hello world!"),
+        });
+
+        let executor = Arc::new(MockExecutor {
+            last_command: Mutex::new(String::new()),
+        });
+        let confirmer = Arc::new(MockConfirmer { approve: true });
+
+        let events: Arc<Mutex<Vec<AgentEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let sink: EventSink = Arc::new(move |event: AgentEvent| {
+            events_clone.lock().unwrap().push(event);
+        });
+
+        let agent = Agent::builder()
+            .llm(llm)
+            .executor(executor)
+            .confirmer(confirmer)
+            .confirm_mode(CommandConfirmMode::Never)
+            .event_sink(sink)
+            .build()
+            .unwrap();
+
+        let result = agent.run("say hello", &[]).await.unwrap();
+        assert_eq!(result, "Hello world!");
+
+        let received = events.lock().unwrap();
+        // Expected: Started → TextDelta("Hello") → TextDelta(" world") → TextDelta("!") → Finished
+        assert_eq!(received.len(), 5, "expected 5 events, got {received:?}");
+        assert!(matches!(&received[0], AgentEvent::Started),
+            "first event should be Started, got {:?}", received[0]);
+        assert!(matches!(&received[1], AgentEvent::TextDelta(s) if s == "Hello"),
+            "second event should be TextDelta, got {:?}", received[1]);
+        assert!(matches!(&received[2], AgentEvent::TextDelta(s) if s == " world"),
+            "third event should be TextDelta, got {:?}", received[2]);
+        assert!(matches!(&received[3], AgentEvent::TextDelta(s) if s == "!"),
+            "fourth event should be TextDelta, got {:?}", received[3]);
+        assert!(matches!(&received[4], AgentEvent::Finished(text) if text == "Hello world!"),
+            "last event should be Finished, got {:?}", received[4]);
     }
 }


### PR DESCRIPTION
## Summary

Closes #44

**Issue #44** was a "verify and close" task: confirm that streaming in `LlmClient` is fully implemented per the spec, and close the issue.

### Verification results

All 3 implementation steps already in place from previous work (#43, SSE flush fix):

| Step | Status | Location |
|------|--------|----------|
| 1. `LlmClient::chat_stream` with default fallback to `chat()` | ✅ | `lib.rs:40-48` |
| 2. `GlmClient` SSE streaming (`"stream": true`, `data:` parsing, tool_calls by index, `[DONE]`) | ✅ | `glm.rs:137-230` |
| 3. `Agent::run` uses `chat_stream` → `AgentEvent::TextDelta` via sink | ✅ | `agent.rs:307-319` |

### DoD verification

| DoD | Status | Details |
|-----|--------|---------|
| SSE parser tests (mid-`data:` break, tool_calls in pieces) | ✅ | 11 tests in `glm.rs` |
| Mock-LLM with streaming → sink gets TextDelta before Finished | ✅ **Added** | New `event_sink_streaming_text_delta` test |
| Non-streaming `LlmClient` implementations work (fallback) | ✅ | `MockLlm` uses default fallback, all tests pass |

### What was added

- **`MockStreamingLlm`** — mock LLM that implements `chat_stream` by calling `on_delta` for each text chunk
- **`event_sink_streaming_text_delta`** test — verifies event sequence: `Started → TextDelta×3 → Finished`

## Tests

- **250 passed, 0 failed, 5 ignored** (ignored tests require docker-sshd — manual verification only)
- `cargo build --workspace` ✅
- `cargo clippy --workspace` ✅ (no warnings)

## Public contract changes

None — this is a verification + test addition only.

## Out of scope

Nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project progress notes with the latest status of streaming support and validation results.

* **Tests**
  * Added a new streaming event-order test to confirm streamed text arrives in the expected sequence and the final response is assembled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->