### PR TITLE
fix(tui): enable Ctrl+N/Ctrl+W in interactive terminal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Fixed visual artifacts (stale text, status-bar fragments) when switching between
   session tabs, especially from interactive to agent views and after Ctrl+Z
   ([#120](https://github.com/devlawey/filar/issues/120)).
+- `Ctrl+N` (new tab) and `Ctrl+W` (close tab) now work from interactive terminal
+  mode; previously they were forwarded to the PTY and ignored
+  ([#121](https://github.com/devlawey/filar/issues/121)).
 
 ## [0.5.1] - 2026-07-22
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2684,3 +2684,22 @@ Normal→Normal).
 
 **Тесты:** `cargo test -p filar-tui` — 210 passed.
 **Следующие шаги:** ручная проверка на Windows Terminal (артефакты при переключении вкладок после Ctrl+Z).
+
+---
+
+## Issue #121: bug(tui) — Ctrl+N не работает в интерактивном режиме
+
+**Проблема:** в интерактивном терминальном режиме `Ctrl+N` и `Ctrl+W` уходили
+в PTY (блокированы гейтом `mode != Interactive` в глобальных хоткеях).
+
+**Решение:**
+- `crates/tui/src/app.rs`, `AppMode::Interactive` в `handle_key`: перед
+  конвертацией в байты PTY перехватываются `Ctrl+N` (`new_tab()`) и
+  `Ctrl+W` (`close_tab()`). Без `toggle_interactive` — старая терминальная
+  вкладка остаётся живой. Перехват всегда (даже при одной вкладке для Ctrl+N).
+- Юнит-тесты: `interactive_ctrl_n_creates_new_tab_without_exiting`,
+  `interactive_ctrl_w_closes_tab`.
+
+**Публичные контракты:** без изменений (внутренний обработчик клавиш).
+
+**Тесты:** `cargo test -p filar-tui` — 212 passed (210 + 2 новых).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -4648,6 +4648,9 @@ mod tests {
         assert_eq!(app.sessions.len(), 2, "Ctrl+N must create a new tab");
         assert!(!app.take_toggle_interactive(), "Ctrl+N must NOT request interactive teardown");
         assert!(app.take_term_input().is_none(), "Ctrl+N must not be forwarded to PTY");
+        // Old tab's terminal still alive in background.
+        assert_eq!(app.sessions[0].mode, AppMode::Interactive);
+        assert!(app.sessions[0].terminal.is_some(), "old tab terminal must persist");
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -851,6 +851,19 @@ impl App {
                     self.toggle_interactive = true;
                     return;
                 }
+                // Ctrl+N — new tab (local). Intercepted always: the new tab
+                // starts in agent mode, the current terminal stays alive in
+                // the background. No toggle_interactive — old PTY untouched.
+                if ctrl_key('n', 'т') {
+                    self.new_tab();
+                    return;
+                }
+                // Ctrl+W — close the active tab. Last tab quits. Intercepted
+                // always: the terminal is torn down inside close_tab.
+                if ctrl_key('w', 'ц') {
+                    self.close_tab();
+                    return;
+                }
                 // Tab navigation when multiple tabs are open: switch tab and
                 // exit interactive mode (global PTY, not per-session). Single
                 // tab → let keys fall through to PTY unchanged.
@@ -4620,5 +4633,34 @@ mod tests {
 
         assert_eq!(app.active, before, "plain key must not switch tab");
         assert_eq!(app.take_term_input().as_deref(), Some(&b"a"[..]));
+    }
+
+    #[test]
+    fn interactive_ctrl_n_creates_new_tab_without_exiting() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        let model = crate::terminal::TerminalModel::new(80, 24);
+        app.enter_interactive(model);
+        assert_eq!(app.sessions.len(), 1);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL));
+
+        assert_eq!(app.sessions.len(), 2, "Ctrl+N must create a new tab");
+        assert!(!app.take_toggle_interactive(), "Ctrl+N must NOT request interactive teardown");
+        assert!(app.take_term_input().is_none(), "Ctrl+N must not be forwarded to PTY");
+    }
+
+    #[test]
+    fn interactive_ctrl_w_closes_tab() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        app.new_tab(); // 2 sessions, active = 1
+        let model = crate::terminal::TerminalModel::new(80, 24);
+        app.enter_interactive(model);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+
+        assert_eq!(app.sessions.len(), 1, "Ctrl+W must close the active tab");
+        assert!(app.take_term_input().is_none(), "Ctrl+W must not be forwarded to PTY");
     }
 }


### PR DESCRIPTION
Closes #121

### Summary

В интерактивном режиме `Ctrl+N` (новая вкладка) и `Ctrl+W` (закрыть вкладку) уходили в PTY. Теперь перехватываются.

### Fix

- `Ctrl+N` → `new_tab()` — без `toggle_interactive`, старая терминальная вкладка остаётся в фоне
- `Ctrl+W` → `close_tab()` — закрывает активную, последняя → quit
- Перехват всегда (для Ctrl+N — даже при одной вкладке)

### Tests
- `interactive_ctrl_n_creates_new_tab_without_exiting`
- `interactive_ctrl_w_closes_tab`
- `cargo test -p filar-tui` — **212 passed, 0 failed**