### PR TITLE
fix(tui): fix interactive PTY grid size — use 4 chrome lines instead of 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- Interactive terminal PTY/grid was sized 2 rows too tall (chrome = 4 lines, not 2),
+  hiding the shell prompt below the viewport until the window was maximized (#107).
+
 ## [0.5.0] - 2026-07-21
 
 Milestone v0.5.0 — hotfix интерактивного режима (select! starvation, скроллбар,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 ### Fixed
 
 - Interactive terminal PTY/grid was sized 2 rows too tall (chrome = 4 lines, not 2),
-  hiding the shell prompt below the viewport until the window was maximized (#107).
+  hiding the shell prompt below the viewport until the window was maximized
+  ([#107](https://github.com/devlawey/filar/issues/107)).
 
 ## [0.5.0] - 2026-07-21
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2566,3 +2566,23 @@ local с тем же LLM-доступом; переход в SSH внутри в
 - #98 (#106): feat лаунчер — тёмная тема, fixed bottom-panel layout
 
 **Engine:** не менялся (core/transport/agent не тронуты). Тег engine-v0.5.0 НЕ ставится.
+
+---
+
+## Issue #107: fix(tui) — интерактивный терминал на 2 строки выше видимой области
+
+**Проблема:** после v0.5.0 строка приглашения шелла в интерактивном режиме
+пряталась под экран при обычной высоте окна. `render_interactive` резервирует
+4 строки хрома (status + separator + separator + help), но PTY/модель
+создавались с `H − 2` — забыты два разделителя.
+
+**Решение:**
+- `crates/tui/src/ui/mod.rs`: константа `INTERACTIVE_CHROME_LINES = 4` и
+  хелпер `interactive_grid_rows(total_height) → total_height.saturating_sub(4)`.
+- `crates/tui/src/runner.rs`: `saturating_sub(2)` → `interactive_grid_rows(size.height)`
+  в обоих местах (вход в режим и ресайз).
+- `crates/tui/src/ui/mod.rs`: юнит-тест `interactive_grid_reserves_four_chrome_lines`.
+
+**Публичные контракты:** `INTERACTIVE_CHROME_LINES`, `interactive_grid_rows` (новые pub).
+
+**Тесты:** `cargo test -p filar-tui` — 207 passed (206 + 1 новый). `cargo build --workspace` зелёный.

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -258,7 +258,7 @@ async fn run_app(
                     Some(Ok(Event::Resize(cols, rows))) => {
                         if in_interactive {
                             let term_cols = cols;
-                            let term_rows = rows.saturating_sub(2); // status + help bar
+                            let term_rows = ui::interactive_grid_rows(rows);
                             if let Some(model) = &mut app.terminal {
                                 model.resize(term_cols, term_rows);
                             }
@@ -292,7 +292,7 @@ async fn run_app(
                         // Enter interactive mode.
                         let size = terminal.size().unwrap_or_default();
                         let cols = size.width;
-                        let rows = size.height.saturating_sub(2);
+                        let rows = ui::interactive_grid_rows(size.height);
                         let term_result: Result<Arc<dyn InteractiveTerminal>> =
                             if let Some(ref target) = config.ssh_target {
                                 SshInteractive::connect(target, cols, rows)

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -18,6 +18,16 @@
 //! All colours come from [`Theme`] — no `Color::*` literals exist outside
 //! `theme.rs`.
 
+/// Number of lines occupied by interactive-mode "chrome"
+/// (status bar + separator + separator + help bar).
+pub const INTERACTIVE_CHROME_LINES: u16 = 4;
+
+/// Returns the number of grid rows available for the interactive terminal,
+/// given the total terminal height.
+pub fn interactive_grid_rows(total_height: u16) -> u16 {
+    total_height.saturating_sub(INTERACTIVE_CHROME_LINES)
+}
+
 mod bars;
 mod chat;
 mod confirm;
@@ -195,4 +205,16 @@ fn render_tab_bar(f: &mut Frame, app: &App, area: Rect) {
     let line = Line::from(spans);
     let paragraph = Paragraph::new(line);
     f.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interactive_grid_reserves_four_chrome_lines() {
+        assert_eq!(interactive_grid_rows(30), 26);
+        assert_eq!(interactive_grid_rows(4), 0);
+        assert_eq!(interactive_grid_rows(3), 0); // saturating
+    }
 }


### PR DESCRIPTION
Closes #107

### Summary

Строка приглашения шелла в интерактивном режиме пряталась под экран. `render_interactive` резервирует 4 строки хрома (status + sep + sep + help), но PTY/модель создавались с `H − 2` — забыты два разделителя.

### Fix

- `INTERACTIVE_CHROME_LINES = 4` + `interactive_grid_rows()` в `ui/mod.rs`
- `runner.rs`: `saturating_sub(2)` → `interactive_grid_rows(size.height)` в обоих местах
- Unit test: `interactive_grid_reserves_four_chrome_lines`

### Tests
- `cargo test -p filar-tui` — **207 passed, 0 failed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the interactive terminal layout using two extra rows, which could hide the shell prompt.
  * The terminal now correctly accounts for surrounding interface elements when resizing or entering interactive mode.
  * Added safeguards for very small terminal windows to prevent invalid sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->