### PR TITLE
fix(tui): decouple render from read_output branch — forced frame after select! (#93)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2318,3 +2318,35 @@ rubric-only). Пересобрать smoke-набор до ~12 кейсов.
 **Тесты:** `cargo test -p filar-agent -p filar-core` — 96 passed, 0 failed.
 `node eval/asserts.test.js` — 20 asserts passed. Точечный перепрогон 5 кейсов +
 финальный полный прогон без кэша — ручная проверка (требует `OPENROUTER_API_KEY`).
+
+---
+
+## Issue #93: TUI — интерактивный режим не перерисовывается (select! starvation)
+
+**Проблема:** в interactive-режиме (Ctrl+T → SSH) вывод не появлялся без нажатия
+клавиш или resize. Причина: `crates/tui/src/runner.rs`, в главном `tokio::select!`
+ветка `read_output().await` стояла выше ветки `render_interval.tick()` — при потоке
+вывода read_output резолвился непрерывно и голодил рендер. `needs_redraw = true`
+выполнялось, но `terminal.draw` не вызывался.
+
+**Решение (принудительный кадр вне состязания веток):**
+- Добавлен трекинг `last_draw: Instant`.
+- В существующей ветке `render_interval.tick()` — `last_draw = Instant::now()`.
+- **После `select!`** добавлен принудительный кадр: если `needs_redraw` и с прошлого
+  draw прошло ≥16 мс — рисовать вне состязания. Ветка `render_interval.tick()`
+  сохраняется для батчинга <16 мс (60fps в Normal/Thinking), принудительный кадр —
+  fallback для starvation-сценария.
+- Первый кадр после `enter_interactive()`: `needs_redraw` выставляется в обработчике
+  Ctrl+T, следующий pass через select! принудительно рисует.
+
+**Ctrl+= / Ctrl+- (зум шрифта):** проверено — на Windows Terminal зум-комбинации
+перехватываются эмулятором терминала ДО crossterm (raw mode не мешает). В коде
+добавлен комментарий с объяснением. `terminal.rs::ctrl_key()` не маппит `=`/`-` —
+в interactive они не форвардятся в PTY.
+
+**Публичные контракты:** без изменений. Логика цикла событий и рендера — внутренняя
+реализация TUI.
+
+**Тесты:** `cargo test -p filar-tui` — 203 passed, 0 failed. `cargo build --workspace`
+зелёный. Ручная проверка на Windows Terminal + SSH — требуется (interactive вывод
+должен появляться сразу, без нажатий).

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -575,6 +575,9 @@ async fn run_app(
         // The render tick above still batches updates (< 16 ms intervals),
         // so 60 fps batching in Normal/Thinking is preserved.
         if needs_redraw && last_draw.elapsed() >= Duration::from_millis(16) {
+            if app.mode == AppMode::Thinking {
+                app.tick = app.tick.wrapping_add(1);
+            }
             if prev_mode != app.mode {
                 terminal.clear().ok();
                 prev_mode = app.mode;
@@ -582,6 +585,9 @@ async fn run_app(
             terminal.draw(|f| ui::render(f, &mut app)).ok();
             needs_redraw = false;
             last_draw = Instant::now();
+            // Prevent the normal render tick from firing immediately on
+            // the next iteration — the frame we just drew is current.
+            render_interval.reset();
             if app.toast_text().is_none() {
                 app.toast = None;
             }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -6,7 +6,7 @@
 
 use std::io::{self, Stdout};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{EnableMouseCapture, DisableMouseCapture, Event, EventStream};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
@@ -229,6 +229,11 @@ async fn run_app(
     let mut needs_redraw = false;
     let mut render_interval = tokio::time::interval(Duration::from_millis(16));
     render_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Track last draw time for forced-frame logic below. The render tick
+    // branch in select! can be starved by continuous output (interactive SSH
+    // PTY); we draw at the end of the iteration body if a frame is pending
+    // and a frame deadline has passed, avoiding competition with read_output.
+    let mut last_draw = Instant::now();
 
     loop {
         let in_interactive = app.mode == AppMode::Interactive;
@@ -240,6 +245,13 @@ async fn run_app(
             maybe_event = events.next() => {
                 match maybe_event {
                     Some(Ok(Event::Key(key))) if key.kind == crossterm::event::KeyEventKind::Press => {
+                        // Note: Ctrl+= / Ctrl+- (terminal font zoom) are NOT
+                        // consumed by filar. On Windows Terminal these are
+                        // intercepted by the terminal emulator before crossterm
+                        // sees them in raw mode; zoom works regardless. In
+                        // interactive mode, they are not forwarded to the PTY
+                        // because ctrl_key() only maps a-z and a few special
+                        // chars (see crates/tui/src/terminal.rs:486-492).
                         app.handle_key(key);
                         needs_redraw = true;
                     }
@@ -540,6 +552,7 @@ async fn run_app(
                 }
                 terminal.draw(|f| ui::render(f, &mut app)).ok();
                 needs_redraw = false;
+                last_draw = Instant::now();
                 // Clear an expired toast so the next tick's guard goes false and
                 // ticking stops after this erasing frame.
                 if app.toast_text().is_none() {
@@ -550,6 +563,28 @@ async fn run_app(
 
         if app.should_quit {
             break;
+        }
+
+        // Force a draw after the iteration if a frame is pending and the
+        // frame deadline (16 ms) has passed, regardless of which select!
+        // branch was chosen. This decouples redraw from branch competition:
+        // continuous output from an SSH interactive PTY starves the render
+        // tick because read_output always resolves first; without this
+        // fallback draw the screen would only update on key/resize events.
+        //
+        // The render tick above still batches updates (< 16 ms intervals),
+        // so 60 fps batching in Normal/Thinking is preserved.
+        if needs_redraw && last_draw.elapsed() >= Duration::from_millis(16) {
+            if prev_mode != app.mode {
+                terminal.clear().ok();
+                prev_mode = app.mode;
+            }
+            terminal.draw(|f| ui::render(f, &mut app)).ok();
+            needs_redraw = false;
+            last_draw = Instant::now();
+            if app.toast_text().is_none() {
+                app.toast = None;
+            }
         }
     }
 


### PR DESCRIPTION
Closes #93

### Summary

Interactive-режим (Ctrl+T → SSH) не перерисовывался без нажатия клавиш / resize: вывод накапливался и «проявлялся» только по Enter/resize.

**Причина:** в `runner.rs` `tokio::select!` ветка `read_output().await` стояла выше `render_interval.tick()` — при потоке вывода `read_output` резолвился непрерывно и голодил рендер.

### Fix

Добавлен **принудительный кадр ПОСЛЕ `select!`**: если `needs_redraw` и past ≥16 ms — рисовать вне состязания веток. Ветка `render_interval.tick()` сохранена для 60fps-батчинга.

```
select! { events, agent, log, read_output, render_tick }
  ↓
if needs_redraw && elapsed >= 16ms → draw  // fallback, beats starvation
```

Also: документирован Ctrl+=/Ctrl+- зум — Windows Terminal перехватывает до crossterm, raw mode не мешает.

### Tests
- `cargo test -p filar-tui` — **203 passed, 0 failed**
- `cargo build --workspace` — зеленый
- Ручная проверка Windows Terminal + SSH — требуется

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where interactive terminal sessions could stop refreshing when PTY output continuously arrived.
  * Ensured timed notifications expire and are properly cleared from the UI.
  * Preserved Ctrl+= / Ctrl+- font zoom shortcuts during interactive sessions.

* **Documentation**
  * Updated progress notes with details about the interactive redraw fix and recommended verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->