### PR TITLE
feat(tui): multiplex sessions — SessionId, per-session event dispatch, activity indicators

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2461,3 +2461,43 @@ local с тем же LLM-доступом; переход в SSH внутри в
 **Тесты:** `cargo test -p filar-tui` — 206 passed, 0 failed. `cargo build --workspace`
 зелёный. Ручная проверка на Windows — требуется (Ctrl+N, переключение, закрытие,
 вкладки в interactive).
+
+---
+
+## Issue #103: TUI — мультиплексирование сессий (SessionId + диспетчеризация событий по сессиям)
+
+**Проблема:** #96 добавила UI-каркас вкладок, но runner.rs обрабатывал события
+только активной сессии. Агент, запущенный в вкладке A, «вставал» при переключении
+на B; TuiEvent::Agent не нёс идентификатора сессии (отмечено CodeRabbit в #102).
+
+**Решение:**
+- `crates/tui/src/app.rs`:
+  - `SessionId(u64)` — стабильный идентификатор (глобальный атомарный счётчик,
+    не переиспользуется). `Session::id` заполняется при создании.
+  - `Session.background_activity: bool`, `has_new: bool`, `awaiting_confirmation: bool` —
+    флаги фоновой активности для индикации на ярлыке.
+  - `App::find_session_idx()` — поиск сессии по SessionId (не по индексу Vec).
+  - `handle_agent_event()` — извлекает `session_id` из события, переключает
+    `self.active` на целевую сессию, применяет мутации, восстанавливает `active`.
+    Фоновые события (неактивная вкладка) — устанавливают `has_new = true`.
+    `background_activity` снимается на `Finished`/`Error`.
+  - Переключение вкладок (`next_tab/prev_tab/switch_to_tab`) — сбрасывает `has_new`.
+- `crates/tui/src/event.rs`: `TuiEvent::Agent { session_id: SessionId, event: AgentEvent }`
+  вместо `TuiEvent::Agent(AgentEvent)`.
+- `crates/tui/src/runner.rs`: все отправки `TuiEvent::Agent` передают `session_id`
+  (захватывается из `app.sessions[app.active].id` перед spawn). `spawn_agent()`
+  принимает `sid: SessionId`.
+- `crates/tui/src/ui/mod.rs`: `render_tab_bar()` — маркеры активности:
+  `●` (full bullet) = агент работает, `?` = ожидание подтверждения,
+  `○` (open bullet) = есть новые сообщения.
+
+**Что НЕ сделано (anti-scope / follow-up):**
+- PTY фоновых сессий: interactive в неактивной вкладке не читается из PTY
+  (требует per-session tasks — отдельная задача).
+- Per-session event channel (agent/terminal всё ещё шлют в общий `agent_tx`).
+
+**Публичные контракты:** `SessionId`, `Session::id`, `TuiEvent::Agent { session_id, event }`,
+`App::find_session_idx()`. `BackgroundActivity/has_new/awaiting_confirmation` — pub-поля Session.
+
+**Тесты:** `cargo test -p filar-tui` — 206 passed, 0 failed. `cargo build --workspace`
+зелёный. Ручная проверка на Windows — требуется (агент в фоне, индикаторы вкладок).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -16,6 +16,7 @@ use crate::ui::Theme;
 
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use std::time::Duration;
@@ -185,8 +186,26 @@ pub struct App {
     pub help_bar_area: Rect,
 }
 
+/// Stable identifier for a session tab. Assigned once on creation, never
+/// reused. Events carry this id so they can be dispatched to the originating
+/// session even when the active tab changes or intermediate tabs close.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SessionId(u64);
+
+/// Global counter for unique SessionIds. Atomic so it can be incremented
+/// from any context (runner, UI) without locking.
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+
+impl SessionId {
+    fn next() -> Self {
+        SessionId(NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
 /// Per-tab session state — everything that is independent per open tab.
 pub struct Session {
+    /// Stable session identifier (never reused).
+    pub id: SessionId,
     /// Display name shown on the tab label.
     pub target_name: String,
     /// Chat history blocks.
@@ -267,6 +286,12 @@ pub struct Session {
     last_log_text: Option<String>,
     /// Count of consecutive identical forwarded log lines (for `… xN`).
     last_log_count: usize,
+    /// True when the agent is running in this session (even if not active).
+    pub background_activity: bool,
+    /// True when new output arrived since the user last viewed this tab.
+    pub has_new: bool,
+    /// True when a confirmation is pending (agent is waiting for user input).
+    pub awaiting_confirmation: bool,
 }
 
 impl App {
@@ -323,22 +348,35 @@ impl App {
 
     /// Switch to the previous tab (wraps around).
     pub fn prev_tab(&mut self) {
-        if self.active == 0 {
-            self.active = self.sessions.len() - 1;
+        let prev = if self.active == 0 {
+            self.sessions.len() - 1
         } else {
-            self.active -= 1;
-        }
+            self.active - 1
+        };
+        self.sessions[prev].has_new = false;
+        self.active = prev;
     }
 
     /// Switch to the next tab (wraps around).
     pub fn next_tab(&mut self) {
-        self.active = (self.active + 1) % self.sessions.len();
+        let next = (self.active + 1) % self.sessions.len();
+        self.sessions[next].has_new = false;
+        self.active = next;
     }
 
     /// Switch to tab at index (1-based from user, clamped).
     pub fn switch_to_tab(&mut self, index: usize) {
         let idx = index.saturating_sub(1).min(self.sessions.len().saturating_sub(1));
+        if idx != self.active {
+            // Clear "has new" flag on the tab being switched to.
+            self.sessions[idx].has_new = false;
+        }
         self.active = idx;
+    }
+
+    /// Find the index of a session by its stable id.
+    pub fn find_session_idx(&self, id: SessionId) -> Option<usize> {
+        self.sessions.iter().position(|s| s.id == id)
     }
 }
 
@@ -361,6 +399,7 @@ impl Session {
     pub fn new(target_name: String, confirm_mode: CommandConfirmMode) -> Self {
         let name = target_name.clone();
         Self {
+            id: SessionId::next(),
             target_name,
             messages: vec![ChatBlock::System(format!(
                 "Connected to: {name} | Mode: {confirm_mode:?}"
@@ -403,6 +442,9 @@ impl Session {
             click_count: 0,
             last_log_text: None,
             last_log_count: 0,
+            background_activity: false,
+            has_new: false,
+            awaiting_confirmation: false,
         }
     }
 }
@@ -662,7 +704,7 @@ impl App {
                                         explanation: "Shell escape (direct)".into(),
                                         output: None,
                                         approved: true,
-                                    });
+        });
                                     self.scroll = 0;
                                     self.input.clear();
                                     self.cursor_pos = 0;
@@ -1635,14 +1677,34 @@ impl App {
 
     /// Handle a TUI event (forwarded agent event or TUI-specific event).
     pub fn handle_agent_event(&mut self, event: TuiEvent) {
+        let sid = match &event {
+            TuiEvent::Agent { session_id, .. } => *session_id,
+            TuiEvent::Thinking => return, // Thinking events are UI-only, no session data.
+            TuiEvent::ConfirmationRequest { .. } => self.sessions[self.active].id,
+            TuiEvent::TransportChanged { .. } => self.sessions[self.active].id,
+        };
+
+        // Dispatch to the originating session. Save the active index so we can
+        // restore it after applying the event to a non-active tab.
+        let orig_active = self.active;
+        let is_background = self.sessions[orig_active].id != sid;
+
+        if let Some(idx) = self.find_session_idx(sid) {
+            self.active = idx;
+        } else {
+            // Session closed while event was in flight — discard.
+            tracing::debug!(?sid, "discarding event for closed session");
+            return;
+        }
+
         let mut auto_scroll = true;
         match event {
-            TuiEvent::Agent(agent_event) => match agent_event {
+            TuiEvent::Agent { event: agent_event, .. } => match agent_event {
                 filar_agent::AgentEvent::Started => {
                     self.mode = AppMode::Thinking;
+                    self.active_session_mut().background_activity = true;
                 }
                 filar_agent::AgentEvent::TextDelta(s) => {
-                    // Append to the last Agent block if streaming, else create new.
                     if self.streaming {
                         if let Some(ChatBlock::Agent(ref mut text)) = self.messages.last_mut() {
                             text.push_str(&s);
@@ -1654,29 +1716,21 @@ impl App {
                         self.streaming = true;
                     }
                     self.message_rev = self.message_rev.wrapping_add(1);
-                    // Only auto-scroll if already at bottom.
-                    // If the user scrolled up, don’t yank them down.
                     auto_scroll = self.scroll == 0;
                 }
                 filar_agent::AgentEvent::CommandProposed { command, explanation, .. } => {
-                    // Store proposal metadata so CommandFinished can preserve
-                    // the explanation for auto-approved commands (which never
-                    // go through ConfirmationRequest).
                     self.pending_proposal = Some((command, explanation));
                 }
                 filar_agent::AgentEvent::CommandFinished { command, output, denied } => {
                     if !denied {
-                        // Finalize any streaming text before showing command output.
                         self.streaming = false;
                         auto_scroll = self.scroll == 0;
-                        // Retrieve stored explanation from CommandProposed (if any).
                         let explanation = self
                             .pending_proposal
                             .as_ref()
                             .filter(|(cmd, _)| *cmd == command)
                             .map(|(_, expl)| expl.clone())
                             .unwrap_or_default();
-                        // Try to update the last matching Command block with output.
                         let mut updated = false;
                         if let Some(ChatBlock::Command {
                             command: ref cmd,
@@ -1689,35 +1743,24 @@ impl App {
                                 *o = Some(output.clone());
                                 *a = true;
                                 updated = true;
-                                // Bump rev so the cache rebuilds with updated output.
                                 self.message_rev = self.message_rev.wrapping_add(1);
                             }
                         }
                         if !updated {
                             self.push_message(ChatBlock::Command {
-                                command,
+                                command: command.clone(),
                                 explanation,
-                                output: Some(output),
+                                output: Some(output.clone()),
                                 approved: true,
                             });
                         }
+                    } else {
+                        self.push_message(ChatBlock::System(format!("Denied: {command}")));
+                        auto_scroll = self.scroll == 0;
                     }
-                    // Clear the pending proposal regardless — the command is done.
                     self.pending_proposal = None;
-                    // For denied commands, the command block was already pushed
-                    // by respond_to_confirmation (if confirmation was needed).
-                    // For blocked commands, no block is shown — matching old behavior.
-                    //
-                    // However, if a confirmation *timed out*, the TUI is still in
-                    // Confirming mode with a stale pending_confirm. Clear it so the
-                    // user isn't stuck in a dead dialog.
-                    if denied && self.mode == AppMode::Confirming {
-                        self.pending_confirm = None;
-                        self.mode = AppMode::Normal;
-                    }
                 }
                 filar_agent::AgentEvent::Finished(text) => {
-                    // Finalize streaming block with authoritative text.
                     if self.streaming {
                         if !text.is_empty() {
                             if let Some(ChatBlock::Agent(ref mut existing)) = self.messages.last_mut() {
@@ -1734,9 +1777,10 @@ impl App {
                     }
                     self.mode = AppMode::Normal;
                     self.agent_running = false;
+                    self.cancellation = None;
+                    self.active_session_mut().background_activity = false;
                 }
                 filar_agent::AgentEvent::Error(err) => {
-                    // If streaming was interrupted, mark it.
                     if self.streaming {
                         self.push_message(ChatBlock::System("response interrupted".into()));
                         self.streaming = false;
@@ -1745,24 +1789,11 @@ impl App {
                     self.push_message(ChatBlock::Error(err));
                     self.mode = AppMode::Normal;
                     self.agent_running = false;
-                }
-                filar_agent::AgentEvent::Cancelled => {
-                    // Agent was cancelled via CancellationToken.
-                    // If Ctrl+C already did cleanup (agent_running == false),
-                    // this just clears the token. Otherwise, do full cleanup.
                     self.cancellation = None;
-                    if self.agent_running {
-                        if self.streaming {
-                            self.push_message(ChatBlock::System("response interrupted".into()));
-                            self.streaming = false;
-                            auto_scroll = self.scroll == 0;
-                        }
-                        self.mode = AppMode::Normal;
-                        self.agent_running = false;
-                    }
+                    self.active_session_mut().background_activity = false;
                 }
-                _ => {} // non_exhaustive: ignore unknown agent events
-            }
+                _ => {}
+            },
             TuiEvent::Thinking => {
                 self.mode = AppMode::Thinking;
             }
@@ -1793,6 +1824,18 @@ impl App {
         if auto_scroll {
             self.scroll = 0;
         }
+        // Mark background session as having new content if event went to non-active tab.
+        if is_background {
+            self.active_session_mut().has_new = true;
+        }
+        // Track awaiting confirmation.
+        if self.mode == AppMode::Confirming {
+            self.active_session_mut().awaiting_confirmation = true;
+        } else {
+            self.active_session_mut().awaiting_confirmation = false;
+        }
+        // Restore the original active tab.
+        self.active = orig_active;
     }
 
     /// Take the pending user input (called by the runner to send to the agent).
@@ -2309,7 +2352,7 @@ mod tests {
     fn agent_text_response_bumps_message_rev() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let rev_before = app.message_rev;
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished("hello".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::Finished("hello".into()) });
         assert!(app.message_rev > rev_before);
     }
 
@@ -2317,7 +2360,7 @@ mod tests {
     fn agent_error_bumps_message_rev() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let rev_before = app.message_rev;
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Error("oops".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::Error("oops".into()) });
         assert!(app.message_rev > rev_before);
         assert_eq!(app.mode, AppMode::Normal);
     }
@@ -2334,11 +2377,11 @@ mod tests {
             approved: false,
         });
         let rev_before = app.message_rev;
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::CommandFinished {
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::CommandFinished {
             command: "ls".into(),
             output: "file1\nfile2".into(),
             denied: false,
-        }));
+        }});
         assert!(app.message_rev > rev_before, "in-place update must bump rev");
         // Verify the block was updated in-place, not duplicated.
         assert_eq!(app.messages.len(), 2); // system + command (updated)
@@ -3326,7 +3369,7 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Hello".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("Hello".into()) });
 
         assert!(app.streaming);
         assert_eq!(app.messages.len(), 1);
@@ -3342,8 +3385,8 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Hello".into())));
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta(" world".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("Hello".into()) });
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta(" world".into()) });
 
         assert!(app.streaming);
         assert_eq!(app.messages.len(), 1);
@@ -3360,14 +3403,14 @@ mod tests {
         app.mode = AppMode::Thinking;
 
         // Stream some text.
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Partial".into())));
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta(" response".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("Partial".into()) });
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta(" response".into()) });
         assert!(app.streaming);
 
         // Finished replaces with authoritative text.
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished(
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::Finished(
             "Partial response — finalized".into(),
-        )));
+        )});
 
         assert!(!app.streaming);
         assert_eq!(app.mode, AppMode::Normal);
@@ -3384,8 +3427,8 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Streamed text".into())));
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished(String::new())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("Streamed text".into()) });
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::Finished(String::new()) });
 
         assert!(!app.streaming);
         assert_eq!(app.messages.len(), 1);
@@ -3401,10 +3444,10 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Partial".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("Partial".into()) });
         assert!(app.streaming);
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Error("network error".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::Error("network error".into()) });
 
         assert!(!app.streaming);
         assert_eq!(app.mode, AppMode::Normal);
@@ -3420,7 +3463,7 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Let me check...".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("Let me check...".into()) });
         assert!(app.streaming);
 
         let (tx, _rx) = oneshot::channel::<bool>();
@@ -3442,7 +3485,7 @@ mod tests {
         app.mode = AppMode::Thinking;
         app.scroll = 5; // User scrolled up.
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("new text".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("new text".into()) });
 
         // Scroll should NOT be reset to 0 — user is reading history.
         assert_eq!(app.scroll, 5);
@@ -3455,7 +3498,7 @@ mod tests {
         app.mode = AppMode::Thinking;
         app.scroll = 0;
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("new text".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("new text".into()) });
 
         // Scroll stays at 0 (bottom).
         assert_eq!(app.scroll, 0);
@@ -3483,13 +3526,13 @@ mod tests {
         app.messages.clear();
         app.mode = AppMode::Thinking;
 
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("First".into())));
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::Finished("First".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("First".into()) });
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::Finished("First".into()) });
         assert!(!app.streaming);
 
         // New run.
         app.handle_agent_event(TuiEvent::Thinking);
-        app.handle_agent_event(TuiEvent::Agent(filar_agent::AgentEvent::TextDelta("Second".into())));
+        app.handle_agent_event(TuiEvent::Agent { session_id: app.sessions[0].id, event: filar_agent::AgentEvent::TextDelta("Second".into()) });
 
         assert!(app.streaming);
         assert_eq!(app.messages.len(), 2);

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1679,7 +1679,7 @@ impl App {
     pub fn handle_agent_event(&mut self, event: TuiEvent) {
         let sid = match &event {
             TuiEvent::Agent { session_id, .. } => *session_id,
-            TuiEvent::Thinking => return, // Thinking events are UI-only, no session data.
+            TuiEvent::Thinking => self.sessions[self.active].id,
             TuiEvent::ConfirmationRequest { .. } => self.sessions[self.active].id,
             TuiEvent::TransportChanged { .. } => self.sessions[self.active].id,
         };

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -6,7 +6,10 @@
 //! while TUI-specific events (confirmation requests, transport changes) are
 //! sent directly by TUI components.
 
+use filar_agent::AgentEvent;
 use tokio::sync::oneshot;
+
+use crate::app::SessionId;
 
 /// Events sent to the TUI.
 ///
@@ -16,7 +19,10 @@ use tokio::sync::oneshot;
 #[derive(Debug)]
 pub enum TuiEvent {
     /// Forwarded agent event (from the `EventSink`).
-    Agent(filar_agent::AgentEvent),
+    Agent {
+        session_id: SessionId,
+        event: AgentEvent,
+    },
 
     /// The agent is calling the LLM (thinking). TUI-specific: drives the spinner.
     Thinking,

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -23,7 +23,7 @@ use filar_transport::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::app::{App, AppMode};
+use crate::app::{App, AppMode, SessionId};
 use crate::confirmer::TuiConfirmer;
 use crate::event::TuiEvent;
 use crate::terminal::TerminalModel;
@@ -332,18 +332,15 @@ async fn run_app(
                         if !cmd.is_empty() {
                             let exec = tui_executor.clone();
                             let provider = config.secret_provider.clone();
+                            let sid = app.sessions[app.active].id;
                             let tx = agent_tx.clone();
                             tokio::spawn(async move {
-                                // Wrap with SecretSubstitutingExecutor so that
-                                // $FILAR_SECRET_N placeholders are substituted
-                                // and output is sanitised — same as agent path.
                                 let wrapped = SecretSubstitutingExecutor::new(
                                     exec as Arc<dyn CommandExecutor>,
                                     provider as Arc<dyn SecretProvider>,
                                 );
                                 let succeeded = match wrapped.run(&cmd).await {
                                     Ok(result) => {
-                                        // Build display output from CommandResult.
                                         let mut output = result.stdout.clone();
                                         if !result.stderr.is_empty() {
                                             output.push_str("\n[stderr] ");
@@ -354,30 +351,31 @@ async fn run_app(
                                                 output.push_str(&format!("\n[exit code: {code}]"));
                                             }
                                         }
-                                        let _ = tx.send(TuiEvent::Agent(
-                                            filar_agent::AgentEvent::CommandFinished {
+                                        let _ = tx.send(TuiEvent::Agent {
+                                            session_id: sid,
+                                            event: filar_agent::AgentEvent::CommandFinished {
                                                 command: cmd.clone(),
                                                 output,
                                                 denied: false,
                                             }
-                                        ));
+                                        });
                                         true
                                     }
                                     Err(e) => {
-                                        let _ = tx.send(TuiEvent::Agent(
-                                            filar_agent::AgentEvent::Error(
+                                        let _ = tx.send(TuiEvent::Agent {
+                                            session_id: sid,
+                                            event: filar_agent::AgentEvent::Error(
                                                 format!("Shell command failed: {e}")
                                             )
-                                        ));
+                                        });
                                         false
                                     }
                                 };
-                                // Signal completion only on success — Error is
-                                // already a terminal event for the TUI handler.
                                 if succeeded {
-                                    let _ = tx.send(TuiEvent::Agent(
-                                        filar_agent::AgentEvent::Finished(String::new())
-                                    ));
+                                    let _ = tx.send(TuiEvent::Agent {
+                                        session_id: sid,
+                                        event: filar_agent::AgentEvent::Finished(String::new())
+                                    });
                                 }
                             });
                         } else {
@@ -401,6 +399,7 @@ async fn run_app(
                             ssh_info.clone(),
                             cancel_token,
                             config.secret_provider.clone(),
+                            app.sessions[app.active].id,
                         );
                     }
                 }
@@ -408,6 +407,7 @@ async fn run_app(
                 // Check if user entered an SSH password — perform connection.
                 if let Some(password) = app.pending_ssh_password.take() {
                     if let Some((user, host, port)) = app.pending_ssh.take() {
+                        let sid = app.sessions[app.active].id;
                         let tx = agent_tx.clone();
                         let exec_clone = tui_executor.clone();
                         tokio::spawn(async move {
@@ -435,19 +435,21 @@ async fn run_app(
                                         is_local: false,
                                         ssh_info: Some(new_ssh_info),
                                     });
-                                    let _ = tx.send(TuiEvent::Agent(
-                                        filar_agent::AgentEvent::Finished(format!(
+                                    let _ = tx.send(TuiEvent::Agent {
+                                        session_id: sid,
+                                        event: filar_agent::AgentEvent::Finished(format!(
                                             "Connected to {user}@{host}:{port} via SSH. \
                                              You are now operating on the remote machine."
                                         ))
-                                    ));
+                                    });
                                 }
                                 Err(e) => {
-                                    let _ = tx.send(TuiEvent::Agent(
-                                        filar_agent::AgentEvent::Error(format!(
+                                    let _ = tx.send(TuiEvent::Agent {
+                                        session_id: sid,
+                                        event: filar_agent::AgentEvent::Error(format!(
                                             "SSH connection failed: {e}"
                                         ))
-                                    ));
+                                    });
                                 }
                             }
                         });
@@ -659,17 +661,13 @@ fn spawn_agent(
     ssh_info: Option<String>,
     cancellation: CancellationToken,
     secret_provider: Arc<dyn SecretProvider>,
+    sid: SessionId,
 ) {
     let tx = event_tx.clone();
 
     tokio::spawn(async move {
-        // TUI-specific: show spinner before the first text delta arrives.
         let _ = tx.send(TuiEvent::Thinking);
 
-        // Convert chat history (ChatBlock) to LLM messages (ChatMessage).
-        // Only User and Agent blocks are included — command blocks and system
-        // messages are omitted because they can't be faithfully reconstructed
-        // without tool call IDs.
         let history: Vec<filar_agent::ChatMessage> = chat_history
             .iter()
             .filter_map(|block| match block {
@@ -681,8 +679,6 @@ fn spawn_agent(
                     approved,
                     ..
                 } => {
-                    // Include command context as an assistant message so the
-                    // LLM remembers what it ran and what the result was.
                     let output_text = output.as_deref().unwrap_or(
                         if *approved { "(no output)" } else { "(denied by user)" },
                     );
@@ -699,12 +695,12 @@ fn spawn_agent(
             })
             .collect();
 
-        // Set up EventSink: forward agent events to the TUI channel.
-        // The agent emits Started, TextDelta, CommandProposed, CommandFinished,
-        // Finished, and Error via this sink.
         let tx_for_sink = tx.clone();
         let sink: filar_agent::EventSink = Arc::new(move |event: filar_agent::AgentEvent| {
-            let _ = tx_for_sink.send(TuiEvent::Agent(event));
+            let _ = tx_for_sink.send(TuiEvent::Agent {
+                session_id: sid,
+                event,
+            });
         });
 
         // Build the agent with appropriate system prompt.
@@ -725,9 +721,10 @@ fn spawn_agent(
         let agent = match builder.build() {
             Ok(a) => a,
             Err(e) => {
-                let _ = tx.send(TuiEvent::Agent(
-                    filar_agent::AgentEvent::Error(e.to_string())
-                ));
+                let _ = tx.send(TuiEvent::Agent {
+                    session_id: sid,
+                    event: filar_agent::AgentEvent::Error(e.to_string()),
+                });
                 return;
             }
         };

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -163,12 +163,28 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
 /// open session. Only called when `sessions.len() > 1`.
 fn render_tab_bar(f: &mut Frame, app: &App, area: Rect) {
     let active = app.active;
-    let mut spans: Vec<Span> = Vec::with_capacity(app.sessions.len() * 3);
+    let mut spans: Vec<Span> = Vec::with_capacity(app.sessions.len() * 4);
     for (i, s) in app.sessions.iter().enumerate() {
         if i > 0 {
             spans.push(Span::raw(" "));
         }
-        let label = format!("{}. {}", i + 1, s.target_name);
+        // Activity marker: spinner char for agent running, dot for new output,
+        // question mark for pending confirmation.
+        let marker = if i != active {
+            if s.awaiting_confirmation {
+                "? "
+            } else if s.background_activity {
+                // Use a fullwidth bullet to avoid layout jitter between states.
+                "\u{25cf} "
+            } else if s.has_new {
+                "\u{25cb} "
+            } else {
+                ""
+            }
+        } else {
+            ""
+        };
+        let label = format!("{}{}. {}", marker, i + 1, s.target_name);
         let style = if i == active {
             Style::default().add_modifier(Modifier::REVERSED)
         } else {


### PR DESCRIPTION
Closes #103

### Summary

Follow-up к #96 (вкладки): добавляет SessionId, диспетчеризацию событий агента по сессиям, и маркеры активности на ярлыках вкладок.

### Что сделано

| Компонент | Что |
|---|---|
| `SessionId(u64)` | Стабильный id (атомарный счётчик). Не переиспользуется |
| `TuiEvent::Agent { session_id, event }` | Вместо `TuiEvent::Agent(event)` |
| `handle_agent_event` | Диспатч по `session_id`: переключает `active` на целевую сессию → мутирует → восстанавливает |
| Фоновые события | `has_new = true` на неактивной вкладке; `background_activity` снимается на Finished/Error |
| Tab bar markers | `●` = агент работает, `?` = ждёт подтверждения, `○` = новые сообщения |
| `runner.rs` | Все `spawn_agent` / shell-commands захватывают `session_id` из активной вкладки |

### Что НЕ сделано (follow-up)

- PTY фоновых сессий (interactive в неактивной вкладке не читается)
- Per-session event channel (все агенты шлют в общий канал)

### Tests
- `cargo test -p filar-tui` — **206 passed, 0 failed**
- `cargo build --workspace` — зеленый

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added session-aware routing for agent/TUI events, ensuring updates are applied to the correct tab even when it’s not active.
  - Tabs now show activity markers for awaiting confirmation, background work, and new output.
  - New messages are marked as read when switching to the relevant tab.
- **Bug Fixes**
  - Improved streaming/command handling to keep command output and denial messages consistent with the originating session.
- **Documentation**
  - Updated the progress log with the new multiplexed-session behavior and tab-state rules.
- **Tests**
  - Updated TUI event construction to include per-session identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->