### PR TITLE
refactor(tui): store interactive backends per SessionId HashMap instead of single variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Interactive terminal backends are now stored per `SessionId` in the runner
+  (internal refactor, no behavior change) preparing per-tab persistent terminals
+  ([#113](https://github.com/devlawey/filar/issues/113)).
+
 ### Fixed
 
 - Interactive scrollbar now responds to mouse drag; it was previously only

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2703,3 +2703,20 @@ Normal→Normal).
 **Публичные контракты:** без изменений (внутренний обработчик клавиш).
 
 **Тесты:** `cargo test -p filar-tui` — 212 passed (210 + 2 новых).
+
+---
+
+## Issue #113: refactor(tui) — хранилище интерактивных бэкендов по SessionId
+
+**Проблема:** бэкенд интерактивного терминала хранился в единственной переменной
+`Option<Arc<dyn InteractiveTerminal>>` — не масштабируется на per-session.
+
+**Решение:**
+- `crates/tui/src/runner.rs`: замена на `HashMap<SessionId, Arc<dyn InteractiveTerminal>>`.
+  Все операции (создание, чтение, ресайз, close, финальная очистка) работают через
+  `active_sid = app.sessions[app.active].id`. Поведение идентично 0.5.1.
+- Финальная очистка: `drain()` всех бэкендов.
+
+**Публичные контракты:** без изменений (внутренний рефактор runner).
+
+**Тесты:** `cargo test -p filar-tui` — 212 passed, 0 failed.

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -242,8 +242,16 @@ async fn run_app(
     loop {
         let in_interactive = app.mode == AppMode::Interactive;
         // Clone the Arc for the read future (avoids borrowing backends map).
-        let active_sid = app.sessions[app.active].id;
-        let term_for_read = interactive_backends.get(&active_sid).cloned();
+        // The read sid is captured alongside the Arc so the read result can
+        // be dispatched to the correct session even if the active tab changes.
+        let read_pair: Option<(crate::app::SessionId, Arc<dyn InteractiveTerminal>)> =
+            if in_interactive {
+                let sid = app.sessions[app.active].id;
+                interactive_backends.get(&sid).map(|term| (sid, term.clone()))
+            } else {
+                None
+            };
+        let term_for_read = read_pair.as_ref().map(|(_, t)| t.clone());
 
         tokio::select! {
             // Terminal keyboard / resize event.
@@ -262,12 +270,13 @@ async fn run_app(
                     }
                     Some(Ok(Event::Resize(cols, rows))) => {
                         if in_interactive {
+                            let resize_sid = app.sessions[app.active].id;
                             let term_cols = cols;
                             let term_rows = ui::interactive_grid_rows(rows);
                             if let Some(model) = &mut app.terminal {
                                 model.resize(term_cols, term_rows);
                             }
-                            if let Some(ref term) = interactive_backends.get(&active_sid) {
+                            if let Some(ref term) = interactive_backends.get(&resize_sid) {
                                 let _ = term.resize(term_cols, term_rows).await;
                             }
                         }
@@ -286,9 +295,10 @@ async fn run_app(
 
                 // Handle mode toggle (Ctrl+T).
                 if app.take_toggle_interactive() {
+                    let toggle_sid = app.sessions[app.active].id;
                     if in_interactive {
                         // Exit interactive mode.
-                        if let Some(term) = interactive_backends.remove(&active_sid) {
+                        if let Some(term) = interactive_backends.remove(&toggle_sid) {
                             let _ = term.close().await;
                         }
                         app.exit_interactive();
@@ -310,8 +320,7 @@ async fn run_app(
                         match term_result {
                             Ok(term) => {
                                 let model = TerminalModel::new(cols, rows);
-                                interactive_backends
-                                    .insert(active_sid, term);
+                                interactive_backends.insert(toggle_sid, term);
                                 app.enter_interactive(model);
                             }
                             Err(e) => {
@@ -324,7 +333,8 @@ async fn run_app(
 
                 // Forward terminal input bytes to the backend.
                 if let Some(bytes) = app.take_term_input() {
-                    if let Some(ref term) = interactive_backends.get(&active_sid) {
+                    let write_sid = app.sessions[app.active].id;
+                    if let Some(ref term) = interactive_backends.get(&write_sid) {
                         let _ = term.write_input(&bytes).await;
                     }
                 }
@@ -509,6 +519,7 @@ async fn run_app(
                     >().await,
                 }
             } => {
+                let read_sid = read_pair.as_ref().map(|(sid, _)| *sid);
                 match maybe_output {
                     Ok(Some(bytes)) => {
                         if let Some(model) = &mut app.terminal {
@@ -518,15 +529,19 @@ async fn run_app(
                     }
                     Ok(None) => {
                         // Terminal EOF (shell exited) — auto-exit interactive mode.
-                        if let Some(term) = interactive_backends.remove(&active_sid) {
-                            let _ = term.close().await;
+                        if let Some(sid) = read_sid {
+                            if let Some(term) = interactive_backends.remove(&sid) {
+                                let _ = term.close().await;
+                            }
                         }
                         app.exit_interactive();
                         needs_redraw = true;
                     }
                     Err(e) => {
                         error!(error = %e, "terminal read error");
-                        interactive_backends.remove(&active_sid);
+                        if let Some(sid) = read_sid {
+                            interactive_backends.remove(&sid);
+                        }
                         app.exit_interactive();
                         needs_redraw = true;
                     }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -219,8 +219,11 @@ async fn run_app(
     // Crossterm event stream for async keyboard input.
     let mut events = EventStream::new();
 
-    // Interactive terminal backend (set when entering interactive mode).
-    let mut interactive_term: Option<Arc<dyn InteractiveTerminal>> = None;
+    // Interactive terminal backends — one per session, keyed by SessionId.
+    let mut interactive_backends: std::collections::HashMap<
+        crate::app::SessionId,
+        Arc<dyn InteractiveTerminal>,
+    > = std::collections::HashMap::new();
 
     // Draw initial UI.
     terminal.draw(|f| ui::render(f, &mut app)).ok();
@@ -238,8 +241,9 @@ async fn run_app(
 
     loop {
         let in_interactive = app.mode == AppMode::Interactive;
-        // Clone the Arc for the read future (avoids borrowing interactive_term).
-        let term_for_read = interactive_term.clone();
+        // Clone the Arc for the read future (avoids borrowing backends map).
+        let active_sid = app.sessions[app.active].id;
+        let term_for_read = interactive_backends.get(&active_sid).cloned();
 
         tokio::select! {
             // Terminal keyboard / resize event.
@@ -263,7 +267,7 @@ async fn run_app(
                             if let Some(model) = &mut app.terminal {
                                 model.resize(term_cols, term_rows);
                             }
-                            if let Some(ref term) = interactive_term {
+                            if let Some(ref term) = interactive_backends.get(&active_sid) {
                                 let _ = term.resize(term_cols, term_rows).await;
                             }
                         }
@@ -284,10 +288,9 @@ async fn run_app(
                 if app.take_toggle_interactive() {
                     if in_interactive {
                         // Exit interactive mode.
-                        if let Some(ref term) = interactive_term {
+                        if let Some(term) = interactive_backends.remove(&active_sid) {
                             let _ = term.close().await;
                         }
-                        interactive_term = None;
                         app.exit_interactive();
                     } else if !app.agent_running {
                         // Enter interactive mode.
@@ -307,7 +310,8 @@ async fn run_app(
                         match term_result {
                             Ok(term) => {
                                 let model = TerminalModel::new(cols, rows);
-                                interactive_term = Some(term);
+                                interactive_backends
+                                    .insert(active_sid, term);
                                 app.enter_interactive(model);
                             }
                             Err(e) => {
@@ -320,7 +324,7 @@ async fn run_app(
 
                 // Forward terminal input bytes to the backend.
                 if let Some(bytes) = app.take_term_input() {
-                    if let Some(ref term) = interactive_term {
+                    if let Some(ref term) = interactive_backends.get(&active_sid) {
                         let _ = term.write_input(&bytes).await;
                     }
                 }
@@ -514,16 +518,15 @@ async fn run_app(
                     }
                     Ok(None) => {
                         // Terminal EOF (shell exited) — auto-exit interactive mode.
-                        if let Some(ref term) = interactive_term {
+                        if let Some(term) = interactive_backends.remove(&active_sid) {
                             let _ = term.close().await;
                         }
-                        interactive_term = None;
                         app.exit_interactive();
                         needs_redraw = true;
                     }
                     Err(e) => {
                         error!(error = %e, "terminal read error");
-                        interactive_term = None;
+                        interactive_backends.remove(&active_sid);
                         app.exit_interactive();
                         needs_redraw = true;
                     }
@@ -602,8 +605,8 @@ async fn run_app(
         }
     }
 
-    // Clean up interactive terminal if still open.
-    if let Some(ref term) = interactive_term {
+    // Clean up interactive terminals — close all remaining backends.
+    for (_, term) in interactive_backends.drain() {
         let _ = term.close().await;
     }
 


### PR DESCRIPTION
Closes #113

### Summary

Подготовительный рефактор под persistent per-session терминалы: замена единственной переменной `interactive_term` на `HashMap<SessionId, Arc<dyn InteractiveTerminal>>`.

### Что изменилось

- `runner.rs`: все операции (создание, read, resize, write_input, close на EOF/ошибке, финальная очистка) работают через `interactive_backends.get(&active_sid)` / `insert` / `remove`
- `active_sid` вычисляется как `app.sessions[app.active].id`
- Поведение идентично 0.5.1 — без смены видимого поведения

### Tests
- `cargo test -p filar-tui` — **212 passed, 0 failed**