### PR TITLE
fix(tui): fix scrollbar content_length — use total lines minus viewport height (#94)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2350,3 +2350,32 @@ rubric-only). Пересобрать smoke-набор до ~12 кейсов.
 **Тесты:** `cargo test -p filar-tui` — 203 passed, 0 failed. `cargo build --workspace`
 зелёный. Ручная проверка на Windows Terminal + SSH — требуется (interactive вывод
 должен появляться сразу, без нажатий).
+
+---
+
+## Issue #94: TUI — скроллбар не доходит до низа (content_length)
+
+**Проблема:** при полностью пролистанном тексте ползунок скроллбара не доходил
+до низа — оставался зазор ~четверть трека. Причина: в `ui/chat.rs` `ScrollbarState`
+получал `content_length(total_lines)` — полное число строк, тогда как в ratatui
+`content_length` = число **прокручиваемых позиций** = `total − viewport_height`.
+
+При 100 строках и 20 видимых: `content_length = 100` вместо `80`, позиция макс =
+`80`, ползунок = `20/100 = 20%` трека → никогда не доходил до 100%.
+
+**Решение:** одна строка в `ui/chat.rs:78`:
+```rust
+let scroll_len = total_lines.saturating_sub(visible_height);
+ScrollbarState::default().content_length(scroll_len)
+```
+Все остальные расчёты (`clamp_scroll`, `update_scrollbar_drag`, `skip`) уже
+использовали корректную формулу `saturating_sub`; баг был только в визуальном
+виджете.
+
+**Тесты:** добавлен `scrollbar_content_length_at_bottom` — проверяет что при
+`scroll = 0` (нижнее положение) `skip == total_lines.saturating_sub(visible_height)`,
+т.е. позиция ползунка совпадает с концом контента.
+
+**Публичные контракты:** без изменений (внутренняя визуализация TUI).
+
+**Тесты:** `cargo test -p filar-tui` — 204 passed, 0 failed.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -4180,11 +4180,10 @@ mod tests {
         assert_eq!(app.scroll, 0);
     }
 
-    /// At scroll = 0 (bottom) the scrollbar `content_length` must equal
-    /// `total_lines.saturating_sub(visible_height)` so the thumb reaches the
-    /// end of the track. Using `total_lines` as content_length (the bug) would
-    /// leave the thumb ~quarter short because position max is `total_lines - height`
-    /// but content_length is `total_lines` — the thumb never reaches 100%.
+    /// At scroll = 0 (bottom) the scrollbar thumb must reach the end of the
+    /// track. `ui::chat::scrollbar_content_len` is the production helper used
+    /// by `render_chat_history`; calling it directly verifies that the formula
+    /// matches the skip-at-bottom invariant.
     #[test]
     fn scrollbar_content_length_at_bottom() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
@@ -4197,17 +4196,45 @@ mod tests {
                 region: crate::ui::layout_cache::LineRegion::Spacer,
             })
             .collect();
-        // Scroll to the bottom.
-        app.scroll = 0;
         let visible_height = app.chat_area.height as usize;
         let total_lines = app.layout_cache.lines.len();
-        let content_length = total_lines.saturating_sub(visible_height);
-        assert_eq!(content_length, 26, "max_scroll = total_lines - height");
-        // scroll = 0 means we're at the bottom; the skip offset from start
-        // should equal content_length (i.e. the thumb position equals total
-        // scrollable positions, positioning it at the end of the track).
+
+        // Production helper — the same function render_chat_history calls.
+        let content_len = crate::ui::scrollbar_content_len(total_lines, visible_height);
+        assert_eq!(content_len, 26);
+
+        // At scroll = 0 (bottom), the skip equals content_len — thumb at end.
+        app.scroll = 0;
         let skip = total_lines.saturating_sub(visible_height + app.scroll);
-        assert_eq!(skip, content_length, "at bottom, skip should equal content_length");
+        assert_eq!(skip, content_len, "at bottom, skip should match scrollbar content_length");
+
+        // Edge: content fits in viewport → content_len = 0, scrollbar hidden.
+        app.layout_cache.lines = (0..10)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        let short = crate::ui::scrollbar_content_len(
+            app.layout_cache.lines.len(),
+            visible_height,
+        );
+        assert_eq!(short, 0, "content fits → no scrollable positions");
+
+        // Edge: content exactly equals viewport → content_len = 0.
+        app.layout_cache.lines = (0..visible_height)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        let exact = crate::ui::scrollbar_content_len(
+            app.layout_cache.lines.len(),
+            visible_height,
+        );
+        assert_eq!(exact, 0, "exact fit → no scrollable positions");
     }
 
     // --- Hit test small terminal ---

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -4180,6 +4180,36 @@ mod tests {
         assert_eq!(app.scroll, 0);
     }
 
+    /// At scroll = 0 (bottom) the scrollbar `content_length` must equal
+    /// `total_lines.saturating_sub(visible_height)` so the thumb reaches the
+    /// end of the track. Using `total_lines` as content_length (the bug) would
+    /// leave the thumb ~quarter short because position max is `total_lines - height`
+    /// but content_length is `total_lines` — the thumb never reaches 100%.
+    #[test]
+    fn scrollbar_content_length_at_bottom() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.chat_area = Rect::new(0, 1, 80, 24); // height=24
+        // 50 lines → visible_height=24, max_scroll = 50-24 = 26
+        app.layout_cache.lines = (0..50)
+            .map(|_| crate::ui::layout_cache::RenderedLine {
+                line: ratatui::text::Line::raw("test"),
+                block_index: None,
+                region: crate::ui::layout_cache::LineRegion::Spacer,
+            })
+            .collect();
+        // Scroll to the bottom.
+        app.scroll = 0;
+        let visible_height = app.chat_area.height as usize;
+        let total_lines = app.layout_cache.lines.len();
+        let content_length = total_lines.saturating_sub(visible_height);
+        assert_eq!(content_length, 26, "max_scroll = total_lines - height");
+        // scroll = 0 means we're at the bottom; the skip offset from start
+        // should equal content_length (i.e. the thumb position equals total
+        // scrollable positions, positioning it at the end of the track).
+        let skip = total_lines.saturating_sub(visible_height + app.scroll);
+        assert_eq!(skip, content_length, "at bottom, skip should equal content_length");
+    }
+
     // --- Hit test small terminal ---
 
     #[test]

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -74,7 +74,7 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
 
     // Scrollbar — shown only when content overflows.
     if total_lines > visible_height {
-        let scroll_len = total_lines.saturating_sub(visible_height);
+        let scroll_len = scrollbar_content_len(total_lines, visible_height);
         let mut scrollbar_state = ScrollbarState::default()
             .content_length(scroll_len)
             .viewport_content_length(visible_height)
@@ -171,4 +171,15 @@ fn apply_selection(
         current_col = span_end;
     }
     Line::from(new_spans)
+}
+
+/// Helper: compute the scrollbar track length (scrollable positions).
+/// `content_length` in ratatui `ScrollbarState` is the number of scrollable
+/// positions, NOT the total number of lines. When `total_lines` is the full
+/// content height and `visible_height` is the viewport, the scrollbar track
+/// represents `total_lines − visible_height` positions.
+///
+/// Extracted for testability — the rendering path and tests share this formula.
+pub(crate) fn scrollbar_content_len(total_lines: usize, visible_height: usize) -> usize {
+    total_lines.saturating_sub(visible_height)
 }

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -74,8 +74,9 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
 
     // Scrollbar — shown only when content overflows.
     if total_lines > visible_height {
+        let scroll_len = total_lines.saturating_sub(visible_height);
         let mut scrollbar_state = ScrollbarState::default()
-            .content_length(total_lines)
+            .content_length(scroll_len)
             .viewport_content_length(visible_height)
             .position(skip);
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -22,6 +22,8 @@ mod bars;
 mod chat;
 mod confirm;
 mod input;
+#[allow(unused_imports)]
+pub(crate) use chat::scrollbar_content_len;
 pub mod layout_cache;
 mod text;
 pub mod theme;


### PR DESCRIPTION
Closes #94

### Summary

Скроллбар не доходил до низа — ползунок останавливался на ~75% при полной прокрутке.

**Причина:** `ui/chat.rs` передавал `content_length(total_lines)` в `ScrollbarState`. В ratatui `content_length` — число **прокручиваемых позиций** = `total − viewport`, а не полное число строк. При 100 строках и 20 видимых: `content_length = 100` вместо `80` → ползунок `20/100 = 20%` трека, никогда не 100%.

### Fix

```rust
// Было:
.content_length(total_lines)
// Стало:
let scroll_len = total_lines.saturating_sub(visible_height);
.content_length(scroll_len)
```

Остальные расчёты (`clamp_scroll`, `update_scrollbar_drag`, `skip`) уже использовали `saturating_sub` корректно — баг был только в визуальном виджете.

### Test

Добавлен `scrollbar_content_length_at_bottom` — проверяет что при `scroll = 0` (низ) skip равен `total_lines − visible_height`, т.е. позиция ползунка = конец контента.

### Tests
- `cargo test -p filar-tui` — **204 passed, 0 failed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the chat scrollbar so it can reach the bottom of the content.
  * Corrected the scroll range to account for the visible portion of the chat.

* **Tests**
  * Added coverage verifying the scrollbar’s bottom position and scroll offset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->