### PR TITLE
fix(tui): resize all terminal models and backends, not just active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Per-tab interactive terminals are torn down on tab close and app exit, and
   background EOF/errors retire a tab's terminal without disturbing the active
   tab ([#116](https://github.com/devlawey/filar/issues/116)).
+- Window resize now propagates to every live per-tab terminal (model and backend),
+  not just the active one, so background terminals stay correctly sized
+  ([#117](https://github.com/devlawey/filar/issues/117)).
 
 ### Added
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2798,3 +2798,22 @@ closed session ignore, EOF outcome).
 **Публичные контракты:** `App::closed_ids`, `App::take_closed_ids()`.
 
 **Тесты:** `cargo test -p filar-tui` — 220 passed (219 + 1 новый).
+
+---
+
+## Issue #117: fix(tui) — ресайз окна применяется ко всем живым терминалам
+
+**Проблема:** ресайз окна применялся только к активной сессии (модель + бэкенд).
+Фоновые терминалы не ресайзились — после разворота на весь экран и обратно
+«съезжал» prompt.
+
+**Решение:**
+- `crates/tui/src/runner.rs`: `Event::Resize` больше не под гейтом `in_interactive`.
+  `resize_all_models()` — применяет `model.resize()` ко ВСЕМ сессиям, у которых
+  есть модель. Все бэкенды в `interactive_backends` получают `term.resize()`.
+- `resize_all_models()` — вынесена как `pub fn` для тестирования.
+
+**Тесты:** `resize_applies_to_all_session_models` — 2 сессии с моделями, ресайз
+применяется к обеим.
+
+**Тесты:** `cargo test -p filar-tui` — 221 passed (220 + 1 новый).

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -325,16 +325,13 @@ async fn run_app(
                         needs_redraw = true;
                     }
                     Some(Ok(Event::Resize(cols, rows))) => {
-                        if in_interactive {
-                            let resize_sid = app.sessions[app.active].id;
-                            let term_cols = cols;
-                            let term_rows = ui::interactive_grid_rows(rows);
-                            if let Some(model) = &mut app.terminal {
-                                model.resize(term_cols, term_rows);
-                            }
-                            if let Some((ref term, _)) = interactive_backends.get(&resize_sid) {
-                                let _ = term.resize(term_cols, term_rows).await;
-                            }
+                        let term_cols = cols;
+                        let term_rows = ui::interactive_grid_rows(rows);
+                        // Resize all session models — even background tabs.
+                        resize_all_models(&mut app, term_cols, term_rows);
+                        // Resize all live backends.
+                        for (_, (ref term, _)) in interactive_backends.iter() {
+                            let _ = term.resize(term_cols, term_rows).await;
                         }
                         needs_redraw = true;
                     }
@@ -786,6 +783,15 @@ async fn recv_term_chunk(
     chunk
 }
 
+/// Resize every session's terminal model — both active and background tabs.
+pub fn resize_all_models(app: &mut App, cols: u16, rows: u16) {
+    for session in app.sessions.iter_mut() {
+        if let Some(ref mut model) = session.terminal {
+            model.resize(cols, rows);
+        }
+    }
+}
+
 /// Spawn the agent in a tokio task to process the user's input.
 #[allow(clippy::too_many_arguments)]
 fn spawn_agent(
@@ -942,5 +948,21 @@ mod tests {
 
         let outcome = route_term_chunk(&mut app, sid, TermChunk::Eof);
         assert!(matches!(outcome, RouteOutcome::Eof));
+    }
+
+    #[test]
+    fn resize_applies_to_all_session_models() {
+        use filar_core::CommandConfirmMode;
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        app.new_tab();
+        for s in app.sessions.iter_mut() {
+            s.terminal = Some(crate::terminal::TerminalModel::new(80, 24));
+        }
+        resize_all_models(&mut app, 100, 30);
+        for s in &app.sessions {
+            let t = s.terminal.as_ref().unwrap();
+            assert_eq!(t.rows(), 30);
+            assert_eq!(t.cols(), 100);
+        }
     }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -330,8 +330,10 @@ async fn run_app(
                         // Resize all session models — even background tabs.
                         resize_all_models(&mut app, term_cols, term_rows);
                         // Resize all live backends.
-                        for (_, (ref term, _)) in interactive_backends.iter() {
-                            let _ = term.resize(term_cols, term_rows).await;
+                        for (sid, (ref term, _)) in interactive_backends.iter() {
+                            if let Err(e) = term.resize(term_cols, term_rows).await {
+                                warn!(error = %e, sid = ?sid, "terminal resize failed");
+                            }
                         }
                         needs_redraw = true;
                     }
@@ -960,7 +962,7 @@ mod tests {
         }
         resize_all_models(&mut app, 100, 30);
         for s in &app.sessions {
-            let t = s.terminal.as_ref().unwrap();
+            let t = s.terminal.as_ref().expect("terminal model must be set");
             assert_eq!(t.rows(), 30);
             assert_eq!(t.cols(), 100);
         }


### PR DESCRIPTION
Closes #117

### Summary

Ресайз окна применялся только к активной сессии — фоновые терминалы не ресайзились, после изменения размера окна «съезжал» prompt.

### Fix

- `Event::Resize` больше не под гейтом `in_interactive`
- `resize_all_models()` — перебирает ВСЕ сессии, ресайзит модели
- Все бэкенды в `interactive_backends` получают `term.resize()`

### Tests
- `resize_applies_to_all_session_models` — 2 сессии, ресайз применяется к обеим
- `cargo test -p filar-tui` — **221 passed, 0 failed**