### PR TITLE
feat(tui): interactive scrollback — PgUp/PgDn, scrollbar, display_offset API (#95)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2379,3 +2379,42 @@ ScrollbarState::default().content_length(scroll_len)
 **Публичные контракты:** без изменений (внутренняя визуализация TUI).
 
 **Тесты:** `cargo test -p filar-tui` — 204 passed, 0 failed.
+
+---
+
+## Issue #95: TUI — скролл истории в интерактивном режиме
+
+**Проблема:** в interactive после большого вывода (`dmesg`) PgUp/PgDn не
+реагировали, скроллбара не было. PgUp/PgDn уходили в PTY как сырые байты,
+вместо того чтобы листать scrollback.
+
+**Решение:**
+- `crates/tui/src/terminal.rs`: `TerminalModel::display_offset()` и
+  `total_grid_lines()` — получение текущего смещения и общего числа строк
+  (screen + history). `scroll_display()`, `scroll_to_bottom()`, `mouse_mode()`,
+  `is_alt_screen()` уже были — scrollback API уже существовал в модели, не
+  был проброшен в UI.
+- `crates/tui/src/app.rs`:
+  - PgUp/PgDn в интерактивном режиме теперь перехватываются ДО конвертации
+    в PTY-байты: PgUp → `scroll_display(+rows)`, PgDn →
+    `scroll_display(-rows)`. В PTY НЕ форвардятся.
+  - Колесо мыши (scroll up/down → `scroll_display(±3)`) уже работало,
+    логика не менялась.
+- `crates/tui/src/ui/mod.rs`: в `render_interactive()` добавлен скроллбар
+  справа от терминала при наличии scrollback-истории. Контент-длина =
+  `total_grid_lines − screen_rows` (та же формула `scrollbar_content_len`
+  из #94). Позиция = `display_offset`. При alt-screen (vim/htop) скроллбар
+  не рисуется.
+
+**Тесты:** добавлены `interactive_pgup_scrolls_scrollback`,
+`interactive_pgdn_scrolls_scrollback`, обновлён `terminal_model_scroll_display_up`
+(теперь проверяет `display_offset`), `terminal_model_scroll_to_bottom`
+(проверяет возврат в 0).
+
+**Публичные контракты:** `TerminalModel::display_offset()` и
+`total_grid_lines()` — новые pub-методы для UI-слоя.
+
+**Тесты:** `cargo test -p filar-tui` — 206 passed, 0 failed.
+Ручная проверка на Windows Terminal + SSH — требуется (PgUp/PgDn, колесо,
+скроллбар в `dmesg`/`journalctl`, ввод сбрасывает к низу, в htop/vim колесо
+уходит в приложение).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -691,21 +691,22 @@ impl App {
                     self.toggle_interactive = true;
                     return;
                 }
-                // PgUp/PgDn — scroll through terminal history (scrollback).
-                // Not forwarded to PTY; the remote app never sees these.
-                if key.code == KeyCode::PageUp {
+                // PgUp/PgDn — scroll through terminal history (scrollback)
+                // when in primary screen. In alt-screen (vim/htop/less)
+                // these keys are forwarded to the PTY so the remote
+                // application receives them — matching mouse wheel logic.
+                if key.code == KeyCode::PageUp || key.code == KeyCode::PageDown {
                     if let Some(t) = self.terminal.as_mut() {
-                        let rows = t.rows() as i32;
-                        t.scroll_display(rows.max(1));
+                        if !t.is_alt_screen() {
+                            let rows = t.rows() as i32;
+                            if key.code == KeyCode::PageUp {
+                                t.scroll_display(rows.max(1));
+                            } else {
+                                t.scroll_display(-rows.max(1));
+                            }
+                            return;
+                        }
                     }
-                    return;
-                }
-                if key.code == KeyCode::PageDown {
-                    if let Some(t) = self.terminal.as_mut() {
-                        let rows = t.rows() as i32;
-                        t.scroll_display(-rows.max(1));
-                    }
-                    return;
                 }
                 // Convert the key event to terminal input bytes.
                 let bytes = key_to_bytes(key);

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -691,6 +691,22 @@ impl App {
                     self.toggle_interactive = true;
                     return;
                 }
+                // PgUp/PgDn — scroll through terminal history (scrollback).
+                // Not forwarded to PTY; the remote app never sees these.
+                if key.code == KeyCode::PageUp {
+                    if let Some(t) = self.terminal.as_mut() {
+                        let rows = t.rows() as i32;
+                        t.scroll_display(rows.max(1));
+                    }
+                    return;
+                }
+                if key.code == KeyCode::PageDown {
+                    if let Some(t) = self.terminal.as_mut() {
+                        let rows = t.rows() as i32;
+                        t.scroll_display(-rows.max(1));
+                    }
+                    return;
+                }
                 // Convert the key event to terminal input bytes.
                 let bytes = key_to_bytes(key);
                 if !bytes.is_empty() {
@@ -4009,10 +4025,9 @@ mod tests {
         for _ in 0..20 {
             model.feed(b"line\n");
         }
+        assert_eq!(model.display_offset(), 0);
         model.scroll_display(3);
-        // Should not panic — display offset changed.
-        // We can't directly read display_offset from the public API,
-        // but the method should complete successfully.
+        assert_eq!(model.display_offset(), 3);
     }
 
     #[test]
@@ -4022,8 +4037,57 @@ mod tests {
             model.feed(b"line\n");
         }
         model.scroll_display(5);
+        assert_eq!(model.display_offset(), 5);
         model.scroll_to_bottom();
-        // Should not panic.
+        assert_eq!(model.display_offset(), 0);
+    }
+
+    /// PgUp in interactive mode scrolls history up, NOT forwarded to PTY.
+    #[test]
+    fn interactive_pgup_scrolls_scrollback() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            for _ in 0..50 {
+                t.feed(b"line\n");
+            }
+        }
+        let rows = app.terminal.as_ref().unwrap().rows() as usize;
+        // Scroll to bottom first.
+        app.terminal.as_mut().unwrap().scroll_to_bottom();
+        // Press PgUp.
+        app.handle_key(crossterm::event::KeyEvent {
+            code: crossterm::event::KeyCode::PageUp,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        });
+        let offset = app.terminal.as_ref().unwrap().display_offset();
+        assert_eq!(offset, rows, "PgUp should scroll one screen up");
+
+        // PgUp was NOT forwarded to PTY (no pending input).
+        assert!(app.take_term_input().is_none(), "PgUp should not be forwarded to PTY");
+    }
+
+    /// PgDn in interactive mode scrolls history down.
+    #[test]
+    fn interactive_pgdn_scrolls_scrollback() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            for _ in 0..30 {
+                t.feed(b"line\n");
+            }
+        }
+        // Scroll up first.
+        app.terminal.as_mut().unwrap().scroll_display(10);
+        // Press PgDn.
+        app.handle_key(crossterm::event::KeyEvent {
+            code: crossterm::event::KeyCode::PageDown,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        });
+        let offset = app.terminal.as_ref().unwrap().display_offset();
+        assert!(offset < 10, "PgDn should decrease the scroll offset");
     }
 
     #[test]

--- a/crates/tui/src/terminal.rs
+++ b/crates/tui/src/terminal.rs
@@ -148,6 +148,17 @@ impl TerminalModel {
         self.term.mode().contains(TermMode::ALT_SCREEN)
     }
 
+    /// Current scrollback offset — 0 at the bottom (latest output), increasing
+    /// as the user scrolls up through history.
+    pub fn display_offset(&self) -> usize {
+        self.term.grid().display_offset()
+    }
+
+    /// Total number of lines in the grid (screen lines + scrollback history).
+    pub fn total_grid_lines(&self) -> usize {
+        self.term.grid().total_lines()
+    }
+
     /// Render the terminal grid to a ratatui frame.
     ///
     /// Each cell is rendered as a character with its foreground/background

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -32,7 +32,7 @@ pub use theme::Theme;
 
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::Style;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use ratatui::Frame;
 
 use crate::app::{App, AppMode};
@@ -112,6 +112,23 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
     // Render the terminal model grid.
     if let Some(ref term) = app.terminal {
         term.render(f, chunks[2]);
+
+        // Scrollbar for scrollback — shown on the right edge of the
+        // terminal area when there's history to scroll through.
+        let grid_total = term.total_grid_lines();
+        let grid_visible = term.rows() as usize;
+        let scroll_len = chat::scrollbar_content_len(grid_total, grid_visible);
+        if scroll_len > 0 {
+            let offset = term.display_offset();
+            let mut state = ScrollbarState::default()
+                .content_length(scroll_len)
+                .viewport_content_length(grid_visible)
+                .position(offset);
+            let sb = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .thumb_style(app.theme.dim())
+                .track_style(app.theme.muted());
+            f.render_stateful_widget(sb, chunks[2], &mut state);
+        }
     } else {
         let block = Block::default()
             .borders(Borders::ALL)

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -120,10 +120,13 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
         let scroll_len = chat::scrollbar_content_len(grid_total, grid_visible);
         if scroll_len > 0 {
             let offset = term.display_offset();
+            // display_offset = 0 at bottom (latest output), but ratatui
+            // position 0 = top of track. Invert: top-of-history offset
+            // maps to position 0, bottom maps to position = scroll_len.
             let mut state = ScrollbarState::default()
                 .content_length(scroll_len)
                 .viewport_content_length(grid_visible)
-                .position(offset);
+                .position(scroll_len.saturating_sub(offset));
             let sb = Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .thumb_style(app.theme.dim())
                 .track_style(app.theme.muted());


### PR DESCRIPTION
Closes #95

### Summary

Добавлен scrollback в интерактивный режим: PgUp/PgDn, колесо мыши (уже работало), скроллбар.

### Что сделано

| Компонент | Что |
|---|---|
| `terminal.rs` | `display_offset()`, `total_grid_lines()` — новые pub-методы |
| `app.rs` | PgUp/PgDn перехватываются до форвардинга в PTY — вызывают `scroll_display(±rows)` |
| `ui/mod.rs` | Скроллбар в `render_interactive()` — `scrollbar_content_len` из #94, позиция = `display_offset` |

### Детали

- **Scrollback API** (`scroll_display`, `scroll_to_bottom`, `mouse_mode`, `is_alt_screen`) уже существовал в `TerminalModel` — не был проброшен в UI. PgUp/PgDn уходили в PTY как `\x1b[5~`/`\x1b[6~`.
- Колесо мыши в primary screen → `scroll_display(±3)` — работало и раньше.
- В htop/vim (alt-screen) колесо → стрелки (было), скроллбар не рисуется.
- Символьный ввод → `scroll_to_bottom()` (уже было).
- Формула скроллбара — та же `scrollbar_content_len` из #94.

### Tests
- `cargo test -p filar-tui` — **206 passed, 0 failed**
- Ручная проверка — требуется (Windows Terminal + SSH: `dmesg`, `journalctl`, htop/vim)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scrollback navigation in Interactive terminal mode using Page Up and Page Down.
  * Added a vertical scrollbar when terminal history is available.
  * Mouse-wheel scrolling continues to work alongside keyboard navigation.

* **Bug Fixes**
  * Page Up and Page Down now scroll terminal history without sending unintended input to running applications such as `vim` or `htop`.
  * Returning to the bottom of the terminal restores the expected view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->