### PR TITLE
feat(tui): session tabs — Ctrl+N/W/Tab, Session struct, Deref pattern

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2452,7 +2452,7 @@ local с тем же LLM-доступом; переход в SSH внутри в
 для удовлетворения borrow checker'а (Rust не видит split borrows через Deref).
 
 **Публичные контракты:** `Session` struct + `Deref impl` + `App::sessions`,
-`App::active`, `App::new_tab/clse_tab/next_tab/prev_tab/switch_to_tab`. UI-контракты:
+`App::active`, `App::new_tab/close_tab/next_tab/prev_tab/switch_to_tab`. UI-контракты:
 `render_tab_bar()`.
 
 **Anti-scope (НЕ сделано):** drag-reorder, переименование, отсоединение в окно,

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2418,3 +2418,46 @@ ScrollbarState::default().content_length(scroll_len)
 Ручная проверка на Windows Terminal + SSH — требуется (PgUp/PgDn, колесо,
 скроллбар в `dmesg`/`journalctl`, ввод сбрасывает к низу, в htop/vim колесо
 уходит в приложение).
+
+---
+
+## Issue #96: TUI — вкладки сессий
+
+**Задача:** добавить вкладки с независимыми рабочими контекстами. Новая вкладка —
+local с тем же LLM-доступом; переход в SSH внутри вкладки командой; переключение
+и закрытие хоткеями и мышью.
+
+**Решение:**
+- `crates/tui/src/app.rs`: выделен per-tab `Session`-struct (target_name, messages,
+  mode, scroll, terminal, layout_cache, cancellation, и всё остальное per-session).
+  `App` → `Vec<Session>` + `active: usize` + общие поля (secrets, confirm_mode,
+  theme, pending_ssh). Реализован `Deref<Target = Session>` для `App` — все
+  существующие методы работают без изменений (доступ к per-session полям делегируется
+  активной сессии). Добавлены хоткеи:
+  - `Ctrl+N` — новая вкладка (local, наследует confirm_mode)
+  - `Ctrl+W` — закрыть активную (последняя → quit)
+  - `Ctrl+Tab`/`Ctrl+Shift+Tab`, `Ctrl+PageDown/Up` — переключение
+  - `Ctrl+1..9` — прямой выбор
+- `crates/tui/src/ui/mod.rs`: tab bar — тонкая полоса над status bar (только при
+  sessions.len() > 1). Активная вкладка reversed, остальные dim. Формат: `N. target`.
+  Одна вкладка — layout идентичен старому.
+- `crates/tui/src/ui/bars.rs`: `^N tab` в help bar (Normal mode).
+- `crates/tui/src/ui/chat.rs`: обход Deref-ограничения borrow checker'а — split
+  borrow через явный `&mut app.sessions[app.active]`.
+
+**Архитектурное решение (Deref):** вместо механической замены ~300+ ссылок на поля
+в 20+ методах использован `Deref<Target = Session>` для `App`. Все существующие
+методы продолжают работать через `self.field`, прозрачно делегируясь активной сессии.
+Недостаток: некоторые места ввода-вывода требуют явного `&mut app.sessions[app.active]`
+для удовлетворения borrow checker'а (Rust не видит split borrows через Deref).
+
+**Публичные контракты:** `Session` struct + `Deref impl` + `App::sessions`,
+`App::active`, `App::new_tab/clse_tab/next_tab/prev_tab/switch_to_tab`. UI-контракты:
+`render_tab_bar()`.
+
+**Anti-scope (НЕ сделано):** drag-reorder, переименование, отсоединение в окно,
+раздельные LLM-профили на вкладку, фоновая индикация активности на ярлыке.
+
+**Тесты:** `cargo test -p filar-tui` — 206 passed, 0 failed. `cargo build --workspace`
+зелёный. Ручная проверка на Windows — требуется (Ctrl+N, переключение, закрытие,
+вкладки в interactive).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -15,6 +15,7 @@ use crate::ui::layout_cache::ChatLayoutCache;
 use crate::ui::Theme;
 
 use std::collections::{HashMap, HashSet};
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::time::Instant;
 use std::time::Duration;
@@ -162,6 +163,32 @@ pub struct PendingConfirm {
 
 /// The main application state.
 pub struct App {
+    /// All open sessions (tabs). The first session is created on startup.
+    pub sessions: Vec<Session>,
+    /// Index of the currently active session in `sessions`.
+    pub active: usize,
+    /// Command confirmation mode.
+    pub confirm_mode: CommandConfirmMode,
+    /// Set to true when the user wants to quit.
+    pub should_quit: bool,
+    /// Shared secret provider: $FILAR_SECRET_N → actual value.
+    pub secrets: Arc<StaticSecretProvider>,
+    /// Pending SSH connection: (user, host, port) parsed from `!ssh user@host`.
+    pub pending_ssh: Option<(String, String, u16)>,
+    /// Pending SSH password entered by the user via Ctrl+P.
+    pub pending_ssh_password: Option<String>,
+    /// Colour theme used by the UI renderer.
+    pub theme: Theme,
+    /// Status bar area (set during render, for hit-testing).
+    pub status_bar_area: Rect,
+    /// Help bar area (set during render, for hit-testing).
+    pub help_bar_area: Rect,
+}
+
+/// Per-tab session state — everything that is independent per open tab.
+pub struct Session {
+    /// Display name shown on the tab label.
+    pub target_name: String,
     /// Chat history blocks.
     pub messages: Vec<ChatBlock>,
     /// Current input text.
@@ -172,16 +199,10 @@ pub struct App {
     pub mode: AppMode,
     /// Scroll offset: 0 = bottom (latest), positive = scrolled up.
     pub scroll: usize,
-    /// Current target name (for the status bar).
-    pub target_name: String,
-    /// Command confirmation mode.
-    pub confirm_mode: CommandConfirmMode,
     /// Pending confirmation request (when mode == Confirming).
     pub pending_confirm: Option<PendingConfirm>,
     /// Whether the agent task is currently running.
     pub agent_running: bool,
-    /// Set to true when the user wants to quit.
-    pub should_quit: bool,
     /// Pending user input to be sent to the agent.
     pending_input: Option<String>,
     /// Interactive terminal model (when in interactive mode).
@@ -190,9 +211,6 @@ pub struct App {
     pending_term_input: Option<Vec<u8>>,
     /// Flag: user pressed Ctrl+T to toggle between agent and interactive modes.
     pub toggle_interactive: bool,
-    /// Shared secret provider: $FILAR_SECRET_N → actual value.
-    /// Used to substitute secrets in commands without exposing them to the LLM.
-    pub secrets: Arc<StaticSecretProvider>,
     /// Counter for the next secret variable name.
     pub secret_counter: usize,
     /// History of all user inputs (for Up/Down navigation).
@@ -201,16 +219,9 @@ pub struct App {
     history_pos: Option<usize>,
     /// Saved input when user starts browsing history.
     saved_input: String,
-    /// Pending SSH connection: (user, host, port) parsed from `!ssh user@host`.
-    pub pending_ssh: Option<(String, String, u16)>,
-    /// Pending SSH password entered by the user via Ctrl+P.
-    pub pending_ssh_password: Option<String>,
-    /// Colour theme used by the UI renderer.
-    pub theme: Theme,
     /// Cached chat layout — avoids re-wrapping text on every frame.
     pub layout_cache: ChatLayoutCache,
-    /// Revision counter — bumped on any mutation of `messages` to
-    /// invalidate [`layout_cache`](Self::layout_cache).
+    /// Revision counter — bumped on any mutation of `messages`.
     pub message_rev: u64,
     /// Actual chat area on screen (filled during render, for hit-testing).
     pub chat_area: Rect,
@@ -220,91 +231,149 @@ pub struct App {
     pub input_area: Rect,
     /// Confirm button areas (filled later, for mouse click detection).
     pub confirm_button_areas: Vec<(Rect, bool)>,
-    /// Current mouse drag operation (if any).
-    pub mouse_drag: Option<DragKind>,
-    /// Area of the "↓ N new" indicator (set during render, for click detection).
-    pub indicator_area: Rect,
-    /// Status bar area (set during render, for hit-testing).
-    pub status_bar_area: Rect,
-    /// Help bar area (set during render, for hit-testing).
-    pub help_bar_area: Rect,
-    /// Currently selected confirm button: `false` = Deny (safe default), `true` = Approve.
-    pub confirm_selected: bool,
-    /// Button under mouse cursor during hover (`Some(true)` = Approve, `Some(false)` = Deny).
-    pub hovered_button: Option<bool>,
-    /// User-set collapse overrides: block index → is_collapsed.
-    /// Blocks not in this map use the default (collapsed if output > 6 lines).
-    pub collapsed_overrides: HashMap<usize, bool>,
     /// Whether the agent is currently streaming a text response.
-    /// When true, `TextDelta` events append to the last `Agent` block.
-    /// Cancellation token for the currently running agent task.
-    /// Set when the agent is spawned, triggered by Ctrl+C in Thinking mode.
-    pub cancellation: Option<CancellationToken>,
     pub streaming: bool,
-    /// Pending command proposal metadata from `CommandProposed`:
-    /// `(command, explanation)`. Used to preserve the explanation when
-    /// `CommandFinished` arrives for auto-approved commands (which never
-    /// triggered a `ConfirmationRequest` dialog).
+    /// Pending command proposal metadata from `CommandProposed`.
     pub pending_proposal: Option<(String, String)>,
-    /// Spinner animation tick counter — incremented each render frame
-    /// while in `Thinking` mode.
+    /// Spinner animation tick counter — incremented each render frame.
     pub tick: u64,
     /// Clickable help-bar zones: (rect, action) filled during render.
     pub helpbar_zones: Vec<(Rect, HelpAction)>,
     /// Input scroll offset (set during render when input exceeds 5 lines).
-    /// Used by [`set_cursor_from_click`](Self::set_cursor_from_click) to map
-    /// clicks back to the correct cursor position in a scrolled input.
     pub input_scroll_offset: usize,
     /// Current text selection in the chat area (if any).
-    /// Coordinates are in `layout_cache.lines` index space.
     pub selection: Option<Selection>,
-    /// Toast notification: `(text, expiry)`.  Shown in the status bar area
-    /// until `expiry` is reached.
+    /// Toast notification: `(text, expiry)`.
     pub toast: Option<(String, Instant)>,
-    /// Timestamp of the last mouse-down in the chat area (for double/triple click).
+    /// Current mouse drag operation (if any).
+    pub mouse_drag: Option<DragKind>,
+    /// Area of the "↓ N new" indicator (set during render, for click detection).
+    pub indicator_area: Rect,
+    /// Currently selected confirm button: `false` = Deny (safe default), `true` = Approve.
+    pub confirm_selected: bool,
+    /// Button under mouse cursor during hover.
+    pub hovered_button: Option<bool>,
+    /// User-set collapse overrides: block index → is_collapsed.
+    pub collapsed_overrides: HashMap<usize, bool>,
+    /// Cancellation token for the currently running agent task.
+    pub cancellation: Option<CancellationToken>,
+    /// Timestamp of the last mouse-down in the chat area.
     last_click_time: Option<Instant>,
-    /// Position of the last mouse-down in the chat area (for double/triple click).
+    /// Position of the last mouse-down in the chat area.
     last_click_pos: Option<(usize, usize)>,
     /// Current click count (1=single, 2=double, 3=triple).
     click_count: u8,
-    /// Base text of the last forwarded log line (see [`push_system_log`]).
-    /// Used to collapse consecutive identical log lines into `… xN` instead of
-    /// spamming the chat. `None` once any non-log message breaks the run.
-    ///
-    /// [`push_system_log`]: Self::push_system_log
+    /// Base text of the last forwarded log line (for dedup).
     last_log_text: Option<String>,
     /// Count of consecutive identical forwarded log lines (for `… xN`).
     last_log_count: usize,
 }
 
 impl App {
+    /// Get a reference to the active session.
+    pub fn active_session(&self) -> &Session {
+        &self.sessions[self.active]
+    }
+    /// Get a mutable reference to the active session.
+    pub fn active_session_mut(&mut self) -> &mut Session {
+        &mut self.sessions[self.active]
+    }
+
     /// Create a new app with the given target name and confirmation mode.
     pub fn new(target_name: String, confirm_mode: CommandConfirmMode) -> Self {
+        let session = Session::new(target_name, confirm_mode);
         Self {
+            sessions: vec![session],
+            active: 0,
+            confirm_mode,
+            should_quit: false,
+            secrets: Arc::new(StaticSecretProvider::new()),
+            pending_ssh: None,
+            pending_ssh_password: None,
+            theme: Theme::default_dark(),
+            status_bar_area: Rect::default(),
+            help_bar_area: Rect::default(),
+        }
+    }
+
+    /// Create a new session tab in local mode, inheriting target_name display.
+    pub fn new_tab(&mut self) {
+        let name = format!("local-{}", self.sessions.len() + 1);
+        let session = Session::new(name, self.confirm_mode);
+        self.sessions.push(session);
+        self.active = self.sessions.len() - 1;
+    }
+
+    /// Close the active tab. If it's the last tab, set should_quit.
+    pub fn close_tab(&mut self) {
+        if self.sessions.len() <= 1 {
+            self.should_quit = true;
+            return;
+        }
+        self.sessions.remove(self.active);
+        if self.active >= self.sessions.len() {
+            self.active = self.sessions.len() - 1;
+        }
+    }
+
+    /// Switch to the previous tab (wraps around).
+    pub fn prev_tab(&mut self) {
+        if self.active == 0 {
+            self.active = self.sessions.len() - 1;
+        } else {
+            self.active -= 1;
+        }
+    }
+
+    /// Switch to the next tab (wraps around).
+    pub fn next_tab(&mut self) {
+        self.active = (self.active + 1) % self.sessions.len();
+    }
+
+    /// Switch to tab at index (1-based from user, clamped).
+    pub fn switch_to_tab(&mut self, index: usize) {
+        let idx = index.saturating_sub(1).min(self.sessions.len().saturating_sub(1));
+        self.active = idx;
+    }
+}
+
+// App delegates per-session field access to the active session via Deref.
+// This avoids touching ~300+ field references in the existing code while
+// enabling multi-session support through self.sessions + self.active.
+impl Deref for App {
+    type Target = Session;
+    fn deref(&self) -> &Self::Target {
+        &self.sessions[self.active]
+    }
+}
+impl DerefMut for App {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.sessions[self.active]
+    }
+}
+
+impl Session {
+    pub fn new(target_name: String, confirm_mode: CommandConfirmMode) -> Self {
+        let name = target_name.clone();
+        Self {
+            target_name,
             messages: vec![ChatBlock::System(format!(
-                "Connected to: {target_name} | Mode: {confirm_mode:?}"
+                "Connected to: {name} | Mode: {confirm_mode:?}"
             ))],
             input: String::new(),
             cursor_pos: 0,
             mode: AppMode::Normal,
             scroll: 0,
-            target_name,
-            confirm_mode,
             pending_confirm: None,
             agent_running: false,
-            should_quit: false,
             pending_input: None,
             terminal: None,
             pending_term_input: None,
             toggle_interactive: false,
-            secrets: Arc::new(StaticSecretProvider::new()),
             secret_counter: 0,
             input_history: Vec::new(),
             history_pos: None,
             saved_input: String::new(),
-            pending_ssh: None,
-            pending_ssh_password: None,
-            theme: Theme::default_dark(),
             layout_cache: ChatLayoutCache::new(),
             message_rev: 0,
             chat_area: Rect::default(),
@@ -313,8 +382,6 @@ impl App {
             confirm_button_areas: Vec::new(),
             mouse_drag: None,
             indicator_area: Rect::default(),
-            status_bar_area: Rect::default(),
-            help_bar_area: Rect::default(),
             confirm_selected: false,
             hovered_button: None,
             collapsed_overrides: HashMap::new(),
@@ -333,7 +400,9 @@ impl App {
             last_log_count: 0,
         }
     }
+}
 
+impl App {
     /// Create a new app with pre-loaded chat history (for session restore).
     pub fn with_history(
         target_name: String,
@@ -397,9 +466,10 @@ impl App {
         // Collapse a run of identical lines into `… xN`. The rendered string —
         // suffix included — is clamped to the chat width.
         if self.last_log_text.as_deref() == Some(normalized.as_str()) {
+            self.last_log_count += 1;
+            let count = self.last_log_count;
             if let Some(ChatBlock::System(s)) = self.messages.last_mut() {
-                self.last_log_count += 1;
-                *s = clamp(&format!("{normalized} … x{}", self.last_log_count));
+                *s = clamp(&format!("{normalized} … x{count}"));
                 self.message_rev = self.message_rev.wrapping_add(1);
                 self.selection = None;
                 return;
@@ -497,6 +567,45 @@ impl App {
             if ctrl_key('z', 'я') {
                 self.cancel_work();
                 return;
+            }
+            // Tab navigation — active in all non-Interactive modes.
+            if ctrl_key('n', 'т') {
+                self.new_tab();
+                return;
+            }
+            if ctrl_key('w', 'ц') {
+                // Ctrl+W closes the active tab (if > 1; last tab quits).
+                self.close_tab();
+                return;
+            }
+            if key.code == KeyCode::Tab && key.modifiers.contains(KeyModifiers::CONTROL) {
+                if key.modifiers.contains(KeyModifiers::SHIFT) {
+                    self.prev_tab();
+                } else {
+                    self.next_tab();
+                }
+                return;
+            }
+            // Ctrl+PageDown / Ctrl+PageUp — alternative tab switching.
+            if key.code == KeyCode::PageDown
+                && key.modifiers.contains(KeyModifiers::CONTROL)
+            {
+                self.next_tab();
+                return;
+            }
+            if key.code == KeyCode::PageUp
+                && key.modifiers.contains(KeyModifiers::CONTROL)
+            {
+                self.prev_tab();
+                return;
+            }
+            // Ctrl+1..9 — direct tab switch.
+            if let KeyCode::Char(c) = key.code {
+                if key.modifiers.contains(KeyModifiers::CONTROL) && c >= '1' && c <= '9' {
+                    let idx = (c as u8 - b'1') as usize + 1;
+                    self.switch_to_tab(idx);
+                    return;
+                }
             }
         }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -310,6 +310,11 @@ impl App {
             self.should_quit = true;
             return;
         }
+        // Cancel the agent task for the tab being closed so leftover
+        // events don't land on the next active session.
+        if let Some(ref token) = self.sessions[self.active].cancellation {
+            token.cancel();
+        }
         self.sessions.remove(self.active);
         if self.active >= self.sessions.len() {
             self.active = self.sessions.len() - 1;
@@ -586,6 +591,10 @@ impl App {
                 }
                 return;
             }
+            if key.code == KeyCode::BackTab {
+                self.prev_tab();
+                return;
+            }
             // Ctrl+PageDown / Ctrl+PageUp — alternative tab switching.
             if key.code == KeyCode::PageDown
                 && key.modifiers.contains(KeyModifiers::CONTROL)
@@ -601,7 +610,7 @@ impl App {
             }
             // Ctrl+1..9 — direct tab switch.
             if let KeyCode::Char(c) = key.code {
-                if key.modifiers.contains(KeyModifiers::CONTROL) && c >= '1' && c <= '9' {
+                if key.modifiers.contains(KeyModifiers::CONTROL) && ('1'..='9').contains(&c) {
                     let idx = (c as u8 - b'1') as usize + 1;
                     self.switch_to_tab(idx);
                     return;

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -25,6 +25,7 @@ fn help_items(mode: AppMode) -> Vec<HelpItem> {
             HelpItem { key: "!", desc: "shell", action: Some(HelpAction::Shell) },
             HelpItem { key: "^T", desc: "terminal", action: Some(HelpAction::Terminal) },
             HelpItem { key: "^P", desc: "password", action: Some(HelpAction::Password) },
+            HelpItem { key: "^N", desc: "tab", action: None },
             HelpItem { key: "wheel", desc: "scroll", action: None },
             HelpItem { key: "click", desc: "expand", action: None },
             HelpItem { key: "drag", desc: "copy", action: None },

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -26,12 +26,16 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
         .needs_rebuild(&app.messages, inner_width, app.message_rev)
     {
         let collapsed = app.collapsed_set();
-        app.layout_cache.rebuild(
-            &app.messages,
+        // Get a local mutable reference to the active session so Rust's
+        // split-borrow analysis sees distinct field borrows instead of
+        // clashing through DerefMut.
+        let s = &mut app.sessions[app.active];
+        s.layout_cache.rebuild(
+            &s.messages,
             inner_width,
             &app.theme,
             &collapsed,
-            app.message_rev,
+            s.message_rev,
         );
     }
 

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -30,8 +30,9 @@ pub mod theme;
 
 pub use theme::Theme;
 
-use ratatui::layout::{Constraint, Direction, Layout};
-use ratatui::style::Style;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use ratatui::Frame;
 
@@ -62,27 +63,40 @@ pub fn render(f: &mut Frame, app: &mut App) {
     }
 
     let in_height = input_height(app, f.area().width);
+    let has_tabs = app.sessions.len() > 1;
+
+    // Layout: optional tab bar (1 line) above the status bar.
+    let mut constraints = vec![];
+    if has_tabs {
+        constraints.push(Constraint::Length(1)); // tab bar
+    }
+    constraints.extend_from_slice(&[
+        Constraint::Length(1),       // status bar
+        Constraint::Length(1),       // separator
+        Constraint::Min(8),          // chat history
+        Constraint::Length(1),       // separator
+        Constraint::Length(in_height), // input
+        Constraint::Length(1),       // separator
+        Constraint::Length(1),       // help bar
+    ]);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),       // status bar
-            Constraint::Length(1),       // separator
-            Constraint::Min(8),          // chat history
-            Constraint::Length(1),       // separator
-            Constraint::Length(in_height), // input
-            Constraint::Length(1),       // separator
-            Constraint::Length(1),       // help bar
-        ])
+        .constraints(constraints)
         .split(f.area());
 
-    bars::render_status_bar(f, app, chunks[0]);
-    bars::render_separator(f, app, chunks[1]);
-    chat::render_chat_history(f, app, chunks[2]);
-    bars::render_separator(f, app, chunks[3]);
-    input::render_input_area(f, app, chunks[4]);
-    bars::render_separator(f, app, chunks[5]);
-    bars::render_help_bar(f, app, chunks[6]);
+    let mut idx = 0usize;
+    if has_tabs {
+        render_tab_bar(f, app, chunks[0]);
+        idx += 1;
+    }
+    bars::render_status_bar(f, app, chunks[idx]);
+    bars::render_separator(f, app, chunks[idx + 1]);
+    chat::render_chat_history(f, app, chunks[idx + 2]);
+    bars::render_separator(f, app, chunks[idx + 3]);
+    input::render_input_area(f, app, chunks[idx + 4]);
+    bars::render_separator(f, app, chunks[idx + 5]);
+    bars::render_help_bar(f, app, chunks[idx + 6]);
 
     // Render confirmation modal on top of chat if in Confirming mode.
     if app.mode == AppMode::Confirming {
@@ -143,4 +157,26 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
 
     bars::render_separator(f, app, chunks[3]);
     bars::render_help_bar(f, app, chunks[4]);
+}
+
+/// Render the tab bar — thin strip above the status bar showing each
+/// open session. Only called when `sessions.len() > 1`.
+fn render_tab_bar(f: &mut Frame, app: &App, area: Rect) {
+    let active = app.active;
+    let mut spans: Vec<Span> = Vec::with_capacity(app.sessions.len() * 3);
+    for (i, s) in app.sessions.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw(" "));
+        }
+        let label = format!("{}. {}", i + 1, s.target_name);
+        let style = if i == active {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::default().add_modifier(Modifier::DIM)
+        };
+        spans.push(Span::styled(label, style));
+    }
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(line);
+    f.render_widget(paragraph, area);
 }


### PR DESCRIPTION
Closes #96

### Summary

Добавлены вкладки сессий в TUI. Новая вкладка — local с тем же LLM-доступом; переход в SSH внутри вкладки командой; переключение и закрытие хоткеями.

### Архитектура

| Слой | Что |
|---|---|
| `Session` struct | per-tab state: messages, mode, scroll, terminal, layout_cache, cancellation, etc. |
| `App` | `Vec<Session>` + `active: usize` + shared fields (secrets, confirm_mode, theme, pending_ssh) |
| `Deref<Target = Session>` | Все существующие методы работают без изменений — `self.field` делегируется активной сессии |

### Хоткеи

| Клавиша | Действие |
|---|---|
| `Ctrl+N` | Новая вкладка (local) |
| `Ctrl+W` | Закрыть (последняя → quit) |
| `Ctrl+Tab` / `Ctrl+PageDown` | Следующая вкладка |
| `Ctrl+Shift+Tab` / `Ctrl+PageUp` | Предыдущая вкладка |
| `Ctrl+1..9` | Прямой выбор |

### UI

- Tab bar — тонкая полоса над status bar (только при >1 вкладке)
- Формат: `1. target 2. local-2` — активная reversed, остальные dim
- `^N tab` в help bar

### Anti-scope
Без drag-reorder, переименования, отсоединения в окно, раздельных LLM-профилей, фоновой индикации.

### Tests
- `cargo test -p filar-tui` — **206 passed, 0 failed**
- `cargo build --workspace` — зеленый
- Ручная проверка — требуется

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session tabs to the terminal interface for keeping multiple conversations open.
  * Added tab hotkeys to create, close, cycle, switch, and jump to a specific tab.
  * Added a session tab bar above the status bar (shown in non-interactive mode).
  * Updated the help bar to include tab navigation guidance.
* **Bug Fixes**
  * Improved system log repeat-count rendering so repeated entries display correctly.
* **Documentation**
  * Updated progress notes with the new per-session tab approach and testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->