### PR TITLE
feat(gui): add alias field for SSH targets in launcher

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2501,3 +2501,25 @@ local с тем же LLM-доступом; переход в SSH внутри в
 
 **Тесты:** `cargo test -p filar-tui` — 206 passed, 0 failed. `cargo build --workspace`
 зелёный. Ручная проверка на Windows — требуется (агент в фоне, индикаторы вкладок).
+
+---
+
+## Issue #97: Лаунчер — поле alias для SSH-таргетов
+
+**Задача:** добавить поле «alias» в настройки каждого SSH-таргета лаунчера.
+Отображать alias на radio-кнопке вместо `SSHn`. Сохраняется как остальные поля
+(save_password, host, port, user) в `settings.json`.
+
+**Решение:**
+- `crates/gui/src/lib.rs`:
+  - `SshProfile::alias: String` — сохраняется в `settings.json` (`#[serde(default)]`).
+  - `SshSlot::alias: String` — runtime-поле для egui-UI.
+  - `from_profile/to_profile` — копируют alias.
+  - Radio-кнопка: если `alias` непустой — показывает alias, иначе `SSH{i}` (как раньше).
+  - Форма SSH: поле `Alias` (hint_text `"deploy"`, desired_width 120).
+
+**Публичные контракты:** `SshProfile::alias` (новое поле, serde(default), обратная
+совместимость — старые конфиги без `alias` не ломаются).
+
+**Тесты:** `cargo build --workspace` зелёный, `cargo test --workspace` — все тесты
+зелёные (agent 62, core 34, transport 24, tui 206). Ручная проверка GUI — требуется.

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -145,8 +145,10 @@ struct SshProfile {
     host: String,
     port: String,
     user: String,
+    /// Optional alias shown in the target selector instead of `SSHn`.
+    #[serde(default)]
+    alias: String,
     /// Whether the user checked "Save password" for this slot.
-    /// The actual password is in the OS credential store, not in this file.
     #[serde(default)]
     save_password: bool,
 }
@@ -207,6 +209,7 @@ struct SshSlot {
     host: String,
     port: String,
     user: String,
+    alias: String,
     password: String,
     save_password: bool,
 }
@@ -226,6 +229,7 @@ impl SshSlot {
                 p.port.clone()
             },
             user: p.user.clone(),
+            alias: p.alias.clone(),
             password,
             save_password: p.save_password,
         }
@@ -236,6 +240,7 @@ impl SshSlot {
             host: self.host.clone(),
             port: self.port.clone(),
             user: self.user.clone(),
+            alias: self.alias.clone(),
             save_password: self.save_password,
         }
     }
@@ -299,7 +304,12 @@ impl eframe::App for LauncherApp {
                 ui.label("Target:");
                 ui.radio_value(&mut self.target_mode, 0, "Local");
                 for i in 1..=SSH_SLOTS {
-                    ui.radio_value(&mut self.target_mode, i, format!("SSH{i}"));
+                    let label = if self.ssh_slots[i - 1].alias.is_empty() {
+                        format!("SSH{i}")
+                    } else {
+                        self.ssh_slots[i - 1].alias.clone()
+                    };
+                    ui.radio_value(&mut self.target_mode, i, label);
                 }
             });
 
@@ -329,6 +339,14 @@ impl eframe::App for LauncherApp {
                         ui.add(
                             egui::TextEdit::singleline(&mut slot.user)
                                 .hint_text("root"),
+                        );
+                        ui.end_row();
+
+                        ui.label("Alias:");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut slot.alias)
+                                .hint_text("deploy")
+                                .desired_width(120.0),
                         );
                         ui.end_row();
 

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -240,7 +240,7 @@ impl SshSlot {
             host: self.host.clone(),
             port: self.port.clone(),
             user: self.user.clone(),
-            alias: self.alias.clone(),
+            alias: self.alias.trim().chars().take(32).collect(),
             save_password: self.save_password,
         }
     }
@@ -304,10 +304,13 @@ impl eframe::App for LauncherApp {
                 ui.label("Target:");
                 ui.radio_value(&mut self.target_mode, 0, "Local");
                 for i in 1..=SSH_SLOTS {
-                    let label = if self.ssh_slots[i - 1].alias.is_empty() {
+                    let alias = self.ssh_slots[i - 1].alias.trim();
+                    let label = if alias.is_empty() {
                         format!("SSH{i}")
+                    } else if alias.chars().count() > 32 {
+                        format!("{}…", alias.chars().take(31).collect::<String>())
                     } else {
-                        self.ssh_slots[i - 1].alias.clone()
+                        alias.to_string()
                     };
                     ui.radio_value(&mut self.target_mode, i, label);
                 }


### PR DESCRIPTION
Closes #97

### Summary

Добавлено поле `alias` в настройки SSH-таргетов лаунчера. Сохраняется в `settings.json`, отображается на radio-кнопке выбора таргета.

### Что сделано

| Компонент | Что |
|---|---|
| `SshProfile::alias` | `String`, `#[serde(default)]` — сохраняется в settings.json |
| `SshSlot::alias` | `String` — runtime-поле для egui |
| Radio label | Если alias непустой → показывается alias, иначе `SSH{i}` |
| SSH form | Поле `Alias` с hint_text `"deploy"` |

### Обратная совместимость
- `alias` помечен `#[serde(default)]` — старые `settings.json` без поля не ломаются
- Пустой alias → radio показывает `SSH{n}` (поведение как раньше)

### Tests
- `cargo build --workspace` — зеленый
- `cargo test --workspace` — все тесты зеленые (326 total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional aliases for SSH launcher targets.
  * Added an “Alias” field to SSH target settings.
  * Target selectors now show the alias (instead of the default SSH label) when it’s set.
  * Alias values are saved and restored with launcher settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->