### PR TITLE
feat(tui): terminal lifecycle — signal close_tab to runner, teardown backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   (supersedes the 0.5.1 exit-on-switch behavior)
   ([#115](https://github.com/devlawey/filar/issues/115)).
 
+### Fixed
+
+- Per-tab interactive terminals are torn down on tab close and app exit, and
+  background EOF/errors retire a tab's terminal without disturbing the active
+  tab ([#116](https://github.com/devlawey/filar/issues/116)).
+
 ### Added
 
 - Per-terminal reader tasks feed a tagged channel so every interactive backend

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2774,3 +2774,27 @@ closed session ignore, EOF outcome).
 
 **Тесты:** `cargo test -p filar-tui` — 218 passed (215 + 3 новых).
 **Следующие шаги:** ручная проверка на Windows Terminal (терминал переживает переключение вкладок, Ctrl+T тумблит вид).
+
+---
+
+## Issue #116: feat(tui) — жизненный цикл терминалов
+
+**Проблема:** close_tab (Ctrl+W) не закрывал бэкенд интерактивного терминала —
+только отменял агента. PTY/reader-задача висели до финальной очистки.
+
+**Решение:**
+- `app.rs`: `close_tab()` теперь кладёт `SessionId` закрытой вкладки в
+  `closed_ids: Vec<SessionId>`. `take_closed_ids()` — drain для runner'а.
+- `runner.rs`: после каждой итерации event-loop дренируются `take_closed_ids()`,
+  для каждого закрытого id — `interactive_backends.remove()` + `close()` +
+  `handle.abort()`.
+- Финальная очистка (уже была из #114) закрывает оставшиеся бэкенды.
+- Background EOF/Err (из #115 fix) чистит `session.terminal = None` для
+  неактивных сессий, не переключая активную.
+
+**Тесты:** новый тест `closing_tab_signals_backend_teardown` (проверяет
+`take_closed_ids()`).
+
+**Публичные контракты:** `App::closed_ids`, `App::take_closed_ids()`.
+
+**Тесты:** `cargo test -p filar-tui` — 220 passed (219 + 1 новый).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -184,6 +184,9 @@ pub struct App {
     pub status_bar_area: Rect,
     /// Help bar area (set during render, for hit-testing).
     pub help_bar_area: Rect,
+    /// SessionIds of recently closed tabs — consumed by runner to teardown
+    /// corresponding interactive backends.
+    pub closed_ids: Vec<SessionId>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -318,6 +321,7 @@ impl App {
             theme: Theme::default_dark(),
             status_bar_area: Rect::default(),
             help_bar_area: Rect::default(),
+            closed_ids: Vec::new(),
         }
     }
 
@@ -330,11 +334,14 @@ impl App {
     }
 
     /// Close the active tab. If it's the last tab, set should_quit.
+    /// Pushes the closed session's SessionId into `closed_ids` so the
+    /// runner can teardown its interactive backend (PTY/reader task).
     pub fn close_tab(&mut self) {
         if self.sessions.len() <= 1 {
             self.should_quit = true;
             return;
         }
+        let sid = self.sessions[self.active].id;
         // Cancel the agent task for the tab being closed so leftover
         // events don't land on the next active session.
         if let Some(ref token) = self.sessions[self.active].cancellation {
@@ -344,6 +351,12 @@ impl App {
         if self.active >= self.sessions.len() {
             self.active = self.sessions.len() - 1;
         }
+        self.closed_ids.push(sid);
+    }
+
+    /// Take and clear the list of closed session IDs (for runner to process).
+    pub fn take_closed_ids(&mut self) -> Vec<SessionId> {
+        std::mem::take(&mut self.closed_ids)
     }
 
     /// Switch to the previous tab (wraps around).
@@ -4740,5 +4753,15 @@ mod tests {
         assert_eq!(app.sessions[0].mode, AppMode::Interactive);
         assert!(app.sessions[1].terminal.is_some());
         assert_eq!(app.sessions[1].mode, AppMode::Interactive);
+    }
+
+    #[test]
+    fn closing_tab_signals_backend_teardown() {
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        app.new_tab(); // active = 1
+        let sid = app.sessions[app.active].id;
+        app.close_tab();
+        let closed = app.take_closed_ids();
+        assert!(closed.contains(&sid), "close_tab must signal SessionId for teardown");
     }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -554,7 +554,16 @@ async fn run_app(
                     }
                 }
 
-                if app.should_quit {
+        // Teardown backends for tabs closed via Ctrl+W / close_tab.
+        // App only signals the SessionId; runner executes the async close.
+        for sid in app.take_closed_ids() {
+            if let Some((term, handle)) = interactive_backends.remove(&sid) {
+                let _ = term.close().await;
+                handle.abort();
+            }
+        }
+
+        if app.should_quit {
                     break;
                 }
             }


### PR DESCRIPTION
Closes #116

### Summary

При закрытии вкладки (Ctrl+W) бэкенд интерактивного терминала (PTY/reader-задача) теперь корректно закрывается — сигнал передаётся из App в runner через `closed_ids`.

### What changed

- `App::closed_ids: Vec<SessionId>` — список закрытых сессий
- `close_tab()` — кладёт `SessionId` в `closed_ids` перед удалением
- `take_closed_ids()` — drain для runner'а
- `runner.rs` — после каждой итерации event-loop дренирует `closed_ids`, закрывает бэкенды (`close().await` + `handle.abort()`)
- Финальная очистка (из #114) закрывает оставшиеся бэкенды
- Background EOF/Err (из #115) чистит модель неактивной сессии

### Tests
- `closing_tab_signals_backend_teardown` — проверяет `take_closed_ids()`
- `cargo test -p filar-tui` — **220 passed, 0 failed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive terminals now shut down correctly when tabs are closed or the application exits.
  * Background terminal errors or end-of-file events now retire only the affected tab’s terminal, without disrupting the active tab.
* **Tests**
  * Added coverage for terminal cleanup when closing tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->