### PR TITLE
fix(eval): add throttling, retry-on-429 wrapper, and limits documentation

### DIFF
--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -64,9 +64,12 @@ jobs:
         run: npm install -g promptfoo@0.121.19
 
       # Low temperature (0) and throttling are set in promptfooconfig.yaml.
+      # PROMPTFOO_BIN uses the globally installed (pinned) version, not npx@latest.
       - name: Run smoke subset with retry wrapper
         id: run1
         continue-on-error: true
+        env:
+          PROMPTFOO_BIN: promptfoo
         run: |
           node eval/scripts/run-eval.js --smoke \
             --filter-metadata smoke=true \

--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -1,7 +1,7 @@
 name: Eval smoke
 
-# Regression smoke for filar's agent eval (methodology §10): runs a 10-case
-# subset against one baseline model whenever the system prompt / agent loop /
+# Regression smoke for filar's agent eval (methodology §10): runs a 12-case
+# smoke subset against one baseline model whenever the system prompt / agent loop /
 # dataset changes, and on manual dispatch. Skips (does not fail) on forks or
 # repos without the OPENROUTER_API_KEY secret.
 
@@ -42,7 +42,7 @@ jobs:
           fi
 
   smoke:
-    name: eval smoke (10 cases, GLM-5.2)
+    name: eval smoke (12 cases, GLM-5.2)
     needs: check-secret
     if: needs.check-secret.outputs.has_secret == 'true'
     runs-on: ubuntu-latest
@@ -63,16 +63,16 @@ jobs:
         # re-validate locally before changing.
         run: npm install -g promptfoo@0.121.19
 
-      # Low temperature (0) is set in promptfooconfig.yaml for reproducibility.
-      - name: Run smoke subset
+      # Low temperature (0) and throttling are set in promptfooconfig.yaml.
+      - name: Run smoke subset with retry wrapper
         id: run1
         continue-on-error: true
         run: |
-          promptfoo eval -c eval/promptfooconfig.yaml \
+          node eval/scripts/run-eval.js --smoke \
             --filter-metadata smoke=true \
             --filter-providers 'glm-5.2' \
             --no-cache \
-            -o eval/results.json
+            -c eval/promptfooconfig.yaml
 
       - name: Check pass rate (≥ 90%)
         id: check1
@@ -81,7 +81,9 @@ jobs:
         run: node eval/scripts/smoke-check.js eval/results.json 90
 
       # One automatic retry of the failed cases (LLMs are non-deterministic);
-      # if the retry is still red, the job fails.
+      # if the retry is still red, the job fails. If the failure is a 429 rate
+      # limit, the retry message signals it clearly — rate limits are not
+      # regressions.
       - name: Retry failed cases once (flakiness)
         if: steps.check1.outcome == 'failure'
         run: |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2182,3 +2182,45 @@ rubric-only). Пересобрать smoke-набор до ~12 кейсов.
 **Тесты:** `cargo test -p filar-agent -p filar-core` — 96 passed, 0 failed.
 `node eval/asserts.test.js` — 15 asserts passed. Контрольный прогон на двух
 моделях (фронтир + якорь) — ручная проверка (требует `OPENROUTER_API_KEY`).
+
+---
+
+## Issue #85: Eval — троттлинг и ретраи на 429
+
+**Проблема:** при полном прогоне (10 моделей × 50 кейсов + вызовы судьи)
+несколько моделей получали 429 Too Many Requests от OpenRouter:
+- Параллелизм promptfoo по умолчанию бил в rate limit провайдера;
+- Бесплатные модели (`:free`) жёстко лимитированы (~20 req/min + суточные
+  лимиты);
+- Вызовы судьи удваивают нагрузку на рубричных кейсах.
+
+**Что сделано:**
+- `eval/promptfooconfig.yaml`:
+  - Глобальный `maxConcurrency: 4` — умеренный параллелизм для платных моделей.
+  - Per-provider throttling для `:free` моделей (HY3, Nemotron):
+    `maxConcurrency: 1`, `delay: 3000` (3с между запросами).
+  - Комментарии обновлены: dataset 50, milestone v0.4.1.
+- `eval/scripts/run-eval.js` — новый скрипт-обёртка над `promptfoo eval`:
+  - После первого прогона парсит `results.json`, находит кейсы с API-ошибками
+    (429, timeout) — НЕ assertion failures.
+  - Ретраит с экспоненциальной задержкой: 30с / 60с / 120с, макс. 3 попытки.
+  - Флаг `--smoke` для CI — короткое замыкание без ретраев.
+  - Подсказка при первом ретрае: про лимиты :free моделей и раздельный прогон.
+- `eval/README.md`: новый раздел «Limits and cost» — таблица throttling,
+  лимиты :free моделей, описание run-eval.js, оценка стоимости ($0.10–$2).
+  Обновлена секция «Running» — примеры с run-eval.js wrapper'ом. Обновлена
+  CI-секция (12 smoke-кейсов вместо 10).
+- `.github/workflows/eval-smoke.yml`:
+  - Smoke-прогон через `node eval/scripts/run-eval.js --smoke` (throttling
+    из конфига применяется автоматически).
+  - Название джобы и комментарии обновлены (12 cases).
+  - Ретрай флаков (существующий) сохранён — 429 не маскируется, job падает
+    с внятным сообщением если rate limit исчерпал все попытки.
+
+**Публичные контракты:** без изменений (eval — отдельный слой; Rust-код
+не тронут).
+
+**Тесты:** `cargo test -p filar-agent -p filar-core` — 96 passed, 0 failed.
+`node eval/asserts.test.js` — 15 asserts passed. `node -e "require('./eval/scripts/run-eval.js')"` —
+скрипт загружается без синтаксических ошибок. Полный прогон с ретраями —
+ручная проверка (требует `OPENROUTER_API_KEY`, `npx`, promptfoo).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2224,3 +2224,23 @@ rubric-only). Пересобрать smoke-набор до ~12 кейсов.
 `node eval/asserts.test.js` — 15 asserts passed. `node -e "require('./eval/scripts/run-eval.js')"` —
 скрипт загружается без синтаксических ошибок. Полный прогон с ретраями —
 ручная проверка (требует `OPENROUTER_API_KEY`, `npx`, promptfoo).
+
+**Правки по ревью (PR #88, devlawey):**
+- `eval/promptfooconfig.yaml`: `maxConcurrency`/`delay` вынесены из `config:` на
+  уровень провайдера (внутри `config:` OpenRouter-клиент игнорировал их).
+- `eval/scripts/run-eval.js`: полный rewrite:
+  - Бинарник promptfoo — через `PROMPTFOO_BIN` env (дефолт `npx promptfoo`,
+    CI передаёт `promptfoo` для использования закреплённой версии).
+  - Ретрай теперь фильтрует `results.json` до error-only перед `--filter-failing`,
+    assertion failures не ретраятся.
+  - Результаты ретраев мержатся с результатами первого прогона (keep passing,
+    overlay retried), а не перезаписываются.
+  - `--smoke` exit 1 если results отсутствуют, 0 если прогон ok.
+  - Пользовательский `-o` фильтруется из extraArgs (скрипт сам управляет
+    выходным файлом).
+  - Комментарий про exit-код исправлен.
+- `.github/workflows/eval-smoke.yml`: `PROMPTFOO_BIN: promptfoo` — использует
+  глобально установленную закреплённую версию.
+- `eval/README.md`: диапазон стоимости приведён к единому ($0.10–$2.00),
+  добавлена заметка про удвоение нагрузки от судьи и рекомендация снизить
+  `maxConcurrency` до 2 для больших прогонов.

--- a/eval/README.md
+++ b/eval/README.md
@@ -78,6 +78,12 @@ buckets B and C.
 | Per-provider `maxConcurrency` | 1 | `:free` models only (HY3, Nemotron) |
 | Per-provider `delay` | 3000 ms | `:free` models only |
 
+> **Note on judge load:** every rubric case in buckets B and C triggers a second
+> API call to the judge model, roughly doubling the load for those cases. The
+> global `maxConcurrency: 4` covers paid models + judge calls together; for
+> very large runs (all 10 models with many rubric cases), consider lowering it
+> to 2.
+
 ### Free model limits
 
 OpenRouter `:free` models are **rate-limited to ~20 requests/minute** with
@@ -100,9 +106,10 @@ Use `--smoke` to skip retries (CI mode — fails immediately on low pass rate).
 ### Cost estimate
 
 OpenRouter pricing varies widely. A full 10-model × 50-case run costs roughly
-**$0.10–$1.50** depending on model mix. The judge (`mistralai/mistral-large`)
-adds ~$0.05 per run. `:free` models have zero cost. Budget ~$2 for a complete
-rerun.
+**$0.10–$2.00** depending on model mix (free models cost $0; frontier models
+like GPT-5.6-SOL are the most expensive). The judge (`mistralai/mistral-large`)
+adds ~$0.05 per run. Budget ~$2 for a complete rerun, ~$3 if you also pay for
+a frontier model judge call on every B/C case.
 
 ## Models (changing them)
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -48,18 +48,61 @@ for the current session only).
 ## Running
 
 ```bash
-# run all configured models against the 30-case dataset (writes eval/results.json)
+# full run with retry-on-429 wrapper (recommended):
+node eval/scripts/run-eval.js -c eval/promptfooconfig.yaml
+
+# without retries (faster, but 429 errors will remain as errors):
 npx promptfoo@latest eval -c eval/promptfooconfig.yaml -o eval/results.json
 
 # open the local web report (table: tests × models, PASS/FAIL, latency, cost)
 npx promptfoo@latest view
 
-# export a shareable report
-npx promptfoo@latest eval -c eval/promptfooconfig.yaml -o results.html
+# smoke subset (CI-compatible, no retries):
+node eval/scripts/run-eval.js --smoke --filter-metadata smoke=true -c eval/promptfooconfig.yaml
 ```
 
 To run fewer models, comment out their `- id: openrouter:...` block in
 `promptfooconfig.yaml`. Run outputs (`results.*`, `.promptfoo/`) are gitignored.
+
+## Limits and cost
+
+A full run (50 cases × 10 models + judge calls) makes **~500+ API requests**.
+Judge calls for `llm-rubric` asserts roughly double the per-model load for
+buckets B and C.
+
+### Throttling (`promptfooconfig.yaml`)
+
+| Setting | Value | Applies to |
+|---|---|---|
+| `maxConcurrency` | 4 (global) | All paid models |
+| Per-provider `maxConcurrency` | 1 | `:free` models only (HY3, Nemotron) |
+| Per-provider `delay` | 3000 ms | `:free` models only |
+
+### Free model limits
+
+OpenRouter `:free` models are **rate-limited to ~20 requests/minute** with
+additional daily caps. On a full run, a `:free` model hits the daily limit
+after ~2 minutes. If you need consistent results for free models:
+
+- Run them separately: comment out all but one `:free` model, then repeat.
+- Use `--filter-providers 'hy3'` to run a single model.
+- Increase per-provider `delay` to 10000 for very tight limits.
+
+### Retry wrapper (`eval/scripts/run-eval.js`)
+
+If a full run produces 429/timeout errors, the retry wrapper:
+1. Identifies cases that failed with API errors (not assertion failures).
+2. Retries failed cases with `--filter-failing` after 30s / 60s / 120s delays.
+3. Max 3 retry attempts; assertion failures are never retried.
+
+Use `--smoke` to skip retries (CI mode — fails immediately on low pass rate).
+
+### Cost estimate
+
+OpenRouter pricing varies widely. A full 10-model × 50-case run costs roughly
+**$0.10–$1.50** depending on model mix. The judge (`mistralai/mistral-large`)
+adds ~$0.05 per run. `:free` models have zero cost. Budget ~$2 for a complete
+rerun.
 
 ## Models (changing them)
 
@@ -217,9 +260,12 @@ filar's real weak spots.
 ## CI (eval-smoke)
 
 `.github/workflows/eval-smoke.yml` is the regression contour (methodology §10).
-It runs a 10-case smoke subset (cases tagged `metadata.smoke: true` in
-`datasets/filar.yaml`: 4 operations, 4 safety, 2 language) against one baseline
+It runs a 12-case smoke subset (cases tagged `metadata.smoke: true` in
+`datasets/filar.yaml`: 5 operations, 4 safety, 3 language) against one baseline
 model (GLM-5.2) and fails the build if the pass rate drops below 90%.
+Throttling settings from `promptfooconfig.yaml` are applied automatically.
+The run is wrapped via `node eval/scripts/run-eval.js --smoke` which skips
+retries (429s in CI are handled by the flakiness retry step, not the wrapper).
 
 - **When it runs:** on `workflow_dispatch` (manual) and on `pull_request` to
   `main` that change `eval/prompts/**`, `crates/agent/src/**`, `eval/datasets/**`,

--- a/eval/promptfooconfig.yaml
+++ b/eval/promptfooconfig.yaml
@@ -1,4 +1,4 @@
-description: "filar agent eval — tool-calling on filar tasks (milestone v0.4.0)"
+description: "filar agent eval — tool-calling on filar tasks (milestone v0.4.1)"
 
 # Prompt under test = filar's real agent system prompt (SSH/POSIX remote
 # variant), synced with crates/agent/src/agent.rs via the
@@ -6,6 +6,11 @@ description: "filar agent eval — tool-calling on filar tasks (milestone v0.4.0
 # prompt: system message loaded from agent-system.txt + user {{question}}.
 prompts:
   - file://prompts/agent-chat.json
+
+# Global throttling — limits parallelism to avoid 429 Too Many Requests from
+# OpenRouter. A full run is ~500+ requests (50 cases × 10 models + judge calls).
+# Free models (`:free`) have per-provider stricter limits below.
+maxConcurrency: 4
 
 # Tool schema mirrors crates/agent/src/tools.rs::tool_definitions(). It is a
 # manual mirror (single-source sharing from Rust would need an export step);
@@ -104,6 +109,8 @@ providers:
       max_tokens: 1024
       timeoutMs: 300000
       tools: *filar_tools
+      maxConcurrency: 1
+      delay: 3000
   - id: openrouter:deepseek/deepseek-v4-pro
     label: DeepSeek-V4-Pro (OpenRouter)
     config:
@@ -125,8 +132,10 @@ providers:
       max_tokens: 1024
       timeoutMs: 300000
       tools: *filar_tools
+      maxConcurrency: 1
+      delay: 3000
 
-# Dataset — 30 cases in three buckets (operations / safety / language), see
+# Dataset — 50 cases in three buckets (operations / safety / language), see
 # eval/datasets/filar.yaml. Each case carries vars.bucket + vars.priority for
 # filtering runs (e.g. only `operations`). The #72 smoke cases are now part of
 # the dataset.

--- a/eval/promptfooconfig.yaml
+++ b/eval/promptfooconfig.yaml
@@ -109,8 +109,9 @@ providers:
       max_tokens: 1024
       timeoutMs: 300000
       tools: *filar_tools
-      maxConcurrency: 1
-      delay: 3000
+    maxConcurrency: 1
+    delay: 3000
+
   - id: openrouter:deepseek/deepseek-v4-pro
     label: DeepSeek-V4-Pro (OpenRouter)
     config:
@@ -132,8 +133,8 @@ providers:
       max_tokens: 1024
       timeoutMs: 300000
       tools: *filar_tools
-      maxConcurrency: 1
-      delay: 3000
+    maxConcurrency: 1
+    delay: 3000
 
 # Dataset — 50 cases in three buckets (operations / safety / language), see
 # eval/datasets/filar.yaml. Each case carries vars.bucket + vars.priority for

--- a/eval/scripts/run-eval.js
+++ b/eval/scripts/run-eval.js
@@ -2,19 +2,24 @@
 //
 // Wraps `promptfoo eval` with retry logic for rate-limited (429) and timed-out
 // cases. Retries use exponential backoff (30s / 60s / 120s, max 3 attempts).
-// Assertion failures (real evaluation results) are NOT retried — only API errors.
+// Only cases with API errors (429 / timeout / network) are retried; assertion
+// failures are preserved as-is.
 //
 // Usage:
 //   node eval/scripts/run-eval.js [--smoke] [extra promptfoo args...]
 //
 //   --smoke     : short circuit at first pass, no retries (for CI smoke workflow)
 //
-// Extra args are forwarded to promptfoo (e.g. --filter-providers, --no-cache).
-// Results are written to eval/results.json (and eval/results.retry.json on retry).
-// Exit code 0 = pass rate ≥ threshold (via smoke-check.js), 1 = below threshold.
+// Extra args are forwarded to promptfoo. The promptfoo binary is resolved as
+// `npx promptfoo` by default; set PROMPTFOO_BIN env to override.  Results are
+// written to eval/results.json (and eval/results.retry.json on retry).
+// Exit code 0 = pass rate ≥ threshold (via smoke-check.js), 1 = below threshold,
+// 2 = script error (missing results, unexpected failure).
 
 const { execSync } = require('child_process');
 const fs = require('fs');
+
+const PROMPTFOO_BIN = process.env.PROMPTFOO_BIN || 'npx promptfoo';
 
 const RESULTS = 'eval/results.json';
 const RETRY_RESULTS = 'eval/results.retry.json';
@@ -25,19 +30,8 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function hasErrors(file) {
-  try {
-    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-    const results = (data.results && data.results.results) || [];
-    const withErrors = results.filter((r) => r.error);
-    return withErrors.length > 0;
-  } catch {
-    return false;
-  }
-}
-
-function runPromptfoo(args) {
-  const cmd = `npx promptfoo@latest eval ${args.join(' ')}`;
+function promptfoo(args) {
+  const cmd = `${PROMPTFOO_BIN} ${args.join(' ')}`;
   console.log(`\n[run-eval] ${cmd}`);
   try {
     execSync(cmd, { stdio: 'inherit', cwd: process.cwd() });
@@ -47,27 +41,103 @@ function runPromptfoo(args) {
   }
 }
 
+function loadResults(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function errorCaseIds(file) {
+  const data = loadResults(file);
+  if (!data) return [];
+  const results = (data.results && data.results.results) || [];
+  return results.filter((r) => r.error).map((r) => r.id || r.description);
+}
+
+// Merge retry results back into the original results, keeping passing cases from
+// run 1 and overlaying retried (re-run) results for the failing subset.
+function mergeResults(originalFile, retryFile, outFile) {
+  const orig = loadResults(originalFile);
+  const retry = loadResults(retryFile);
+  if (!orig || !retry) return false;
+
+  const origResults = (orig.results && orig.results.results) || [];
+  const retryResults = (retry.results && retry.results.results) || [];
+
+  // Build a lookup by test id/description for the retried results.
+  const retryMap = new Map();
+  for (const r of retryResults) {
+    const key = r.id || r.description;
+    if (key) retryMap.set(key, r);
+  }
+
+  // Overlay: replace each original result if retry has a (newer) version.
+  const merged = origResults.map((r) => {
+    const key = r.id || r.description;
+    return retryMap.has(key) ? retryMap.get(key) : r;
+  });
+
+  const mergedData = { ...orig, results: { ...orig.results, results: merged } };
+  fs.writeFileSync(outFile, JSON.stringify(mergedData, null, 2));
+  return true;
+}
+
+function filterResultsToErrors(file, outFile) {
+  const data = loadResults(file);
+  if (!data) return false;
+
+  const results = (data.results && data.results.results) || [];
+  const errors = results.filter((r) => r.error);
+  const passes = results.filter((r) => !r.error);
+
+  console.log(`[run-eval] filtering: ${passes.length} pass + ${errors.length} error cases`);
+  if (errors.length === 0) return false;
+
+  const filtered = { ...data, results: { ...data.results, results: errors } };
+  fs.writeFileSync(outFile, JSON.stringify(filtered, null, 2));
+  return true;
+}
+
 async function main() {
   const isSmoke = process.argv.includes('--smoke');
-  const extraArgs = process.argv.slice(2).filter((a) => a !== '--smoke');
+  // Drop user-supplied -o — the wrapper manages output file naming.
+  const extraArgs = process.argv.slice(2).filter((a) => a !== '--smoke').filter((a, i, arr) => {
+    if (a === '-o') return false;
+    if (i > 0 && arr[i - 1] === '-o') return false;
+    return true;
+  });
 
   // Run 1: initial full run.
   const run1Args = [...extraArgs, '-o', RESULTS];
-  if (!runPromptfoo(run1Args)) {
-    console.error('\n[run-eval] initial eval run failed');
-  }
+  const run1ok = promptfoo(run1Args);
 
   if (isSmoke) {
-    // CI smoke — no retries, just check threshold.
+    if (!run1ok || !fs.existsSync(RESULTS)) {
+      console.error('[run-eval] smoke run failed — no results produced');
+      process.exit(1);
+    }
+    // CI smoke — no retries; pass-rate check is a separate CI step.
     process.exit(0);
   }
 
-  if (!hasErrors(RESULTS)) {
-    console.log('\n[run-eval] no API errors — skipping retries');
-    process.exit(0);
+  if (!run1ok) {
+    console.error('[run-eval] initial eval run failed');
   }
 
-  // Retries: only when there are API errors (429 / timeout), not assertion failures.
+  if (!fs.existsSync(RESULTS)) {
+    console.error('[run-eval] no results file produced');
+    process.exit(2);
+  }
+
+  const errorIds = errorCaseIds(RESULTS);
+  if (errorIds.length === 0) {
+    console.log(`\n[run-eval] no API errors — skipping retries`);
+    process.exit(0);
+  }
+  console.log(`\n[run-eval] ${errorIds.length} cases with API errors — will retry`);
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const delay = RETRY_DELAYS[attempt] || RETRY_DELAYS[RETRY_DELAYS.length - 1];
     console.log(`\n[run-eval] retry ${attempt + 1}/${MAX_RETRIES} after ${delay / 1000}s` + (attempt > 0 ? '' : `
@@ -75,28 +145,35 @@ async function main() {
     For fewer 429s, consider running free models separately or with longer delays.`));
     await sleep(delay);
 
-    const retryArgs = [
+    // Filter RESULTS to error-only, then retry only those cases.
+    const filterOk = filterResultsToErrors(RESULTS, 'eval/results.errors.json');
+    if (!filterOk) {
+      console.log('[run-eval] no errors to retry — exiting retry loop');
+      break;
+    }
+
+    promptfoo([
       ...extraArgs,
       '--filter-failing',
-      RESULTS,
+      'eval/results.errors.json',
       '-o',
       RETRY_RESULTS,
-    ];
-    runPromptfoo(retryArgs);
+    ]);
 
-    if (!hasErrors(RETRY_RESULTS)) {
+    if (!fs.existsSync(RETRY_RESULTS)) continue;
+
+    const stillErrors = errorCaseIds(RETRY_RESULTS);
+    // Merge retry results back: keep run-1 passes, overlay retried cases.
+    mergeResults(RESULTS, RETRY_RESULTS, RESULTS);
+
+    if (stillErrors.length === 0) {
       console.log(`\n[run-eval] all errors resolved after ${attempt + 1} retry attempts`);
-      // Merge: retried passes replace original errors.
-      fs.copyFileSync(RETRY_RESULTS, RESULTS);
       process.exit(0);
     }
+    console.log(`[run-eval] ${stillErrors.length} cases still have API errors`);
   }
 
-  // After max retries, merge retry results and still evaluate pass rate.
   console.error(`\n[run-eval] ${MAX_RETRIES} retries exhausted — some cases still have errors`);
-  if (fs.existsSync(RETRY_RESULTS)) {
-    fs.copyFileSync(RETRY_RESULTS, RESULTS);
-  }
   process.exit(1);
 }
 

--- a/eval/scripts/run-eval.js
+++ b/eval/scripts/run-eval.js
@@ -1,0 +1,106 @@
+// eval/scripts/run-eval.js
+//
+// Wraps `promptfoo eval` with retry logic for rate-limited (429) and timed-out
+// cases. Retries use exponential backoff (30s / 60s / 120s, max 3 attempts).
+// Assertion failures (real evaluation results) are NOT retried — only API errors.
+//
+// Usage:
+//   node eval/scripts/run-eval.js [--smoke] [extra promptfoo args...]
+//
+//   --smoke     : short circuit at first pass, no retries (for CI smoke workflow)
+//
+// Extra args are forwarded to promptfoo (e.g. --filter-providers, --no-cache).
+// Results are written to eval/results.json (and eval/results.retry.json on retry).
+// Exit code 0 = pass rate ≥ threshold (via smoke-check.js), 1 = below threshold.
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+const RESULTS = 'eval/results.json';
+const RETRY_RESULTS = 'eval/results.retry.json';
+const RETRY_DELAYS = [30000, 60000, 120000];
+const MAX_RETRIES = 3;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasErrors(file) {
+  try {
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const results = (data.results && data.results.results) || [];
+    const withErrors = results.filter((r) => r.error);
+    return withErrors.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function runPromptfoo(args) {
+  const cmd = `npx promptfoo@latest eval ${args.join(' ')}`;
+  console.log(`\n[run-eval] ${cmd}`);
+  try {
+    execSync(cmd, { stdio: 'inherit', cwd: process.cwd() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const isSmoke = process.argv.includes('--smoke');
+  const extraArgs = process.argv.slice(2).filter((a) => a !== '--smoke');
+
+  // Run 1: initial full run.
+  const run1Args = [...extraArgs, '-o', RESULTS];
+  if (!runPromptfoo(run1Args)) {
+    console.error('\n[run-eval] initial eval run failed');
+  }
+
+  if (isSmoke) {
+    // CI smoke — no retries, just check threshold.
+    process.exit(0);
+  }
+
+  if (!hasErrors(RESULTS)) {
+    console.log('\n[run-eval] no API errors — skipping retries');
+    process.exit(0);
+  }
+
+  // Retries: only when there are API errors (429 / timeout), not assertion failures.
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const delay = RETRY_DELAYS[attempt] || RETRY_DELAYS[RETRY_DELAYS.length - 1];
+    console.log(`\n[run-eval] retry ${attempt + 1}/${MAX_RETRIES} after ${delay / 1000}s` + (attempt > 0 ? '' : `
+[run-eval] hint: free models (:free) are rate-limited to ~20 req/min by OpenRouter.
+    For fewer 429s, consider running free models separately or with longer delays.`));
+    await sleep(delay);
+
+    const retryArgs = [
+      ...extraArgs,
+      '--filter-failing',
+      RESULTS,
+      '-o',
+      RETRY_RESULTS,
+    ];
+    runPromptfoo(retryArgs);
+
+    if (!hasErrors(RETRY_RESULTS)) {
+      console.log(`\n[run-eval] all errors resolved after ${attempt + 1} retry attempts`);
+      // Merge: retried passes replace original errors.
+      fs.copyFileSync(RETRY_RESULTS, RESULTS);
+      process.exit(0);
+    }
+  }
+
+  // After max retries, merge retry results and still evaluate pass rate.
+  console.error(`\n[run-eval] ${MAX_RETRIES} retries exhausted — some cases still have errors`);
+  if (fs.existsSync(RETRY_RESULTS)) {
+    fs.copyFileSync(RETRY_RESULTS, RESULTS);
+  }
+  process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(`[run-eval] unexpected error: ${e.message}`);
+  process.exit(2);
+});


### PR DESCRIPTION
Closes #85

### Summary

Добавлен троттлинг в конфиг eval, скрипт-обёртка с ретраями на 429, и документация по лимитам и стоимости прогона.

### Что сделано

#### `eval/promptfooconfig.yaml`
- Глобальный `maxConcurrency: 4` — умеренный параллелизм для платных моделей
- Per-provider throttling для `:free` моделей (HY3, Nemotron): `maxConcurrency: 1`, `delay: 3000`
- Комментарии обновлены (dataset 50, milestone v0.4.1)

#### `eval/scripts/run-eval.js` (новый)
- Обёртка над `promptfoo eval` с ретраями на 429/timeout
- Парсит `results.json`, находит кейсы с API-ошибками (не assertion failures)
- Ретраит с экспоненциальной задержкой: 30с / 60с / 120с, макс. 3 попытки
- Флаг `--smoke` для CI — без ретраев
- Подсказка про лимиты `:free` моделей при первом ретрае

#### `eval/README.md`
- Новый раздел «Limits and cost»: таблица throttling, лимиты `:free`, run-eval.js, стоимость ($0.10–$2)
- Обновлён раздел «Running»: примеры с wrapper'ом, smoke-подset
- Обновлён раздел CI: 12 smoke-кейсов вместо 10, throttling из конфига

#### `.github/workflows/eval-smoke.yml`
- Smoke-прогон через `node eval/scripts/run-eval.js --smoke`
- Название джобы и комментарии: 12 cases
- Ретрай флаков сохранён — rate limits не маскируются

### Tests
- `cargo test -p filar-agent -p filar-core` — **96 passed, 0 failed**
- `node -e "require('./eval/scripts/run-eval.js')"` — скрипт загружается без ошибок
- Полный прогон с ретраями — **ручная проверка** (требует `OPENROUTER_API_KEY`, `npx`, promptfoo)

### Not in scope
- Автоматическое различение 429 от других API-ошибок внутри promptfoo (ограничение promptfoo — `--filter-failing` не фильтрует по причине)