### PR TITLE
refactor(agent): rename GlmClient to OpenAiCompatClient (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed the LLM client `GlmClient` → `OpenAiCompatClient` (module `glm` →
+  `openai_compat`); filar works with any OpenAI-compatible endpoint, not just
+  GLM. `GlmClient` stays as a deprecated re-export alias for back-compat (#71).
+
+### Added
+
+- README "Choosing an LLM" section with a verified-providers table and
+  OpenAI-compatibility notes; `docs/ENGINE_API.md` local-model example and
+  `key_env` override note (#71).
+
 ## [0.3.1] - 2026-07-14
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1862,3 +1862,43 @@ milestone v0.3.1 продолжается следующими issue.
 
 **Дальше:** issue #71 (GlmClient → OpenAiCompatClient) — переименование клиента,
 зависит от этого PR (обе правят `glm.rs`).
+
+---
+
+## Issue #71: GlmClient → OpenAiCompatClient — любой OpenAI-compatible endpoint (milestone v0.4.0)
+
+**Что сделано:**
+- Файл `crates/agent/src/glm.rs` → `openai_compat.rs` (git rename), структура
+  `GlmClient` → `OpenAiCompatClient` (включая `impl LlmClient` и `impl`-блоки,
+  smoke-тесты). Тело запроса и поведение не изменились.
+- В `lib.rs`: `pub mod openai_compat;`, `pub use OpenAiCompatClient;` и
+  deprecated-алиас `pub use OpenAiCompatClient as GlmClient;`
+  (`#[deprecated(note = "renamed to OpenAiCompatClient")]`) — обратная
+  совместимость для внешних потребителей движка до следующего мажорного тега.
+- `app/main.rs` переведён на `OpenAiCompatClient` (чтобы не триггерить
+  deprecation-warning под `-D warnings`).
+- Rustdoc/комментарии/логи: формулировки «the GLM API» → «OpenAI-compatible API
+  (default: GLM)». Дефолты конфига (GLM, `GLM_API_KEY`) сохранены; в доке указано
+  переопределение env-ключа через `LlmProfile::key_env`.
+- `README.md`: раздел «Choosing an LLM» с таблицей проверенных провайдеров
+  (GLM cloud — verified, Ollama — pending manual check) и заметками о
+  совместимости (стриминг tool_calls по `index`, непустой `content` при
+  tool_calls, пустой `tools` массив уже опускается — подтверждено тестом).
+- `docs/ENGINE_API.md`: пример переименован на `OpenAiCompatClient` (с пометкой
+  про deprecated-алиас), добавлен раздел про локальную/стороннюю модель
+  (`api_base_url = http://localhost:11434/v1`, ключ-заглушка) и `key_env`.
+- Тесты: добавлен `glm_client_alias_still_compiles` (`#[allow(deprecated)]`) —
+  доказывает, что `crate::GlmClient` и `OpenAiCompatClient` — один тип; golden-
+  тест на тело запроса остался зелёным.
+
+**Публичные контракты:**
+- `filar_agent::openai_compat::OpenAiCompatClient` — новое имя клиента (was
+  `filar_agent::glm::GlmClient`).
+- `filar_agent::GlmClient` — deprecated re-export-алиас (временно).
+- Модуль `filar_agent::glm` переименован в `filar_agent::openai_compat`.
+
+**Ручная проверка:** Ollama-эндпоинт не проверялся в этом PR (нет локального
+сервера) — отмечен в таблице как pending manual check.
+
+**Дальше:** issue #72–#74 (eval-каркас, датасет, CI smoke) — оставшиеся задачи
+milestone v0.4.0.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Filar is a Rust-based terminal application that integrates an AI agent (LLM) wit
 
 ## Features
 
-- **AI Agent** — powered by GLM (OpenAI-compatible API), with tool calling support
+- **AI Agent** — powered by any OpenAI-compatible LLM (default: GLM), with tool calling support
 - **SSH Remote Execution** — agent manages remote machines via SSH, zero-install (no files left on the remote)
 - **Local Mode** — run commands on your own machine via PowerShell
 - **TUI Interface** — built with [ratatui](https://ratatui.rs/) + [crossterm](https://github.com/crossterm-rs/crossterm)
@@ -116,6 +116,55 @@ filar --session <session-id>
 
 ---
 
+## Choosing an LLM
+
+Filar works with **any OpenAI-compatible** `chat/completions` endpoint — the
+agent client is not GLM-specific. You switch providers by changing only the
+config (`model`, `api_base_url`, and the API key env var).
+
+The default profile points at the GLM cloud (`open.bigmodel.cn`,
+`GLM_API_KEY`). To use a local model (Ollama / LM Studio) or another cloud
+provider, point `api_base_url` at its OpenAI-compatible base URL and supply
+the key its API expects (local servers usually accept any non-empty string):
+
+```toml
+[llm]
+model = "llama3.1"
+api_base_url = "http://localhost:11434/v1"
+max_tokens = 4096
+temperature = 0.3          # local models benefit from lower temperature
+```
+
+### Verified providers
+
+| Provider | Endpoint | Tool calling | Streaming | Notes |
+|----------|----------|--------------|-----------|-------|
+| GLM cloud | `https://open.bigmodel.cn/api/paas/v4` | verified | verified | Default profile; key via `GLM_API_KEY`. |
+| Ollama (local) | `http://localhost:11434/v1` | pending manual check | pending manual check | OpenAI-compatible; set a non-empty key. |
+
+> The table lists only what has been checked by hand. Add rows as more
+> providers are verified (including via the eval tasks of milestone v0.4.0).
+
+### Provider differences to be aware of
+
+These are known OpenAI-compatibility quirks that may surface in filar's request
+cycle. They are **not** patched with hacks in the client; they are documented
+here, and critical ones get separate issues.
+
+- **Streaming `tool_calls` deltas** — filar accumulates streamed tool-call
+  fragments keyed by the `index` field (per the OpenAI streaming spec). GLM
+  follows this. If a provider streams tool calls without a stable `index`,
+  accumulation may mis-order; verify per provider.
+- **Non-empty `content` on assistant tool-call messages** — filar always
+  serializes a `content` string (possibly empty) on assistant messages that
+  carry `tool_calls`. Some servers reject an empty/`null` `content` in that
+  case; if so, file an issue rather than special-casing the client.
+- **Empty `tools` array** — filar omits `tools` entirely when empty
+  (`skip_serializing_if = "Vec::is_empty"`), confirmed by tests. Servers that
+  reject a present-but-empty `tools` array are therefore unaffected.
+
+---
+
 ## Usage
 
 ### Agent Mode
@@ -177,7 +226,7 @@ filar/
 ├── crates/
 │   ├── core/        # Config, errors, secrets, chat, sessions
 │   ├── transport/   # CommandExecutor trait: SSH + Local implementations
-│   ├── agent/       # LLM client (GLM), agent loop, tools, security
+│   ├── agent/       # LLM client (OpenAI-compatible), agent loop, tools, security
 │   ├── tui/         # Terminal UI (ratatui + crossterm + alacritty_terminal)
 │   ├── gui/         # GUI launcher (egui + keyring)
 │   └── app/         # Binary: ties everything together
@@ -205,7 +254,7 @@ cargo test
 
 62 unit tests covering:
 - Agent loop (text response, tool calls, max iterations)
-- GLM client (serialization, deserialization)
+- OpenAI-compatible client (serialization, deserialization)
 - Security (destructive command detection, confirm modes)
 - Tools (parsing, shell quoting)
 - TUI (terminal model, key mapping, app state)

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,22 +1,33 @@
 //! Agent crate: LLM client, agent loop, and tools.
 //!
 //! This crate houses:
-//! - The [`LlmClient`] trait and its `GlmClient` implementation (Stage 4).
+//! - The [`LlmClient`] trait and its `OpenAiCompatClient` implementation (Stage 4).
 //! - The agent loop that orchestrates LLM ↔ tool execution (Stage 5).
 //! - Tool definitions (`run_command`, `read_file`, `list_dir`) (Stage 5).
 //! - Security layer: confirmation, destructive command detection (Stage 5).
 
 pub mod agent;
 pub mod events;
-pub mod glm;
+pub mod openai_compat;
 pub mod security;
 pub mod tools;
 
 // Re-export key types for convenience.
 pub use agent::{Agent, AgentBuilder};
 pub use events::{AgentEvent, EventSink};
+pub use openai_compat::OpenAiCompatClient;
 pub use security::{CliConfirmer, CommandConfirmer, ConfirmDecision};
 pub use tools::{tool_definitions, ToolKind};
+
+/// Deprecated alias for [`OpenAiCompatClient`].
+///
+/// `GlmClient` was renamed to `OpenAiCompatClient` because the client is not
+/// GLM-specific — it speaks the standard OpenAI-compatible `chat/completions`
+/// protocol and works with any such endpoint (default: GLM). The alias is kept
+/// temporarily so external engine consumers (bots, mobile) keep compiling; it
+/// will be removed at the next major engine tag.
+#[deprecated(note = "renamed to OpenAiCompatClient")]
+pub use openai_compat::OpenAiCompatClient as GlmClient;
 
 use filar_core::Result;
 
@@ -26,8 +37,9 @@ use filar_core::Result;
 
 /// Trait abstracting an LLM backend.
 ///
-/// The primary implementation is [`glm::GlmClient`] targeting the GLM API.
-/// The trait allows swapping models without touching the agent loop.
+/// The primary implementation is [`openai_compat::OpenAiCompatClient`] targeting
+/// any OpenAI-compatible API (default: GLM). The trait allows swapping models
+/// without touching the agent loop.
 #[async_trait::async_trait]
 pub trait LlmClient: Send + Sync {
     /// Send a chat request and return the model's response.

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -1,13 +1,17 @@
-//! GLM LLM client — OpenAI-compatible `chat/completions` API.
+//! OpenAI-compatible LLM client — `chat/completions` API.
 //!
-//! Implements [`crate::LlmClient`] using `reqwest` to talk to the GLM
-//! platform (e.g. `open.bigmodel.cn`). The API is OpenAI-compatible, so the
-//! request/response shapes mirror the standard `chat/completions` format with
-//! tool/function calling support.
+//! Implements [`crate::LlmClient`] using `reqwest` to talk to any
+//! OpenAI-compatible endpoint (default: the GLM platform, e.g.
+//! `open.bigmodel.cn`). The request/response shapes mirror the standard
+//! `chat/completions` format with tool/function calling support, so any
+//! provider implementing that protocol (GLM cloud, Ollama / LM Studio at
+//! `http://localhost:11434/v1`, DeepSeek, OpenAI, …) works by changing only
+//! the config.
 //!
 //! # Features
 //! - Configurable model, base URL, and max tokens (from [`filar_core::LlmConfig`]).
-//! - API key read from the `GLM_API_KEY` environment variable.
+//! - API key read from the `GLM_API_KEY` environment variable by default
+//!   (overridable per profile via `filar_core::LlmProfile::key_env`).
 //! - Retries with exponential backoff on transient failures (5xx, 429, network).
 //! - Request timeout.
 //! - Tool calling (function calling) support.
@@ -33,11 +37,12 @@ const DEFAULT_MAX_RETRIES: u32 = 3;
 const DEFAULT_BACKOFF_BASE: Duration = Duration::from_millis(500);
 
 // ---------------------------------------------------------------------------
-// GlmClient
+// OpenAiCompatClient
 // ---------------------------------------------------------------------------
 
-/// [`LlmClient`] implementation backed by the GLM (OpenAI-compatible) API.
-pub struct GlmClient {
+/// [`LlmClient`] implementation backed by an OpenAI-compatible
+/// `chat/completions` API (default endpoint: GLM).
+pub struct OpenAiCompatClient {
     http: reqwest::Client,
     api_base_url: String,
     model: String,
@@ -51,15 +56,15 @@ pub struct GlmClient {
     extra_body: Option<serde_json::Value>,
 }
 
-impl GlmClient {
-    /// Create a new `GlmClient` from the given LLM config.
+impl OpenAiCompatClient {
+    /// Create a new `OpenAiCompatClient` from the given LLM config.
     ///
     /// The API key is read from the `GLM_API_KEY` environment variable.
     pub fn new(config: &LlmConfig, timeout: Duration) -> Result<Self> {
         Self::new_with_key(config, timeout, &secrets::glm_api_key()?)
     }
 
-    /// Create a new `GlmClient` using a [`SecretProvider`] to retrieve the
+    /// Create a new `OpenAiCompatClient` using a [`SecretProvider`] to retrieve the
     /// API key.  The `key_name` is the logical name passed to the provider
     /// (e.g. `"GLM_API_KEY"` or a profile-specific env var name).
     ///
@@ -75,7 +80,7 @@ impl GlmClient {
         Self::new_with_key(config, timeout, &api_key)
     }
 
-    /// Create a new `GlmClient` with an explicit API key (useful for testing).
+    /// Create a new `OpenAiCompatClient` with an explicit API key (useful for testing).
     pub fn new_with_key(config: &LlmConfig, timeout: Duration, api_key: &str) -> Result<Self> {
         let http = reqwest::Client::builder()
             .timeout(timeout)
@@ -118,7 +123,7 @@ impl GlmClient {
 }
 
 #[async_trait::async_trait]
-impl LlmClient for GlmClient {
+impl LlmClient for OpenAiCompatClient {
     async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse> {
         let api_request = ApiRequest::from_chat_request(
             request,
@@ -133,7 +138,7 @@ impl LlmClient for GlmClient {
             merge_extra_body(&mut body, extra);
         }
 
-        debug!(model = %self.model, "sending chat request to GLM API");
+        debug!(model = %self.model, "sending chat request to OpenAI-compatible API");
 
         // Retry loop with exponential backoff.
         let mut last_error: Option<ApiError> = None;
@@ -146,7 +151,7 @@ impl LlmClient for GlmClient {
 
             match self.send_request(&body).await {
                 Ok(response) => {
-                    debug!("GLM API request succeeded");
+                    debug!("OpenAI-compatible API request succeeded");
                     return response.try_into_chat_response();
                 }
                 Err(e) if e.is_retryable() => {
@@ -184,7 +189,7 @@ impl LlmClient for GlmClient {
             merge_extra_body(&mut body, extra);
         }
 
-        debug!(model = %self.model, "sending streaming chat request to GLM API");
+        debug!(model = %self.model, "sending streaming chat request to OpenAI-compatible API");
 
         // Retry loop for the initial connection only (not mid-stream).
         let response = {
@@ -273,7 +278,7 @@ impl LlmClient for GlmClient {
     }
 }
 
-impl GlmClient {
+impl OpenAiCompatClient {
     /// Send a single request to the API and return the raw response.
     async fn send_request(&self, body: &serde_json::Value) -> std::result::Result<ApiResponse, ApiError> {
         let response = self
@@ -300,7 +305,7 @@ impl GlmClient {
             // This way if parsing fails, we can include the actual response
             // body in the error message for debugging.
             let body_text = response.text().await.unwrap_or_default();
-            debug!(status = %status, body_len = body_text.len(), "GLM API success response");
+            debug!(status = %status, body_len = body_text.len(), "OpenAI-compatible API success response");
             let api_response: ApiResponse = serde_json::from_str(&body_text)
                 .map_err(|e| {
                     let preview = if body_text.len() > 500 {
@@ -315,7 +320,7 @@ impl GlmClient {
         } else {
             let status_code = status.as_u16();
             let body_text = response.text().await.unwrap_or_default();
-            info!(status_code, body = %body_text, "GLM API returned error status");
+            info!(status_code, body = %body_text, "OpenAI-compatible API returned error status");
             match status_code {
                 401 | 403 => Err(ApiError::Auth(format!("HTTP {status_code}: {body_text}"))),
                 429 => Err(ApiError::RateLimit(body_text)),
@@ -354,7 +359,7 @@ impl GlmClient {
         } else {
             let status_code = status.as_u16();
             let body_text = response.text().await.unwrap_or_default();
-            info!(status_code, body = %body_text, "GLM API returned error status");
+            info!(status_code, body = %body_text, "OpenAI-compatible API returned error status");
             match status_code {
                 401 | 403 => Err(ApiError::Auth(format!("HTTP {status_code}: {body_text}"))),
                 429 => Err(ApiError::RateLimit(body_text)),
@@ -973,7 +978,7 @@ mod tests {
             max_tokens: 256,
             ..Default::default()
         };
-        let client = GlmClient::new_with_key(&config, Duration::from_secs(60), &api_key).unwrap();
+        let client = OpenAiCompatClient::new_with_key(&config, Duration::from_secs(60), &api_key).unwrap();
 
         let request = ChatRequest {
             messages: vec![
@@ -998,7 +1003,7 @@ mod tests {
             max_tokens: 256,
             ..Default::default()
         };
-        let client = GlmClient::new_with_key(&config, Duration::from_secs(60), &api_key).unwrap();
+        let client = OpenAiCompatClient::new_with_key(&config, Duration::from_secs(60), &api_key).unwrap();
 
         let request = ChatRequest {
             messages: vec![
@@ -1364,5 +1369,24 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         let extra = serde_json::json!(42);
         merge_extra_body(&mut body, &extra);
         assert_eq!(body["model"], "glm-5.1");
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn glm_client_alias_still_compiles() {
+        // The deprecated `GlmClient` alias (re-exported in `lib.rs`) must
+        // resolve to the same type as `OpenAiCompatClient`, so existing engine
+        // consumers (bots, mobile) keep compiling until the next major engine
+        // tag removes the alias.
+        fn assert_same_type(_: &OpenAiCompatClient) {}
+        let config = LlmConfig {
+            model: "glm-5.1".into(),
+            api_base_url: "https://open.bigmodel.cn/api/paas/v4".into(),
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let client = crate::GlmClient::new_with_key(&config, Duration::from_secs(1), "dummy-key")
+            .unwrap();
+        assert_same_type(&client);
     }
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
-use filar_agent::glm::GlmClient;
+use filar_agent::OpenAiCompatClient;
 use filar_agent::LlmClient;
 use filar_core::{secrets, default_base_dir, Config, SessionStore, StaticSecretProvider};
 use filar_transport::{LocalExecutor, SshExecutor};
@@ -327,7 +327,7 @@ async fn run() -> anyhow::Result<()> {
     let secret_provider = Arc::new(StaticSecretProvider::new());
     secret_provider.insert(secrets::env_vars::GLM_API_KEY, &api_key);
 
-    let llm: Arc<dyn LlmClient> = Arc::new(GlmClient::new_with_provider(
+    let llm: Arc<dyn LlmClient> = Arc::new(OpenAiCompatClient::new_with_provider(
         &llm_config,
         Duration::from_secs(config.timeouts.llm_secs),
         secrets::env_vars::GLM_API_KEY,

--- a/docs/ENGINE_API.md
+++ b/docs/ENGINE_API.md
@@ -86,9 +86,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // 5. Build the agent.
+    // 5. Build the agent. `OpenAiCompatClient` speaks the OpenAI-compatible
+    //    chat/completions protocol (default endpoint: GLM). The deprecated
+    //    `GlmClient` alias still works for existing consumers.
     let agent = AgentBuilder::new()
-        .llm(Arc::new(filar_agent::GlmClient::new_with_provider(
+        .llm(Arc::new(filar_agent::OpenAiCompatClient::new_with_provider(
             &filar_core::LlmConfig {
                 api_base_url: "https://open.bigmodel.cn/api/paas/v4".into(),
                 model: "glm-4-flash".into(),
@@ -223,3 +225,51 @@ let config = LlmConfig {
     extra_body: Some(serde_json::json!({ "thinking": { "type": "disabled" } })),
 };
 ```
+
+## Using a local or third-party OpenAI-compatible model
+
+`OpenAiCompatClient` is provider-agnostic: point `api_base_url` at any
+OpenAI-compatible endpoint and supply the API key it expects. No code changes
+are needed — only the config.
+
+A local model served by [Ollama](https://ollama.com/) or LM Studio exposes an
+OpenAI-compatible API at `http://localhost:11434/v1` (Ollama) or
+`http://localhost:1234/v1` (LM Studio). Local servers usually do not check the
+key, but filar requires a non-empty value — pass any placeholder:
+
+```toml
+[llm]
+model = "llama3.1"
+api_base_url = "http://localhost:11434/v1"
+max_tokens = 4096
+temperature = 0.3
+```
+
+```rust
+use filar_core::LlmConfig;
+
+let config = LlmConfig {
+    model: "llama3.1".into(),
+    api_base_url: "http://localhost:11434/v1".into(),
+    max_tokens: 4096,
+    temperature: Some(0.3),
+    ..Default::default()
+};
+// key: any non-empty placeholder for a local server
+```
+
+### Choosing the API key environment variable
+
+By default the key is read from `GLM_API_KEY`. A profile can override this with
+`key_env` so each provider uses its own variable:
+
+```toml
+[[llm_profiles]]
+name = "local"
+model = "llama3.1"
+api_base_url = "http://localhost:11434/v1"
+key_env = "OLLAMA_KEY"          # any name; value just needs to be non-empty
+temperature = 0.3
+```
+
+Select it at launch with `--llm local` (or `Config::select_llm(Some("local"))`).


### PR DESCRIPTION
Closes #71

## Summary

Renames the LLM client `GlmClient` → `OpenAiCompatClient` (module `glm` →
`openai_compat`) to reflect that filar works with any OpenAI-compatible
endpoint, not just GLM. The request/response protocol is unchanged.

- `crates/agent/src/glm.rs` → `openai_compat.rs` (`GlmClient` → `OpenAiCompatClient`).
- `lib.rs`: `pub use OpenAiCompatClient;` plus a `#[deprecated]` `GlmClient`
  re-export alias — external engine consumers (bots, mobile) keep compiling
  until the next major engine tag.
- `app/main.rs`: switched to `OpenAiCompatClient` (avoids the deprecation
  warning under `-D warnings`).
- Defaults unchanged (GLM cloud, `GLM_API_KEY`); rustdoc/comments/log strings
  reworded from "the GLM API" to "OpenAI-compatible API (default: GLM)".
- `README.md`: new "Choosing an LLM" section with a verified-providers table
  and OpenAI-compatibility notes.
- `docs/ENGINE_API.md`: minimal example updated; added a local/third-party
  model example (`http://localhost:11434/v1`, placeholder key) and a `key_env`
  override note.

## Tests

- `cargo build --workspace` — green.
- `cargo test --workspace` — 203 passed, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings` — green (the
  deprecated alias does not warn; the alias-compile test uses `#[allow(deprecated)]`).
- Added `glm_client_alias_still_compiles` proving `crate::GlmClient` and
  `OpenAiCompatClient` are the same type. Golden test on the request body
  remains green (body unchanged).

## Requires manual check

- Ollama endpoint (`http://localhost:11434/v1`) was not verified in this PR
  (no local server available). Marked "pending manual check" in the README
  provider table. Tool-calling and streaming on Ollama should be confirmed
  separately (and via the v0.4.0 eval tasks).
- `#[ignore]` SSH integration tests (docker-sshd) not run by the agent.

## Out of scope

- Historical plan docs (`PLAN.md`, `docs/plans/*`) and past `PROGRESS.md`
  entries still mention `GlmClient`/`glm.rs` — left as-is (journal of past
  state); only the "Дальше" pointer and a new #71 entry were updated.
- No behavior change to the client; provider incompatibilities are documented,
  not patched (per the issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for any OpenAI-compatible chat/completions endpoint, including local providers such as Ollama and LM Studio.
  * Added configurable provider selection through model, API base URL, and API key settings.
  * Renamed the primary LLM client to `OpenAiCompatClient`; the previous name remains available as a deprecated compatibility alias.

* **Documentation**
  * Added provider selection guidance, verified provider information, local model setup instructions, and notes on provider-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->