### PR TITLE
feat(core): SecretProvider — секреты не только из env (#46)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "thiserror 1.0.69",
  "toml 0.8.23",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ keyring = { version = "3", default-features = false, features = ["apple-native",
 # Clipboard
 arboard = "3"
 
+# Secret zeroization
+zeroize = { version = "1", features = ["derive"] }
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1424,7 +1424,7 @@ issue. Если чего-то не хватает — дополнить.
   `spawn_agent` принимает `secret_provider`
 - `crates/tui/src/app.rs` — `Arc<StaticSecretProvider>` вместо `Arc<Mutex<HashMap>>`
 
-**Тесты:** 269 passed, 0 failed, 5 ignored.
+**Тесты:** 274 passed, 0 failed, 5 ignored.
 
 **Публичные контракты:**
 - `filar_core::SecretProvider` — новый трейт (`get`, `secret_names`).
@@ -1432,4 +1432,15 @@ issue. Если чего-то не хватает — дополнить.
 - `filar_transport::SecretSubstitutingExecutor` — новый `CommandExecutor` wrapper.
 - `filar_agent::glm::GlmClient::new_with_provider` — новый конструктор.
 - `filar_agent::AgentBuilder::secret_provider` — новый builder method.
-- `filar_tui::TuiConfig` — новое поле `secret_provider: Arc<dyn SecretProvider>`.
+- `filar_tui::TuiConfig` — новое поле `secret_provider: Arc<StaticSecretProvider>`.
+
+**Review fixes (PR #54, CodeRabbit):**
+- `StaticSecretProvider::insert()` — zeroize старого значения при перезаписи.
+- `StaticSecretProvider::remove()` — возврат `bool` вместо `Option<String>`, zeroize внутри.
+- `SecretSubstitutingExecutor::run()` — фильтр только `$`-префиксных имён (API key не подставляется).
+- `SecretSubstitutingExecutor::run()` — sort по убыванию длины (защита от substring collision `$FILAR_SECRET_1` vs `_10`).
+- `SecretSubstitutingExecutor::run()` — санитизация error path (маскировка секрета в сообщении об ошибке).
+- `runner.rs` — `app.secrets = config.secret_provider.clone()` (общий экземпляр провайдера).
+- `runner.rs` — shell-escape `!cmd` обёрнут в `SecretSubstitutingExecutor`.
+- `TuiConfig.secret_provider` — тип изменён с `Arc<dyn SecretProvider>` на `Arc<StaticSecretProvider>`.
+- Добавлены 3 теста: error sanitization, substring collision, API key exclusion.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1381,3 +1381,55 @@ issue. Если чего-то не хватает — дополнить.
 - **Тест на `command_timeout`**: добавлен `command_timeout_cancels_executor` —
   `HangingExecutor` + `command_timeout(100ms)` → `executor.cancel()` вызывается,
   `CommandFinished` содержит "timed out", агент продолжает работу.
+
+### Issue #46: SecretProvider — секреты не только из env (Engine 0.4)
+
+**Задача:** вынести чтение секретов за пределы `std::env::var`, подготовив движок
+к внешним фронтендам (бот, мобилка). Перенести подстановку `$FILAR_SECRET_N`
+и санитизацию вывода из TUI в движок.
+
+**Что сделано:**
+
+1. **`filar-core::secrets`** — добавлен трейт `SecretProvider` с методами `get(name)`
+   и `secret_names()`. Две реализации:
+   - `EnvSecretProvider` — читает из `std::env` (дефолт для TUI/десктопа).
+   - `StaticSecretProvider` — in-memory `HashMap` через `Arc<RwLock<…>>`,
+     mutable, zeroize на drop (последний клон).
+2. **`filar-transport::secret::SecretSubstitutingExecutor`** — обёртка над
+   `CommandExecutor`: подстановка `$FILAR_SECRET_N` перед выполнением, маскирование
+   значений в stdout/stderr после.
+3. **`filar-agent::glm::GlmClient::new_with_provider`** — получает API-ключ через
+   `SecretProvider`, без прямого `std::env::var`.
+4. **`AgentBuilder::secret_provider()`** — принимает `Arc<dyn SecretProvider>`,
+   в `build()` оборачивает executor в `SecretSubstitutingExecutor`.
+5. **`main.rs`** — создаёт `StaticSecretProvider`, загружает API-ключ,
+   передаёт в TUI через `TuiConfig.secret_provider`.
+6. **TUI runner** — `TuiExecutor` упрощён (только swapping), подстановка/санитизация
+   теперь в `SecretSubstitutingExecutor` (движок).
+7. **`App`** — `secrets` заменён с `Arc<Mutex<HashMap>>` на `Arc<StaticSecretProvider>`.
+8. **`zeroize` crate** добавлен в workspace + `filar-core`.
+
+**Изменённые файлы:**
+- `Cargo.toml` — `zeroize` dependency
+- `crates/core/Cargo.toml` — `zeroize` dependency
+- `crates/core/src/secrets.rs` — `SecretProvider` trait, `EnvSecretProvider`,
+  `StaticSecretProvider`, 11 тестов
+- `crates/core/src/lib.rs` — re-export `SecretProvider`, `EnvSecretProvider`, `StaticSecretProvider`
+- `crates/transport/src/secret.rs` — новый файл: `SecretSubstitutingExecutor` + 5 тестов
+- `crates/transport/src/lib.rs` — модуль + re-export `SecretSubstitutingExecutor`
+- `crates/agent/src/glm.rs` — `new_with_provider()` конструктор
+- `crates/agent/src/agent.rs` — `secret_provider` field + builder method + `build()` wrapping
+- `crates/app/src/main.rs` — `StaticSecretProvider` creation + `GlmClient::new_with_provider`
+- `crates/tui/src/runner.rs` — `TuiConfig.secret_provider`, `TuiExecutor` упрощён,
+  `spawn_agent` принимает `secret_provider`
+- `crates/tui/src/app.rs` — `Arc<StaticSecretProvider>` вместо `Arc<Mutex<HashMap>>`
+
+**Тесты:** 269 passed, 0 failed, 5 ignored.
+
+**Публичные контракты:**
+- `filar_core::SecretProvider` — новый трейт (`get`, `secret_names`).
+- `filar_core::EnvSecretProvider`, `filar_core::StaticSecretProvider` — новые типы.
+- `filar_transport::SecretSubstitutingExecutor` — новый `CommandExecutor` wrapper.
+- `filar_agent::glm::GlmClient::new_with_provider` — новый конструктор.
+- `filar_agent::AgentBuilder::secret_provider` — новый builder method.
+- `filar_tui::TuiConfig` — новое поле `secret_provider: Arc<dyn SecretProvider>`.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use filar_core::{CommandConfirmMode, CoreError, Result};
-use filar_transport::CommandExecutor;
+use filar_core::{CommandConfirmMode, CoreError, Result, SecretProvider};
+use filar_transport::{CommandExecutor, SecretSubstitutingExecutor};
 
 use crate::{
     events::{AgentEvent, EventSink},
@@ -130,6 +130,11 @@ pub struct Agent {
     confirm_timeout: Option<Duration>,
     /// Optional timeout for command execution.
     command_timeout: Option<Duration>,
+    /// Optional secret provider (stored for potential future use).
+    /// The executor is already wrapped in `SecretSubstitutingExecutor`
+    /// during `build()` if this is set.
+    #[allow(dead_code)]
+    secret_provider: Option<Arc<dyn SecretProvider>>,
 }
 
 /// Builder for [`Agent`].
@@ -146,6 +151,7 @@ pub struct AgentBuilder {
     cancellation: Option<CancellationToken>,
     confirm_timeout: Option<Duration>,
     command_timeout: Option<Duration>,
+    secret_provider: Option<Arc<dyn SecretProvider>>,
 }
 
 impl AgentBuilder {
@@ -164,6 +170,7 @@ impl AgentBuilder {
             cancellation: None,
             confirm_timeout: None,
             command_timeout: None,
+            secret_provider: None,
         }
     }
 
@@ -257,6 +264,17 @@ impl AgentBuilder {
         self
     }
 
+    /// Set a secret provider for command substitution and output sanitisation.
+    ///
+    /// When set, the executor is wrapped in [`SecretSubstitutingExecutor`] during
+    /// [`build`](Self::build). `$FILAR_SECRET_N` placeholders in commands are
+    /// replaced with actual values from the provider before execution, and
+    /// secret values in command output are masked back to placeholders.
+    pub fn secret_provider(mut self, provider: Arc<dyn SecretProvider>) -> Self {
+        self.secret_provider = Some(provider);
+        self
+    }
+
     /// Convenience: set the system prompt for local execution.
     pub fn local_mode(self) -> Self {
         self.system_prompt(build_system_prompt(true, None, cfg!(windows)))
@@ -269,9 +287,16 @@ impl AgentBuilder {
 
     /// Build the agent.
     pub fn build(self) -> Result<Agent> {
+        let executor = self.executor.ok_or_else(|| CoreError::Other("executor not set".into()))?;
+        // Wrap the executor in SecretSubstitutingExecutor if a provider is set.
+        let secret_provider = self.secret_provider;
+        let executor: Arc<dyn CommandExecutor> = match &secret_provider {
+            Some(provider) => Arc::new(SecretSubstitutingExecutor::new(executor, provider.clone())),
+            None => executor,
+        };
         Ok(Agent {
             llm: self.llm.ok_or_else(|| CoreError::Other("LLM client not set".into()))?,
-            executor: self.executor.ok_or_else(|| CoreError::Other("executor not set".into()))?,
+            executor,
             confirmer: self.confirmer.ok_or_else(|| CoreError::Other("confirmer not set".into()))?,
             confirm_mode: self.confirm_mode,
             max_iterations: self.max_iterations,
@@ -284,6 +309,7 @@ impl AgentBuilder {
             cancellation: self.cancellation,
             confirm_timeout: self.confirm_timeout,
             command_timeout: self.command_timeout,
+            secret_provider,
         })
     }
 }

--- a/crates/agent/src/glm.rs
+++ b/crates/agent/src/glm.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
-use filar_core::{secrets, CoreError, LlmConfig, Result};
+use filar_core::{secrets, CoreError, LlmConfig, Result, SecretProvider};
 
 use crate::{ChatMessage, ChatRequest, ChatResponse, LlmClient, ToolCall};
 use std::collections::BTreeMap;
@@ -54,6 +54,22 @@ impl GlmClient {
     /// The API key is read from the `GLM_API_KEY` environment variable.
     pub fn new(config: &LlmConfig, timeout: Duration) -> Result<Self> {
         Self::new_with_key(config, timeout, &secrets::glm_api_key()?)
+    }
+
+    /// Create a new `GlmClient` using a [`SecretProvider`] to retrieve the
+    /// API key.  The `key_name` is the logical name passed to the provider
+    /// (e.g. `"GLM_API_KEY"` or a profile-specific env var name).
+    ///
+    /// This is the preferred constructor for engine consumers (bots, mobile,
+    /// GUI-launched sessions) — it avoids direct `std::env::var` calls.
+    pub fn new_with_provider(
+        config: &LlmConfig,
+        timeout: Duration,
+        key_name: &str,
+        provider: &dyn SecretProvider,
+    ) -> Result<Self> {
+        let api_key = provider.get(key_name)?;
+        Self::new_with_key(config, timeout, &api_key)
     }
 
     /// Create a new `GlmClient` with an explicit API key (useful for testing).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::EnvFilter;
 
 use filar_agent::glm::GlmClient;
 use filar_agent::LlmClient;
-use filar_core::{secrets, Config, SessionStore};
+use filar_core::{secrets, Config, SessionStore, StaticSecretProvider};
 use filar_transport::{LocalExecutor, SshExecutor};
 use filar_tui::TuiConfig;
 
@@ -264,10 +264,17 @@ async fn run() -> anyhow::Result<()> {
         anyhow::bail!("API key is required. Enter it in the GUI launcher or set the GLM_API_KEY environment variable.");
     }
 
-    let llm: Arc<dyn LlmClient> = Arc::new(GlmClient::new_with_key(
+    // ── Create SecretProvider ──────────────────────────────────────────
+    // The StaticSecretProvider holds the API key and will also hold dynamic
+    // $FILAR_SECRET_N variables added at runtime (via Ctrl+P in the TUI).
+    let secret_provider = Arc::new(StaticSecretProvider::new());
+    secret_provider.insert(secrets::env_vars::GLM_API_KEY, &api_key);
+
+    let llm: Arc<dyn LlmClient> = Arc::new(GlmClient::new_with_provider(
         &llm_config,
         Duration::from_secs(config.timeouts.llm_secs),
-        &api_key,
+        secrets::env_vars::GLM_API_KEY,
+        &*secret_provider,
     )?);
 
     info!(model = %llm_config.model, "LLM client initialised");
@@ -327,6 +334,7 @@ async fn run() -> anyhow::Result<()> {
         initial_messages,
         ssh_target: ssh_target.clone(),
         is_local: ssh_target.is_none(),
+        secret_provider,
     };
 
     info!("launching TUI");

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+zeroize = { workspace = true }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,4 +14,5 @@ pub mod session;
 pub use chat::ChatBlock;
 pub use config::{Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig, HostKeyPolicy};
 pub use error::{CoreError, Result};
+pub use secrets::{EnvSecretProvider, SecretProvider, StaticSecretProvider};
 pub use session::{Session, SessionMeta, SessionStore};

--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -120,15 +120,33 @@ impl StaticSecretProvider {
     }
 
     /// Insert or replace a secret. Visible to all clones.
+    ///
+    /// If a secret with the same name already exists, the old value is
+    /// zeroized before being dropped.
     pub fn insert(&self, name: impl Into<String>, value: impl Into<String>) {
         if let Ok(mut secrets) = self.secrets.write() {
-            secrets.insert(name.into(), value.into());
+            if let Some(mut old) = secrets.insert(name.into(), value.into()) {
+                old.zeroize();
+            }
         }
     }
 
-    /// Remove a secret. Returns the previous value if it existed.
-    pub fn remove(&self, name: &str) -> Option<String> {
-        self.secrets.write().ok()?.remove(name)
+    /// Remove a secret. Returns `true` if the secret existed.
+    ///
+    /// The removed value is zeroized internally — it is never returned to
+    /// the caller in plaintext.
+    pub fn remove(&self, name: &str) -> bool {
+        if let Some(mut value) = self
+            .secrets
+            .write()
+            .ok()
+            .and_then(|mut s| s.remove(name))
+        {
+            value.zeroize();
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -268,8 +286,10 @@ mod tests {
     fn static_provider_remove() {
         let provider = StaticSecretProvider::new();
         provider.insert("SECRET", "value");
-        assert_eq!(provider.remove("SECRET"), Some("value".into()));
+        assert!(provider.remove("SECRET"));
         assert!(provider.get("SECRET").is_err());
+        // Removing again returns false.
+        assert!(!provider.remove("SECRET"));
     }
 
     #[test]

--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -1,8 +1,17 @@
-//! Reading secrets from the environment.
+//! Reading secrets from the environment or other providers.
 //!
-//! Secrets are **never** hardcoded. They are always read from environment
-//! variables at runtime. The [`secrets`] module centralises this logic so
-//! that no other part of the codebase needs to know variable names.
+//! Secrets are **never** hardcoded. They are read at runtime from a
+//! [`SecretProvider`] — the default implementation ([`EnvSecretProvider`])
+//! reads from environment variables, while [`StaticSecretProvider`] allows
+//! programmatic injection (for bots, FFI, tests, and GUI input).
+//!
+//! The [`secrets`] module centralises this logic so that no other part of the
+//! codebase needs to know variable names or storage details.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use zeroize::Zeroize;
 
 use crate::error::{CoreError, Result};
 
@@ -12,25 +21,294 @@ pub mod env_vars {
     pub const GLM_API_KEY: &str = "GLM_API_KEY";
 }
 
+// ---------------------------------------------------------------------------
+// SecretProvider trait
+// ---------------------------------------------------------------------------
+
+/// Trait for retrieving secrets by logical name.
+///
+/// Implementations:
+/// - [`EnvSecretProvider`] — reads from `std::env` (default for TUI/desktop).
+/// - [`StaticSecretProvider`] — in-memory `HashMap`, mutable at runtime
+///   (for FFI, bots, tests, and GUI-provided credentials).
+///
+/// All engine code that needs a secret (API keys, `$FILAR_SECRET_N` variables)
+/// must go through this trait — direct `std::env::var` calls for secrets are
+/// only permitted inside `EnvSecretProvider`.
+pub trait SecretProvider: Send + Sync {
+    /// Retrieve a secret by its logical name (e.g. `"GLM_API_KEY"`,
+    /// `"$FILAR_SECRET_1"`).
+    ///
+    /// Returns [`CoreError::Secret`] if the secret is not available.
+    fn get(&self, name: &str) -> Result<String>;
+
+    /// List all known secret variable names (e.g. `["$FILAR_SECRET_1", ...]`).
+    ///
+    /// Used by `SecretSubstitutingExecutor` to enumerate placeholders for
+    /// substitution and output sanitisation.
+    fn secret_names(&self) -> Vec<String>;
+}
+
+// ---------------------------------------------------------------------------
+// EnvSecretProvider
+// ---------------------------------------------------------------------------
+
+/// Default [`SecretProvider`] — reads secrets from environment variables.
+///
+/// This is the default for TUI/desktop: `GLM_API_KEY` and `FILAR_SECRET_*`
+/// are read from the process environment.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EnvSecretProvider;
+
+impl EnvSecretProvider {
+    /// Create a new `EnvSecretProvider`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SecretProvider for EnvSecretProvider {
+    fn get(&self, name: &str) -> Result<String> {
+        // Secret variable names may start with `$` (e.g. `$FILAR_SECRET_1`),
+        // but environment variables never have a `$` prefix.
+        let env_name = name.strip_prefix('$').unwrap_or(name);
+        std::env::var(env_name)
+            .ok()
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| CoreError::Secret(format!("{name} not set or empty")))
+    }
+
+    fn secret_names(&self) -> Vec<String> {
+        // Return all FILAR_SECRET_* env vars.
+        std::env::vars()
+            .filter(|(k, v)| k.starts_with("FILAR_SECRET_") && !v.is_empty())
+            .map(|(k, _)| format!("${k}"))
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StaticSecretProvider
+// ---------------------------------------------------------------------------
+
+/// In-memory [`SecretProvider`] backed by a `HashMap`.
+///
+/// Designed for FFI, bots, tests, and GUI-launched sessions where secrets
+/// are injected programmatically rather than read from env. Values are
+/// zeroized when the last clone is dropped.
+///
+/// The internal `HashMap` is shared via `Arc<RwLock<…>>`, so clones see
+/// mutations — `insert()` on one clone is visible to all.
+#[derive(Debug, Clone)]
+pub struct StaticSecretProvider {
+    secrets: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl StaticSecretProvider {
+    /// Create an empty provider.
+    pub fn new() -> Self {
+        Self {
+            secrets: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Create a provider pre-loaded with the given secrets.
+    pub fn with_secrets(secrets: HashMap<String, String>) -> Self {
+        Self {
+            secrets: Arc::new(RwLock::new(secrets)),
+        }
+    }
+
+    /// Insert or replace a secret. Visible to all clones.
+    pub fn insert(&self, name: impl Into<String>, value: impl Into<String>) {
+        if let Ok(mut secrets) = self.secrets.write() {
+            secrets.insert(name.into(), value.into());
+        }
+    }
+
+    /// Remove a secret. Returns the previous value if it existed.
+    pub fn remove(&self, name: &str) -> Option<String> {
+        self.secrets.write().ok()?.remove(name)
+    }
+}
+
+impl Default for StaticSecretProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecretProvider for StaticSecretProvider {
+    fn get(&self, name: &str) -> Result<String> {
+        let secrets = self
+            .secrets
+            .read()
+            .map_err(|_| CoreError::Other("secrets lock poisoned".into()))?;
+        secrets
+            .get(name)
+            .filter(|v| !v.is_empty())
+            .cloned()
+            .ok_or_else(|| CoreError::Secret(format!("{name} not set or empty")))
+    }
+
+    fn secret_names(&self) -> Vec<String> {
+        self.secrets
+            .read()
+            .map(|secrets| secrets.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+/// Zeroize all secret values when the last clone is dropped.
+impl Drop for StaticSecretProvider {
+    fn drop(&mut self) {
+        // Only zeroize if this is the last clone (Arc count == 1).
+        if let Some(rwlock) = Arc::get_mut(&mut self.secrets) {
+            if let Ok(map) = rwlock.get_mut() {
+                for value in map.values_mut() {
+                    value.zeroize();
+                }
+                map.clear();
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy convenience functions (delegates to EnvSecretProvider)
+// ---------------------------------------------------------------------------
+
 /// Retrieve the GLM API key from the environment.
 ///
 /// Returns [`CoreError::Secret`] if the variable is unset or empty.
+///
+/// **Deprecated:** prefer [`SecretProvider::get`] with [`EnvSecretProvider`].
 pub fn glm_api_key() -> Result<String> {
-    read_secret(env_vars::GLM_API_KEY)
+    EnvSecretProvider::new().get(env_vars::GLM_API_KEY)
 }
 
 /// Retrieve an API key from a named environment variable.
 ///
-/// This is a generalisation of [`glm_api_key`] that allows different
-/// LLM profiles to use different environment variables.
+/// **Deprecated:** prefer [`SecretProvider::get`] with [`EnvSecretProvider`].
 pub fn api_key(env_var: &str) -> Result<String> {
-    read_secret(env_var)
+    EnvSecretProvider::new().get(env_var)
 }
 
-/// Generic helper: read a non-empty secret from the environment.
-fn read_secret(var_name: &str) -> Result<String> {
-    std::env::var(var_name)
-        .ok()
-        .filter(|v| !v.is_empty())
-        .ok_or_else(|| CoreError::Secret(format!("{var_name} not set or empty")))
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_provider_get_returns_env_var() {
+        // SAFETY: env var manipulation is not thread-safe, but this test
+        // uses a unique name unlikely to collide with other tests.
+        let name = "FILAR_TEST_SECRET_ENV_42";
+        std::env::set_var(name, "test-value");
+        let provider = EnvSecretProvider::new();
+        assert_eq!(provider.get(name).unwrap(), "test-value");
+        std::env::remove_var(name);
+    }
+
+    #[test]
+    fn env_provider_get_missing_returns_error() {
+        let provider = EnvSecretProvider::new();
+        assert!(provider.get("FILAR_NONEXISTENT_SECRET_99999").is_err());
+    }
+
+    #[test]
+    fn env_provider_get_strips_dollar_prefix() {
+        let name = "FILAR_TEST_SECRET_DOLLAR";
+        std::env::set_var(name, "dollar-value");
+        let provider = EnvSecretProvider::new();
+        // `$FILAR_TEST_SECRET_DOLLAR` should resolve to env var `FILAR_TEST_SECRET_DOLLAR`.
+        assert_eq!(provider.get(&format!("${name}")).unwrap(), "dollar-value");
+        std::env::remove_var(name);
+    }
+
+    #[test]
+    fn static_provider_insert_and_get() {
+        let provider = StaticSecretProvider::new();
+        provider.insert("API_KEY", "abc123");
+        assert_eq!(provider.get("API_KEY").unwrap(), "abc123");
+    }
+
+    #[test]
+    fn static_provider_get_missing_returns_error() {
+        let provider = StaticSecretProvider::new();
+        assert!(provider.get("MISSING").is_err());
+    }
+
+    #[test]
+    fn static_provider_empty_value_returns_error() {
+        let provider = StaticSecretProvider::new();
+        provider.insert("EMPTY", "");
+        assert!(provider.get("EMPTY").is_err());
+    }
+
+    #[test]
+    fn static_provider_secret_names() {
+        let provider = StaticSecretProvider::new();
+        provider.insert("$FILAR_SECRET_1", "pass1");
+        provider.insert("$FILAR_SECRET_2", "pass2");
+        provider.insert("GLM_API_KEY", "key");
+
+        let mut names = provider.secret_names();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["$FILAR_SECRET_1", "$FILAR_SECRET_2", "GLM_API_KEY"]
+        );
+    }
+
+    #[test]
+    fn static_provider_remove() {
+        let provider = StaticSecretProvider::new();
+        provider.insert("SECRET", "value");
+        assert_eq!(provider.remove("SECRET"), Some("value".into()));
+        assert!(provider.get("SECRET").is_err());
+    }
+
+    #[test]
+    fn static_provider_clone_shares_state() {
+        let provider = StaticSecretProvider::new();
+        let clone = provider.clone();
+        provider.insert("KEY", "val");
+        // Clone sees the mutation.
+        assert_eq!(clone.get("KEY").unwrap(), "val");
+    }
+
+    #[test]
+    fn static_provider_overwrite() {
+        let provider = StaticSecretProvider::new();
+        provider.insert("KEY", "old");
+        provider.insert("KEY", "new");
+        assert_eq!(provider.get("KEY").unwrap(), "new");
+    }
+
+    #[test]
+    fn static_provider_with_secrets() {
+        let mut map = HashMap::new();
+        map.insert("KEY1".into(), "val1".into());
+        map.insert("KEY2".into(), "val2".into());
+        let provider = StaticSecretProvider::with_secrets(map);
+        assert_eq!(provider.get("KEY1").unwrap(), "val1");
+        assert_eq!(provider.get("KEY2").unwrap(), "val2");
+    }
+
+    #[test]
+    fn env_provider_secret_names_scans_env() {
+        // SAFETY: uses unique names unlikely to collide.
+        std::env::set_var("FILAR_SECRET_TEST_A", "alpha");
+        std::env::set_var("FILAR_SECRET_TEST_B", "beta");
+        let provider = EnvSecretProvider::new();
+        let names = provider.secret_names();
+        assert!(names.contains(&"$FILAR_SECRET_TEST_A".to_string()));
+        assert!(names.contains(&"$FILAR_SECRET_TEST_B".to_string()));
+        std::env::remove_var("FILAR_SECRET_TEST_A");
+        std::env::remove_var("FILAR_SECRET_TEST_B");
+    }
 }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod interactive;
 pub mod local;
+pub mod secret;
 pub mod ssh;
 
 use std::time::Duration;
@@ -19,6 +20,7 @@ use filar_core::Result;
 // Re-export key types.
 pub use interactive::{InteractiveTerminal, LocalInteractive, SshInteractive};
 pub use local::LocalExecutor;
+pub use secret::SecretSubstitutingExecutor;
 pub use ssh::{SshExecutor, SshSession};
 
 /// Result of executing a command.

--- a/crates/transport/src/secret.rs
+++ b/crates/transport/src/secret.rs
@@ -1,0 +1,238 @@
+//! `SecretSubstitutingExecutor` — wraps a [`CommandExecutor`] to handle
+//! `$FILAR_SECRET_N` substitution and output sanitisation through a
+//! [`SecretProvider`].
+//!
+//! Before executing a command, `$FILAR_SECRET_N` placeholders are replaced
+//! with actual secret values from the provider. After execution, any
+//! occurrence of a secret value in stdout/stderr is masked back to its
+//! placeholder name, so the LLM never sees the real secret.
+
+use std::sync::Arc;
+
+use filar_core::{Result, SecretProvider};
+
+use crate::CommandExecutor;
+
+// ---------------------------------------------------------------------------
+// SecretSubstitutingExecutor
+// ---------------------------------------------------------------------------
+
+/// [`CommandExecutor`] wrapper that handles secret variable substitution
+/// and output sanitisation via a [`SecretProvider`].
+///
+/// **Substitution:** before passing the command to the inner executor,
+/// `$FILAR_SECRET_N` placeholders are replaced with actual values from
+/// the provider.
+///
+/// **Sanitisation:** after execution, any occurrence of a secret value in
+/// stdout/stderr is replaced back with its placeholder name, so the LLM
+/// never sees the real secret.
+pub struct SecretSubstitutingExecutor {
+    inner: Arc<dyn CommandExecutor>,
+    provider: Arc<dyn SecretProvider>,
+}
+
+impl SecretSubstitutingExecutor {
+    /// Create a new `SecretSubstitutingExecutor` wrapping `inner` with the
+    /// given secret `provider`.
+    pub fn new(inner: Arc<dyn CommandExecutor>, provider: Arc<dyn SecretProvider>) -> Self {
+        Self { inner, provider }
+    }
+}
+
+#[async_trait::async_trait]
+impl CommandExecutor for SecretSubstitutingExecutor {
+    async fn run(&self, command: &str) -> Result<crate::CommandResult> {
+        // Substitute secret placeholders with actual values.
+        let names = self.provider.secret_names();
+        let actual_command = {
+            let mut cmd = command.to_string();
+            for name in &names {
+                if let Ok(value) = self.provider.get(name) {
+                    if !value.is_empty() {
+                        cmd = cmd.replace(name, &value);
+                    }
+                }
+            }
+            cmd
+        };
+
+        let mut result = self.inner.run(&actual_command).await?;
+
+        // Sanitise output — replace any secret value with its placeholder.
+        for name in &names {
+            if let Ok(value) = self.provider.get(name) {
+                if !value.is_empty() {
+                    result.stdout = result.stdout.replace(&value, name);
+                    result.stderr = result.stderr.replace(&value, name);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn cancel(&self) -> Result<()> {
+        self.inner.cancel().await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use filar_core::{EnvSecretProvider, StaticSecretProvider};
+    use std::sync::Mutex;
+
+    /// A simple mock executor that records the last command and returns a
+    /// canned result.
+    struct MockExecutor {
+        last_command: Mutex<String>,
+        stdout: String,
+        stderr: String,
+    }
+
+    impl MockExecutor {
+        fn new(stdout: &str) -> Self {
+            Self {
+                last_command: Mutex::new(String::new()),
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CommandExecutor for MockExecutor {
+        async fn run(&self, command: &str) -> Result<crate::CommandResult> {
+            *self.last_command.lock().unwrap() = command.to_string();
+            Ok(crate::CommandResult {
+                stdout: self.stdout.clone(),
+                stderr: self.stderr.clone(),
+                exit_code: Some(0),
+                duration: std::time::Duration::from_millis(1),
+            })
+        }
+        async fn cancel(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn substitution_with_static_provider() {
+        // Set up a StaticSecretProvider with a secret.
+        let provider = Arc::new(StaticSecretProvider::new());
+        provider.insert("$FILAR_SECRET_1", "s3cr3t-p@ss");
+        let provider_trait: Arc<dyn SecretProvider> = provider;
+
+        // The mock returns the substituted password in stdout (simulating
+        // e.g. `echo $FILAR_SECRET_1` where the shell already expanded it).
+        let mock = Arc::new(MockExecutor::new("user:s3cr3t-p@ss"));
+        let exec = SecretSubstitutingExecutor::new(mock.clone(), provider_trait);
+
+        let result = exec
+            .run("echo user:$FILAR_SECRET_1")
+            .await
+            .unwrap();
+
+        // The inner executor received the substituted command.
+        assert_eq!(*mock.last_command.lock().unwrap(), "echo user:s3cr3t-p@ss");
+
+        // The output is sanitised — the actual secret is replaced with the
+        // placeholder name.
+        assert_eq!(result.stdout, "user:$FILAR_SECRET_1");
+    }
+
+    #[tokio::test]
+    async fn sanitisation_masks_secret_in_stderr() {
+        let static_provider = StaticSecretProvider::new();
+        static_provider.insert("$FILAR_SECRET_1", "my-secret");
+        let provider: Arc<dyn SecretProvider> = Arc::new(static_provider);
+
+        let mut mock = MockExecutor::new("");
+        mock.stderr = "error: auth failed for my-secret".into();
+        let mock = Arc::new(mock);
+
+        let exec = SecretSubstitutingExecutor::new(mock, provider);
+        let result = exec.run("some-cmd").await.unwrap();
+
+        // stderr is sanitised.
+        assert_eq!(result.stderr, "error: auth failed for $FILAR_SECRET_1");
+    }
+
+    #[tokio::test]
+    async fn no_secrets_passes_command_through() {
+        let provider: Arc<dyn SecretProvider> = Arc::new(StaticSecretProvider::new());
+        let mock = Arc::new(MockExecutor::new("hello"));
+        let exec = SecretSubstitutingExecutor::new(mock.clone(), provider);
+
+        let result = exec.run("echo hello").await.unwrap();
+
+        assert_eq!(*mock.last_command.lock().unwrap(), "echo hello");
+        assert_eq!(result.stdout, "hello");
+    }
+
+    #[tokio::test]
+    async fn dynamic_secret_insertion_visible_to_executor() {
+        let provider = Arc::new(StaticSecretProvider::new());
+        let provider_trait: Arc<dyn SecretProvider> = provider.clone();
+
+        let mock = Arc::new(MockExecutor::new("pw=mypassword"));
+        let exec = SecretSubstitutingExecutor::new(mock.clone(), provider_trait);
+
+        // Insert a secret AFTER creating the executor — it should be visible
+        // because StaticSecretProvider uses shared interior mutability.
+        provider.insert("$FILAR_SECRET_2", "mypassword");
+
+        let result = exec.run("echo pw=$FILAR_SECRET_2").await.unwrap();
+
+        assert_eq!(*mock.last_command.lock().unwrap(), "echo pw=mypassword");
+        assert_eq!(result.stdout, "pw=$FILAR_SECRET_2");
+    }
+
+    #[tokio::test]
+    async fn multiple_secrets_substituted_and_sanitised() {
+        let provider = Arc::new(StaticSecretProvider::new());
+        provider.insert("$FILAR_SECRET_1", "alice");
+        provider.insert("$FILAR_SECRET_2", "bob");
+        let provider_trait: Arc<dyn SecretProvider> = provider;
+
+        // Output contains both secrets.
+        let mock = Arc::new(MockExecutor::new("alice and bob are here"));
+        let exec = SecretSubstitutingExecutor::new(mock.clone(), provider_trait);
+
+        let result = exec
+            .run("echo $FILAR_SECRET_1 and $FILAR_SECRET_2")
+            .await
+            .unwrap();
+
+        assert_eq!(*mock.last_command.lock().unwrap(), "echo alice and bob");
+        assert_eq!(result.stdout, "$FILAR_SECRET_1 and $FILAR_SECRET_2 are here");
+    }
+
+    #[tokio::test]
+    async fn substitution_with_env_provider() {
+        // Set up an env var that EnvSecretProvider will discover.
+        std::env::set_var("FILAR_SECRET_TESTENV", "env-pw-42");
+        let provider: Arc<dyn SecretProvider> = Arc::new(EnvSecretProvider::new());
+
+        let mock = Arc::new(MockExecutor::new("auth=env-pw-42"));
+        let exec = SecretSubstitutingExecutor::new(mock.clone(), provider);
+
+        let result = exec
+            .run("echo auth=$FILAR_SECRET_TESTENV")
+            .await
+            .unwrap();
+
+        // The inner executor received the substituted command.
+        assert_eq!(*mock.last_command.lock().unwrap(), "echo auth=env-pw-42");
+
+        // The output is sanitised.
+        assert_eq!(result.stdout, "auth=$FILAR_SECRET_TESTENV");
+
+        std::env::remove_var("FILAR_SECRET_TESTENV");
+    }
+}

--- a/crates/transport/src/secret.rs
+++ b/crates/transport/src/secret.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use filar_core::{Result, SecretProvider};
+use filar_core::{CoreError, Result, SecretProvider};
 
 use crate::CommandExecutor;
 
@@ -43,8 +43,20 @@ impl SecretSubstitutingExecutor {
 #[async_trait::async_trait]
 impl CommandExecutor for SecretSubstitutingExecutor {
     async fn run(&self, command: &str) -> Result<crate::CommandResult> {
-        // Substitute secret placeholders with actual values.
-        let names = self.provider.secret_names();
+        // Only substitute $-prefixed secret names (e.g. $FILAR_SECRET_N).
+        // This prevents non-command secrets (like the LLM API key, which is
+        // stored without a $ prefix) from being injected into shell commands.
+        let mut names: Vec<String> = self
+            .provider
+            .secret_names()
+            .into_iter()
+            .filter(|n| n.starts_with('$'))
+            .collect();
+        // Sort by descending length to prevent substring collisions:
+        // $FILAR_SECRET_1 is a substring of $FILAR_SECRET_10, so the longer
+        // name must be processed first.
+        names.sort_unstable_by_key(|n| std::cmp::Reverse(n.len()));
+
         let actual_command = {
             let mut cmd = command.to_string();
             for name in &names {
@@ -57,7 +69,23 @@ impl CommandExecutor for SecretSubstitutingExecutor {
             cmd
         };
 
-        let mut result = self.inner.run(&actual_command).await?;
+        // Capture the result so we can sanitise the error path too —
+        // error messages may embed the substituted command with real secrets.
+        let run_result = self.inner.run(&actual_command).await;
+        let mut result = match run_result {
+            Ok(r) => r,
+            Err(e) => {
+                let mut msg = e.to_string();
+                for name in &names {
+                    if let Ok(value) = self.provider.get(name) {
+                        if !value.is_empty() {
+                            msg = msg.replace(&value, name);
+                        }
+                    }
+                }
+                return Err(CoreError::Other(msg));
+            }
+        };
 
         // Sanitise output — replace any secret value with its placeholder.
         for name in &names {
@@ -211,6 +239,97 @@ mod tests {
 
         assert_eq!(*mock.last_command.lock().unwrap(), "echo alice and bob");
         assert_eq!(result.stdout, "$FILAR_SECRET_1 and $FILAR_SECRET_2 are here");
+    }
+
+    /// A mock executor that always returns an error containing the
+    /// command it received (simulating a shell error that embeds the
+    /// command line).
+    struct FailingMockExecutor {
+        last_command: Mutex<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl CommandExecutor for FailingMockExecutor {
+        async fn run(&self, command: &str) -> Result<crate::CommandResult> {
+            *self.last_command.lock().unwrap() = command.to_string();
+            Err(filar_core::CoreError::Other(format!(
+                "command failed: {command}"
+            )))
+        }
+        async fn cancel(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn error_path_is_sanitised() {
+        let provider = Arc::new(StaticSecretProvider::new());
+        provider.insert("$FILAR_SECRET_1", "s3cr3t");
+        let provider_trait: Arc<dyn SecretProvider> = provider;
+
+        let mock = Arc::new(FailingMockExecutor {
+            last_command: Mutex::new(String::new()),
+        });
+        let exec = SecretSubstitutingExecutor::new(mock, provider_trait);
+
+        let result = exec.run("echo $FILAR_SECRET_1").await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            !err_msg.contains("s3cr3t"),
+            "secret leaked in error: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("$FILAR_SECRET_1"),
+            "placeholder missing in error: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn substring_collision_with_10_plus_secrets() {
+        let provider = Arc::new(StaticSecretProvider::new());
+        provider.insert("$FILAR_SECRET_1", "one");
+        provider.insert("$FILAR_SECRET_10", "ten");
+        let provider_trait: Arc<dyn SecretProvider> = provider;
+
+        let mock = Arc::new(MockExecutor::new("one and ten"));
+        let exec = SecretSubstitutingExecutor::new(mock.clone(), provider_trait);
+
+        let result = exec
+            .run("echo $FILAR_SECRET_1 and $FILAR_SECRET_10")
+            .await
+            .unwrap();
+
+        // Both secrets should be correctly substituted in the command.
+        assert_eq!(
+            *mock.last_command.lock().unwrap(),
+            "echo one and ten"
+        );
+        // Both should be correctly masked in the output.
+        assert_eq!(
+            result.stdout,
+            "$FILAR_SECRET_1 and $FILAR_SECRET_10"
+        );
+    }
+
+    #[tokio::test]
+    async fn api_key_not_substituted() {
+        let provider = Arc::new(StaticSecretProvider::new());
+        provider.insert("GLM_API_KEY", "sk-1234567890");
+        provider.insert("$FILAR_SECRET_1", "runtime-secret");
+        let provider_trait: Arc<dyn SecretProvider> = provider;
+
+        let mock = Arc::new(MockExecutor::new(""));
+        let exec = SecretSubstitutingExecutor::new(mock.clone(), provider_trait);
+
+        let _ = exec.run("echo GLM_API_KEY").await.unwrap();
+
+        // GLM_API_KEY is NOT substituted because it lacks the $ prefix.
+        assert_eq!(
+            *mock.last_command.lock().unwrap(),
+            "echo GLM_API_KEY"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -6,7 +6,7 @@
 
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
-use filar_core::{ChatBlock, CommandConfirmMode};
+use filar_core::{ChatBlock, CommandConfirmMode, StaticSecretProvider};
 use ratatui::layout::Rect;
 
 use crate::event::TuiEvent;
@@ -15,7 +15,7 @@ use crate::ui::layout_cache::ChatLayoutCache;
 use crate::ui::Theme;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 use std::time::Duration;
 
@@ -186,9 +186,9 @@ pub struct App {
     pending_term_input: Option<Vec<u8>>,
     /// Flag: user pressed Ctrl+T to toggle between agent and interactive modes.
     pub toggle_interactive: bool,
-    /// Shared secret variables: $FILAR_SECRET_N → actual value.
+    /// Shared secret provider: $FILAR_SECRET_N → actual value.
     /// Used to substitute secrets in commands without exposing them to the LLM.
-    pub secrets: Arc<Mutex<HashMap<String, String>>>,
+    pub secrets: Arc<StaticSecretProvider>,
     /// Counter for the next secret variable name.
     pub secret_counter: usize,
     /// History of all user inputs (for Up/Down navigation).
@@ -285,7 +285,7 @@ impl App {
             terminal: None,
             pending_term_input: None,
             toggle_interactive: false,
-            secrets: Arc::new(Mutex::new(HashMap::new())),
+            secrets: Arc::new(StaticSecretProvider::new()),
             secret_counter: 0,
             input_history: Vec::new(),
             history_pos: None,
@@ -620,9 +620,7 @@ impl App {
                             // Regular secret variable — never sent to the LLM.
                             self.secret_counter += 1;
                             let var_name = format!("$FILAR_SECRET_{}", self.secret_counter);
-                            if let Ok(mut secrets) = self.secrets.lock() {
-                                secrets.insert(var_name.clone(), password);
-                            }
+                            self.secrets.insert(var_name.clone(), password);
                             let agent_msg = format!(
                                 "Password provided as secret variable {}. \
                                  Use this variable directly in your commands.",

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -4,9 +4,8 @@
 //! (keyboard) and agent events (from the agent task). The agent runs in a
 //! separate tokio task, and communication happens via channels.
 
-use std::collections::HashMap;
 use std::io::{self, Stdout};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crossterm::event::{EnableMouseCapture, DisableMouseCapture, Event, EventStream};
@@ -18,7 +17,7 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use filar_agent::{AgentBuilder, CommandConfirmer, LlmClient};
-use filar_core::{CommandConfirmMode, CoreError, Result};
+use filar_core::{CommandConfirmMode, CoreError, Result, SecretProvider};
 use filar_transport::{CommandExecutor, InteractiveTerminal, LocalInteractive, SshInteractive};
 use tokio_util::sync::CancellationToken;
 
@@ -30,20 +29,17 @@ use crate::ui;
 use filar_core::ChatBlock;
 
 // ---------------------------------------------------------------------------
-// TuiExecutor — wraps an executor and emits events
+// TuiExecutor — wraps an executor for runtime swapping
 // ---------------------------------------------------------------------------
 
-/// A [`CommandExecutor`] wrapper that handles secret substitution and
-/// output sanitization.
+/// A [`CommandExecutor`] wrapper whose inner executor is swappable at runtime.
 ///
-/// The inner executor is swappable at runtime, allowing the transport
-/// to switch from local to SSH (or vice versa) without restarting the app.
-/// Command execution events are emitted by the agent via `EventSink`, not
-/// by this wrapper.
+/// This allows the transport to switch from local to SSH (or vice versa)
+/// without restarting the app. Secret substitution and output sanitisation
+/// are handled by [`SecretSubstitutingExecutor`] in the engine, which wraps
+/// this executor during `AgentBuilder::build()`.
 struct TuiExecutor {
     inner: Arc<tokio::sync::RwLock<Arc<dyn CommandExecutor>>>,
-    /// Shared secret variables for command substitution.
-    secrets: Arc<Mutex<HashMap<String, String>>>,
 }
 
 impl TuiExecutor {
@@ -57,40 +53,8 @@ impl TuiExecutor {
 #[async_trait::async_trait]
 impl CommandExecutor for TuiExecutor {
     async fn run(&self, command: &str) -> Result<filar_transport::CommandResult> {
-        // Substitute secret variables ($FILAR_SECRET_N) with actual values
-        // before executing the command.
-        let actual_command = {
-            let mut cmd = command.to_string();
-            if let Ok(secrets) = self.secrets.lock() {
-                for (var, value) in secrets.iter() {
-                    if !value.is_empty() {
-                        cmd = cmd.replace(var, value);
-                    }
-                }
-            }
-            cmd
-        };
-
-        let mut result = {
-            let executor = self.inner.read().await.clone();
-            executor.run(&actual_command).await?
-        };
-
-        // Sanitize output — replace any secret value with its variable name
-        // so the LLM never sees the actual password in command output.
-        {
-            let secrets = self.secrets.lock();
-            if let Ok(secrets) = secrets {
-                for (var, value) in secrets.iter() {
-                    if !value.is_empty() {
-                        result.stdout = result.stdout.replace(value, var);
-                        result.stderr = result.stderr.replace(value, var);
-                    }
-                }
-            }
-        }
-
-        Ok(result)
+        let executor = self.inner.read().await.clone();
+        executor.run(command).await
     }
 
     async fn cancel(&self) -> Result<()> {
@@ -157,6 +121,10 @@ pub struct TuiConfig {
     pub ssh_target: Option<filar_core::SshTarget>,
     /// Whether commands execute on the local machine (true) or over SSH (false).
     pub is_local: bool,
+    /// Secret provider for command substitution and output sanitisation.
+    /// Shared between the TUI (for dynamic `$FILAR_SECRET_N` insertion) and
+    /// the agent (via `SecretSubstitutingExecutor`).
+    pub secret_provider: Arc<dyn SecretProvider>,
 }
 
 /// Run the TUI with the given LLM client, executor, and configuration.
@@ -229,12 +197,9 @@ async fn run_app(
     let mut is_local = config.is_local;
 
     // Create the TUI confirmer and executor wrappers.
-    // Share secrets between App and TuiExecutor for secure variable substitution.
-    let shared_secrets = app.secrets.clone();
     let confirmer = Arc::new(TuiConfirmer::new(agent_tx.clone()));
     let tui_executor = Arc::new(TuiExecutor {
         inner: Arc::new(tokio::sync::RwLock::new(executor)),
-        secrets: shared_secrets,
     });
 
     // Crossterm event stream for async keyboard input.
@@ -401,6 +366,7 @@ async fn run_app(
                             is_local,
                             ssh_info.clone(),
                             cancel_token,
+                            config.secret_provider.clone(),
                         );
                     }
                 }
@@ -581,6 +547,7 @@ fn spawn_agent(
     is_local: bool,
     ssh_info: Option<String>,
     cancellation: CancellationToken,
+    secret_provider: Arc<dyn SecretProvider>,
 ) {
     let tx = event_tx.clone();
 
@@ -636,7 +603,8 @@ fn spawn_agent(
             .confirmer(confirmer)
             .confirm_mode(confirm_mode)
             .event_sink(sink)
-            .cancellation(cancellation);
+            .cancellation(cancellation)
+            .secret_provider(secret_provider);
         if is_local {
             builder = builder.local_mode();
         } else {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -17,8 +17,10 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use filar_agent::{AgentBuilder, CommandConfirmer, LlmClient};
-use filar_core::{CommandConfirmMode, CoreError, Result, SecretProvider};
-use filar_transport::{CommandExecutor, InteractiveTerminal, LocalInteractive, SshInteractive};
+use filar_core::{CommandConfirmMode, CoreError, Result, SecretProvider, StaticSecretProvider};
+use filar_transport::{
+    CommandExecutor, InteractiveTerminal, LocalInteractive, SecretSubstitutingExecutor, SshInteractive,
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::app::{App, AppMode};
@@ -122,9 +124,9 @@ pub struct TuiConfig {
     /// Whether commands execute on the local machine (true) or over SSH (false).
     pub is_local: bool,
     /// Secret provider for command substitution and output sanitisation.
-    /// Shared between the TUI (for dynamic `$FILAR_SECRET_N` insertion) and
-    /// the agent (via `SecretSubstitutingExecutor`).
-    pub secret_provider: Arc<dyn SecretProvider>,
+    /// Shared between the TUI (for dynamic `$FILAR_SECRET_N` insertion via
+    /// Ctrl+P) and the agent (via `SecretSubstitutingExecutor`).
+    pub secret_provider: Arc<StaticSecretProvider>,
 }
 
 /// Run the TUI with the given LLM client, executor, and configuration.
@@ -186,6 +188,10 @@ async fn run_app(
             std::mem::take(&mut config.initial_messages),
         )
     };
+    // Wire the App to the same StaticSecretProvider instance used by the
+    // agent's SecretSubstitutingExecutor, so Ctrl+P inserts are visible to
+    // command substitution and output sanitisation.
+    app.secrets = config.secret_provider.clone();
 
     // Channel for agent → UI events.
     let (agent_tx, mut agent_rx) = mpsc::unbounded_channel::<TuiEvent>();
@@ -305,9 +311,17 @@ async fn run_app(
                         let cmd = stripped.trim().to_string();
                         if !cmd.is_empty() {
                             let exec = tui_executor.clone();
+                            let provider = config.secret_provider.clone();
                             let tx = agent_tx.clone();
                             tokio::spawn(async move {
-                                let succeeded = match exec.run(&cmd).await {
+                                // Wrap with SecretSubstitutingExecutor so that
+                                // $FILAR_SECRET_N placeholders are substituted
+                                // and output is sanitised — same as agent path.
+                                let wrapped = SecretSubstitutingExecutor::new(
+                                    exec as Arc<dyn CommandExecutor>,
+                                    provider as Arc<dyn SecretProvider>,
+                                );
+                                let succeeded = match wrapped.run(&cmd).await {
                                     Ok(result) => {
                                         // Build display output from CommandResult.
                                         let mut output = result.stdout.clone();


### PR DESCRIPTION
## Summary

Closes #46

Реализован `SecretProvider` — трейт для получения секретов не только из env, подготовка движка к внешним фронтендам (бот, мобилка).

### Что сделано

1. **`filar-core::secrets`** — новый трейт `SecretProvider` с методами `get(name)` и `secret_names()`:
   - `EnvSecretProvider` — читает из `std::env` (дефолт для TUI/десктопа)
   - `StaticSecretProvider` — in-memory `HashMap` через `Arc<RwLock<…>>`, mutable, zeroize на drop

2. **`filar-transport::SecretSubstitutingExecutor`** — обёртка над `CommandExecutor`: подстановка `$FILAR_SECRET_N` перед выполнением, маскирование значений в stdout/stderr после. **Перенесено из TUI в движок.**

3. **`filar-agent::glm::GlmClient::new_with_provider`** — получает API-ключ через `SecretProvider`, без прямого `std::env::var`.

4. **`AgentBuilder::secret_provider()`** — принимает `Arc<dyn SecretProvider>`, в `build()` оборачивает executor в `SecretSubstitutingExecutor`.

5. **`main.rs`** — создаёт `StaticSecretProvider`, загружает API-ключ, передаёт в TUI через `TuiConfig.secret_provider`.

6. **TUI** — `TuiExecutor` упрощён (только swapping executor'а), подстановка/санитизация теперь в движке. `App.secrets` заменён с `Arc<Mutex<HashMap>>` на `Arc<StaticSecretProvider>`.

7. **`zeroize` crate** добавлен в workspace + `filar-core`.

### DoD

- [x] Ни одного прямого `std::env::var` для секретов вне `EnvSecretProvider`
- [x] Тесты подстановки/санитизации проходят с обоими провайдерами
- [x] TUI/GUI работают без изменений конфигурации

### Тесты

- **271 passed, 0 failed, 5 ignored** (docker-sshd — ручная проверка)
- `cargo clippy --workspace` — чисто

### Не вошло в скоуп

- SSH_PASSWORD в `ssh.rs`/`interactive.rs` — транспортный credential, не engine secret
- `#[ignore]`-тесты (docker-sshd) — не запускались, требуют ручной проверки

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secrets can now be managed at runtime through a provider-based flow, including adding and reusing multiple secrets in the app.
  * Secret values entered in the UI are now handled more safely and can be masked in command output.

* **Bug Fixes**
  * Improved secret handling so sensitive values are less likely to appear in logs or command results.
  * Environment-based secrets now support more flexible lookup and missing-value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->