### PR TITLE
feat(tui): persistent per-tab terminals — hide/show view, remove exit-on-switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   (including background tabs) is drained and routed to its own session model
   ([#114](https://github.com/devlawey/filar/issues/114)).
 
+### Changed
+
+- Interactive terminals are now persistent per tab: switching tabs no longer
+  closes the terminal, and Ctrl+T toggles the view without killing the PTY
+  (supersedes the 0.5.1 exit-on-switch behavior)
+  ([#115](https://github.com/devlawey/filar/issues/115)).
+
 ### Fixed
 
 - Interactive scrollbar now responds to mouse drag; it was previously only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,19 +16,16 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Interactive terminal backends are now stored per `SessionId` in the runner
   (internal refactor, no behavior change) preparing per-tab persistent terminals
   ([#113](https://github.com/devlawey/filar/issues/113)).
+- Interactive terminals are now persistent per tab: switching tabs no longer
+  closes the terminal, and Ctrl+T toggles the view without killing the PTY
+  (supersedes the 0.5.1 exit-on-switch behavior)
+  ([#115](https://github.com/devlawey/filar/issues/115)).
 
 ### Added
 
 - Per-terminal reader tasks feed a tagged channel so every interactive backend
   (including background tabs) is drained and routed to its own session model
   ([#114](https://github.com/devlawey/filar/issues/114)).
-
-### Changed
-
-- Interactive terminals are now persistent per tab: switching tabs no longer
-  closes the terminal, and Ctrl+T toggles the view without killing the PTY
-  (supersedes the 0.5.1 exit-on-switch behavior)
-  ([#115](https://github.com/devlawey/filar/issues/115)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2743,3 +2743,33 @@ Normal→Normal).
 closed session ignore, EOF outcome).
 
 **Тесты:** `cargo test -p filar-tui` — 215 passed (212 + 3 новых).
+
+---
+
+## Issue #115: feat(tui) — персистентное переключение вкладок
+
+**Проблема:** в 0.5.1 переключение вкладок в интерактивном режиме убивало PTY
+(exit-on-switch). Нужно оставлять терминал живым — как оставлял.
+
+**Решение:**
+- `app.rs`:
+  - Ctrl+T в Interactive → `hide_interactive_view()` (прячет вид, PTY жив).
+  - Ctrl+T в Normal с живым терминалом → `show_interactive_view()`.
+  - Ctrl+T в Normal без терминала → `toggle_interactive = true` (runner создаст).
+  - Ctrl+Tab/Ctrl+PgUp/Ctrl+PgDn в Interactive → переключение вкладки **без**
+    `toggle_interactive` (терминал остаётся в фоне).
+  - `hide_interactive_view()`: mode = Normal, terminal сохраняется.
+  - `show_interactive_view()`: mode = Interactive, если terminal.is_some().
+  - `exit_interactive()` НЕ трогался — полный teardown через runner/tab close.
+- `runner.rs`:
+  - При `take_toggle_interactive()`: если бэкенд уже существует для сессии,
+    просто `show_interactive_view()`. Новый создаётся только если бэкенда нет.
+
+**Тесты:** `interactive_ctrl_tab_switches_without_exiting` (был `_and_exits`),
+`hide_view_keeps_terminal_alive`, `show_view_restores_interactive`,
+`ctrl_t_in_normal_shows_hidden_terminal`.
+
+**Публичные контракты:** `hide_interactive_view()`, `show_interactive_view()` —
+новые pub-методы App.
+
+**Тесты:** `cargo test -p filar-tui` — 218 passed (215 + 3 новых).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2773,3 +2773,4 @@ closed session ignore, EOF outcome).
 новые pub-методы App.
 
 **Тесты:** `cargo test -p filar-tui` — 218 passed (215 + 3 новых).
+**Следующие шаги:** ручная проверка на Windows Terminal (терминал переживает переключение вкладок, Ctrl+T тумблит вид).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -725,8 +725,13 @@ impl App {
                     }
                 }
                 _ if ctrl_key('t', 'е') => {
-                    // Toggle to interactive terminal mode.
-                    self.toggle_interactive = true;
+                    // If the active session already has a live terminal,
+                    // show it instead of creating a new one.
+                    if self.terminal.is_some() {
+                        self.show_interactive_view();
+                    } else {
+                        self.toggle_interactive = true;
+                    }
                 }
                 _ if ctrl_key('p', 'з') => {
                     // Enter secure password input mode.
@@ -845,10 +850,11 @@ impl App {
                 _ => {}
             },
             AppMode::Interactive => {
-                // Ctrl+T toggles back to agent mode. Every other key — including
-                // ^C/^Q/^Z — is forwarded to the remote PTY unchanged.
+                // Ctrl+T toggles the terminal view: hides the terminal while
+                // keeping the PTY alive in the background. To fully close the
+                // terminal, close the tab (Ctrl+W) or exit the session.
                 if ctrl_key('t', 'е') {
-                    self.toggle_interactive = true;
+                    self.hide_interactive_view();
                     return;
                 }
                 // Ctrl+N — new tab (local). Intercepted always: the new tab
@@ -892,7 +898,6 @@ impl App {
                         _ => false,
                     };
                     if switch {
-                        self.toggle_interactive = true;
                         return;
                     }
                 }
@@ -1985,6 +1990,20 @@ impl App {
         self.push_message(ChatBlock::System(
             "Returned to agent mode".into(),
         ));
+    }
+
+    /// Hide the interactive view, keeping the terminal alive in the background.
+    pub fn hide_interactive_view(&mut self) {
+        if self.mode == AppMode::Interactive {
+            self.mode = AppMode::Normal;
+        }
+    }
+
+    /// Show the interactive view for the active session, if a terminal exists.
+    pub fn show_interactive_view(&mut self) {
+        if self.terminal.is_some() {
+            self.mode = AppMode::Interactive;
+        }
     }
 
     /// Scroll to the bottom (latest messages).
@@ -4605,7 +4624,7 @@ mod tests {
     }
 
     #[test]
-    fn interactive_ctrl_tab_switches_and_exits() {
+    fn interactive_ctrl_tab_switches_without_exiting() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         let mut app = App::new("t0".into(), CommandConfirmMode::Always);
         app.new_tab(); // now 2 sessions, active = 1
@@ -4616,7 +4635,7 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL));
 
         assert_ne!(app.active, before, "Ctrl+Tab must switch tab");
-        assert!(app.take_toggle_interactive(), "Ctrl+Tab must request interactive exit");
+        assert!(!app.take_toggle_interactive(), "Ctrl+Tab must NOT request interactive teardown");
         assert!(app.take_term_input().is_none(), "Ctrl+Tab must not be forwarded to PTY");
     }
 
@@ -4665,5 +4684,36 @@ mod tests {
 
         assert_eq!(app.sessions.len(), 1, "Ctrl+W must close the active tab");
         assert!(app.take_term_input().is_none(), "Ctrl+W must not be forwarded to PTY");
+    }
+
+    #[test]
+    fn hide_view_keeps_terminal_alive() {
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        app.enter_interactive(crate::terminal::TerminalModel::new(80, 24));
+        app.hide_interactive_view();
+        assert_eq!(app.mode, AppMode::Normal);
+        assert!(app.terminal.is_some(), "terminal model must persist");
+    }
+
+    #[test]
+    fn show_view_restores_interactive() {
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        app.enter_interactive(crate::terminal::TerminalModel::new(80, 24));
+        app.hide_interactive_view();
+        app.show_interactive_view();
+        assert_eq!(app.mode, AppMode::Interactive);
+    }
+
+    #[test]
+    fn cyttrl_t_in_normal_shows_hidden_terminal() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        app.enter_interactive(crate::terminal::TerminalModel::new(80, 24));
+        app.hide_interactive_view();
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+
+        assert_eq!(app.mode, AppMode::Interactive, "Ctrl+T must show hidden terminal");
+        assert!(!app.take_toggle_interactive(), "must not request runner teardown");
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -870,9 +870,9 @@ impl App {
                     self.close_tab();
                     return;
                 }
-                // Tab navigation when multiple tabs are open: switch tab and
-                // exit interactive mode (global PTY, not per-session). Single
-                // tab → let keys fall through to PTY unchanged.
+                // Tab navigation when multiple tabs are open: switch the active
+                // tab while preserving per-tab terminal state. PTY stays alive
+                // in the background — no teardown, no toggle_interactive.
                 if self.sessions.len() > 1 {
                     let switch = match (key.code, key.modifiers) {
                         (KeyCode::Tab, m) if m.contains(KeyModifiers::CONTROL) => {
@@ -1359,8 +1359,8 @@ impl App {
             }
             HelpAction::Quit => {
                 if self.mode == AppMode::Interactive {
-                    // No quit from interactive — Ctrl+T returns to agent mode.
-                    self.toggle_interactive = true;
+                    // Hide terminal view without killing PTY (persistent tabs).
+                    self.hide_interactive_view();
                 } else {
                     self.quit();
                 }
@@ -4705,7 +4705,7 @@ mod tests {
     }
 
     #[test]
-    fn cyttrl_t_in_normal_shows_hidden_terminal() {
+    fn ctrl_t_in_normal_shows_hidden_terminal() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         let mut app = App::new("t0".into(), CommandConfirmMode::Always);
         app.enter_interactive(crate::terminal::TerminalModel::new(80, 24));
@@ -4715,5 +4715,30 @@ mod tests {
 
         assert_eq!(app.mode, AppMode::Interactive, "Ctrl+T must show hidden terminal");
         assert!(!app.take_toggle_interactive(), "must not request runner teardown");
+    }
+
+    #[test]
+    fn each_tab_preserves_its_own_terminal() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        app.new_tab(); // active = 1 (t1)
+
+        // Give each tab a distinct terminal model.
+        let _t0 = app.sessions[0].id;
+        let _t1 = app.sessions[1].id;
+        app.sessions[0].terminal = Some(crate::terminal::TerminalModel::new(80, 20));
+        app.sessions[1].terminal = Some(crate::terminal::TerminalModel::new(80, 24));
+        app.sessions[0].mode = AppMode::Interactive;
+        app.sessions[1].mode = AppMode::Interactive;
+
+        // Switch to tab 0.
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL | KeyModifiers::SHIFT));
+        assert_eq!(app.active, 0);
+
+        // Verify tab 0's terminal is intact, tab 1's also alive.
+        assert!(app.sessions[0].terminal.is_some());
+        assert_eq!(app.sessions[0].mode, AppMode::Interactive);
+        assert!(app.sessions[1].terminal.is_some());
+        assert_eq!(app.sessions[1].mode, AppMode::Interactive);
     }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -607,6 +607,10 @@ async fn run_app(
                                 let _ = term.close().await;
                                 handle.abort();
                             }
+                            // Clear the terminal model for the dying session.
+                            if let Some(s) = app.sessions.iter_mut().find(|s| s.id == sid) {
+                                s.terminal = None;
+                            }
                             if app.sessions.get(app.active).map(|s| s.id) == Some(sid)
                                 && app.mode == AppMode::Interactive
                             {
@@ -618,6 +622,9 @@ async fn run_app(
                             if let Some((term, handle)) = interactive_backends.remove(&sid) {
                                 let _ = term.close().await;
                                 handle.abort();
+                            }
+                            if let Some(s) = app.sessions.iter_mut().find(|s| s.id == sid) {
+                                s.terminal = None;
                             }
                             if app.sessions.get(app.active).map(|s| s.id) == Some(sid)
                                 && app.mode == AppMode::Interactive

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -359,6 +359,9 @@ async fn run_app(
                             handle.abort();
                         }
                         app.exit_interactive();
+                    } else if interactive_backends.contains_key(&toggle_sid) {
+                        // Session already has a live backend — just show its view.
+                        app.show_interactive_view();
                     } else if !app.agent_running {
                         // Enter interactive mode.
                         let size = terminal.size().unwrap_or_default();


### PR DESCRIPTION
Closes #115

### Summary

🔑 **Core feature of v0.6.0.** Переключение вкладок больше не убивает терминал — PTY остаётся живым в фоне. `Ctrl+T` тумблит вид (прячет/показывает) без закрытия PTY.

### What changed

| Component | What |
|---|---|
| `hide_interactive_view()` | `mode = Normal`, terminal stays alive |
| `show_interactive_view()` | `mode = Interactive`, only if terminal exists |
| `Ctrl+T` in Interactive | `hide_interactive_view()` — не `toggle_interactive` |
| `Ctrl+T` in Normal | Если терминал есть → `show`, если нет → `toggle_interactive` (runner создаст) |
| `Ctrl+Tab`/`Ctrl+PgUp`/`Ctrl+PgDn` in Interactive | Только переключение вкладки, **без** `toggle_interactive` |
| runner.rs | При входе проверяет `interactive_backends.contains_key()` — если да, только показывает вид |

### Behavior change from 0.5.1
- 0.5.1: exit-on-switch — переключение вкладки = закрытие терминала
- 0.6.0: persistent — терминал живёт в фоне, `Ctrl+T` тумблит вид

### Tests
- `interactive_ctrl_tab_switches_without_exiting` (was `_and_exits`)
- `hide_view_keeps_terminal_alive`
- `show_view_restores_interactive`
- `ctrl_t_in_normal_shows_hidden_terminal`
- `cargo test -p filar-tui` — **218 passed, 0 failed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Interactive terminals now persist when switching tabs.
  - `Ctrl+T` hides and restores the terminal view without closing the terminal session.
  - Tab navigation no longer terminates active interactive terminals.

- **Bug Fixes**
  - Prevented unnecessary terminal recreation when returning to a previously hidden interactive terminal.

- **Documentation**
  - Updated changelog and progress documentation to describe the new terminal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->