### PR TITLE
fix(tui): per-session executor, Ctrl+N always local, !ssh scoped to t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- Command executors are now per session: a new tab always starts local, and `!ssh`
+  reconnects only its own tab instead of swapping the connection for every tab; the
+  interactive terminal now opens on the tab's current host
+  ([#140](https://github.com/devlawey/filar/issues/140)).
+
 ## [0.6.0] - 2026-07-23
 
 ### Changed

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2849,6 +2849,72 @@ closed session ignore, EOF outcome).
 
 ---
 
+## Issue #140: fix(tui) — per-session executor, Ctrl+N always local, !ssh scoped to tab
+
+**Milestone:** Filar v0.6.1. **Ветка:** `fix/140-per-session-executor`.
+
+**Проблема:** executor был один на всё приложение — все вкладки делили одно
+SSH-соединение. `!ssh` переподключал ВСЕ вкладки, `Ctrl+N` создавал вкладку на
+том же транспорте, а подпись `local-N` всегда врала.
+
+**Решение:**
+
+1. **Per-session executors** (`runner.rs`):
+   - `HashMap<SessionId, ExecutorEntry>` вместо единственного `Arc<TuiExecutor>`.
+   - `ExecutorEntry { executor, ssh_target }` — хранение цели для `Ctrl+T`.
+   - `ssh_target: Arc<RwLock<Option<SshTarget>>>` — разделяемый между event loop
+     и `!ssh`-таском для записи цели подключения.
+   - Стартовый executor (из `main.rs`) кладётся для первой сессии; новые вкладки
+     получают `LocalExecutor` через сигнал `pending_local_executors`.
+
+2. **`App::new_tab()`** (`app.rs`):
+   - Сигналит runner о необходимости `LocalExecutor` через `pending_local_executors`.
+   - Новая вкладка всегда локальная (`ssh_info: None`), не наследует SSH-состояние
+     другой сессии.
+
+3. **`Ctrl+N` создаёт `LocalExecutor`** (`runner.rs`):
+   - `take_pending_local_executors()` — runner асинхронно создаёт `LocalExecutor`,
+     оборачивает в `TuiExecutor` и кладёт в `executors`.
+   - До готовности executor'а ввод показывает ошибку "not ready yet" без паники.
+
+4. **`!ssh` действует только на свою вкладку** (`runner.rs`):
+   - `swap_executor` вызывается на executor'е конкретного `SessionId`.
+   - `ssh_target` сохраняется в `ExecutorEntry` для последующего `Ctrl+T`.
+   - `TransportChanged` несёт `session_id` — runner обновляет `Session::ssh_info`.
+
+5. **`Ctrl+T` — по цели вкладки** (`runner.rs`):
+   - Читает `ExecutorEntry::ssh_target` вместо `config.ssh_target`.
+   - Стартовый конфиг — только для первой вкладки.
+
+6. **Закрытие вкладки освобождает executor** (`runner.rs`):
+   - `executors.remove(&sid)` в обработчике `take_closed_ids()`.
+
+7. **`TransportChanged` — посессионно** (`event.rs`, `runner.rs`):
+   - Поле `session_id: SessionId` добавлено в `TuiEvent::TransportChanged`.
+   - Runner обновляет `Session::ssh_info` конкретной сессии вместо глобальных
+     переменных `is_local`/`ssh_info`.
+
+**Изменённые файлы:**
+- `crates/tui/src/app.rs` — `Session::ssh_info`, `App::pending_local_executors`,
+  `take_pending_local_executors()`, `new_tab()` сигналит runner
+- `crates/tui/src/event.rs` — `TransportChanged { session_id, ... }`
+- `crates/tui/src/runner.rs` — `ExecutorEntry`, `executors: HashMap<SessionId, ExecutorEntry>`,
+  `pending_local_executors` обработчик, per-session shell escape / spawn_agent / !ssh / Ctrl+T /
+  close_tab, TransportChanged interceptor
+
+**Тесты:** 5 новых (227 total): `new_tab_signals_pending_local_executor`,
+`new_tab_session_defaults_to_local_ssh_info`, `new_tab_does_not_inherit_ssh_state`,
+`take_pending_local_executors_clears_list`, `transport_changed_carries_session_id`.
+`cargo test --workspace` — 227 tui + 62 agent + 34 core + 24 transport = все зелёные.
+
+**Публичные контракты:**
+- `TuiEvent::TransportChanged` — новое поле `session_id: SessionId`.
+- `App` — новое поле `pending_local_executors: Vec<SessionId>`, метод `take_pending_local_executors()`.
+- `Session` — новое поле `ssh_info: Option<String>`.
+- `ExecutorEntry` — новый приватный тип в `runner.rs`.
+
+---
+
 ## Релиз v0.6.0 (подготовка)
 
 **Дата:** 2026-07-23. **Milestone:** Filar v0.6.0 (6/6 issues, все смерджены).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -187,6 +187,10 @@ pub struct App {
     /// SessionIds of recently closed tabs — consumed by runner to teardown
     /// corresponding interactive backends.
     pub closed_ids: Vec<SessionId>,
+    /// SessionIds of new tabs awaiting a local executor from the runner.
+    /// App signals the runner here; runner creates the executor asynchronously
+    /// and stores it in its per-session map.
+    pub pending_local_executors: Vec<SessionId>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -295,6 +299,9 @@ pub struct Session {
     pub has_new: bool,
     /// True when a confirmation is pending (agent is waiting for user input).
     pub awaiting_confirmation: bool,
+    /// SSH connection info for this tab (e.g. "user@host:port"). None = local.
+    /// Set when `!ssh` succeeds for this tab. Used for display and system prompt.
+    pub ssh_info: Option<String>,
 }
 
 impl App {
@@ -322,13 +329,17 @@ impl App {
             status_bar_area: Rect::default(),
             help_bar_area: Rect::default(),
             closed_ids: Vec::new(),
+            pending_local_executors: Vec::new(),
         }
     }
 
     /// Create a new session tab in local mode, inheriting target_name display.
+    /// Signals the runner to create a new LocalExecutor for this tab via
+    /// [`pending_local_executors`](Self::pending_local_executors).
     pub fn new_tab(&mut self) {
         let name = format!("local-{}", self.sessions.len() + 1);
         let session = Session::new(name, self.confirm_mode);
+        self.pending_local_executors.push(session.id);
         self.sessions.push(session);
         self.active = self.sessions.len() - 1;
     }
@@ -357,6 +368,11 @@ impl App {
     /// Take and clear the list of closed session IDs (for runner to process).
     pub fn take_closed_ids(&mut self) -> Vec<SessionId> {
         std::mem::take(&mut self.closed_ids)
+    }
+
+    /// Take and clear the list of sessions awaiting a local executor (for runner to process).
+    pub fn take_pending_local_executors(&mut self) -> Vec<SessionId> {
+        std::mem::take(&mut self.pending_local_executors)
     }
 
     /// Switch to the previous tab (wraps around).
@@ -458,6 +474,7 @@ impl Session {
             background_activity: false,
             has_new: false,
             awaiting_confirmation: false,
+            ssh_info: None,
         }
     }
 }
@@ -4776,5 +4793,65 @@ mod tests {
         assert_eq!(app.active, 0, "should switch to tab 0");
         assert!(!app.sessions[0].has_new, "marker must clear on target tab");
         assert!(app.sessions[1].has_new, "marker on old active tab must survive");
+    }
+
+    // ── Per-session executor tests ─────────────────────────────────────
+
+    #[test]
+    fn new_tab_signals_pending_local_executor() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let initial_sid = app.sessions[0].id;
+        // The initial tab is NOT in pending_local_executors.
+        assert!(
+            !app.pending_local_executors.contains(&initial_sid),
+            "initial tab must not request a local executor (it already has one)"
+        );
+        app.new_tab();
+        let new_sid = app.sessions[1].id;
+        assert!(
+            app.pending_local_executors.contains(&new_sid),
+            "new_tab must signal runner to create a LocalExecutor"
+        );
+        let pending = app.take_pending_local_executors();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], new_sid);
+        assert!(app.pending_local_executors.is_empty());
+    }
+
+    #[test]
+    fn new_tab_session_defaults_to_local_ssh_info() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.new_tab();
+        assert!(
+            app.sessions[0].ssh_info.is_none(),
+            "initial session ssh_info should be None (local)"
+        );
+        assert!(
+            app.sessions[1].ssh_info.is_none(),
+            "new tab ssh_info must be None (always starts local)"
+        );
+    }
+
+    #[test]
+    fn new_tab_does_not_inherit_ssh_state() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        // Simulate session 0 getting SSH info.
+        app.sessions[0].ssh_info = Some("root@10.0.0.5:22".into());
+        app.new_tab();
+        assert!(
+            app.sessions[1].ssh_info.is_none(),
+            "new tab must not inherit SSH info from another tab"
+        );
+    }
+
+    #[test]
+    fn take_pending_local_executors_clears_list() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.new_tab();
+        app.new_tab();
+        assert_eq!(app.pending_local_executors.len(), 2);
+        let taken = app.take_pending_local_executors();
+        assert_eq!(taken.len(), 2);
+        assert!(app.pending_local_executors.is_empty());
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -710,6 +710,11 @@ impl App {
                                         host.clone(),
                                         port,
                                     ));
+                                    // Update session ssh_info immediately so
+                                    // spawn_agent sees the correct is_local/ssh_info
+                                    // even before TransportChanged arrives.
+                                    self.ssh_info =
+                                        Some(format!("{user}@{host}:{port}"));
                                     self.push_message(ChatBlock::System(format!(
                                         "Connecting to {user}@{host}:{port} via SSH. \
                                          Press Ctrl+P to enter the password."

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -39,9 +39,32 @@ pub enum TuiEvent {
     },
 
     /// The transport was switched (e.g. from local to SSH).
-    /// The runner uses this to update the system prompt for future agent calls.
+    /// The runner uses this to update per-session connection info.
     TransportChanged {
+        session_id: SessionId,
         is_local: bool,
         ssh_info: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_changed_carries_session_id() {
+        let sid = SessionId(42);
+        let event = TuiEvent::TransportChanged {
+            session_id: sid,
+            is_local: false,
+            ssh_info: Some("root@10.0.0.5:22".into()),
+        };
+        if let TuiEvent::TransportChanged { session_id, is_local, ref ssh_info } = event {
+            assert_eq!(session_id, SessionId(42));
+            assert!(!is_local);
+            assert_eq!(ssh_info.as_deref(), Some("root@10.0.0.5:22"));
+        } else {
+            panic!("expected TransportChanged");
+        }
+    }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -397,8 +397,12 @@ async fn run_app(
                         let cols = size.width;
                         let rows = ui::interactive_grid_rows(size.height);
                         // Use the tab's own SSH target, not the global config.
-                        let ssh_target = executors.get(&toggle_sid)
-                            .and_then(|e| e.ssh_target.blocking_read().clone());
+                        let ssh_guard = executors.get(&toggle_sid)
+                            .map(|e| e.ssh_target.clone());
+                        let ssh_target = match ssh_guard {
+                            Some(g) => g.read().await.clone(),
+                            None => None,
+                        };
                         let term_result: Result<Arc<dyn InteractiveTerminal>> =
                             if let Some(ref target) = ssh_target {
                                 SshInteractive::connect(target, cols, rows)
@@ -581,7 +585,7 @@ async fn run_app(
                                             .await;
                                         // Store the SshTarget so Ctrl+T can open a PTY
                                         // on the same host for this tab.
-                                        *st.blocking_write() = Some(target.clone());
+                                        *st.write().await = Some(target.clone());
                                     }
                                     // Notify runner to update per-session info.
                                     let _ = tx.send(TuiEvent::TransportChanged {
@@ -640,6 +644,10 @@ async fn run_app(
                     if let Some(s) = app.sessions.iter_mut().find(|s| s.id == sid) {
                         s.ssh_info = None;
                     }
+                    app.push_error(format!(
+                        "Failed to create local executor for new tab: {e}"
+                    ));
+                    app.pending_local_executors.push(sid);
                 }
             }
         }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -123,6 +123,22 @@ impl CommandExecutor for TuiExecutor {
 }
 
 // ---------------------------------------------------------------------------
+// Per-session executor storage
+// ---------------------------------------------------------------------------
+
+/// Entry in the per-session executor map.
+///
+/// Each session tab has its own executor so that `!ssh` only reconnects
+/// the tab that issued it, and `Ctrl+T` opens a PTY on the tab's host.
+struct ExecutorEntry {
+    executor: Arc<TuiExecutor>,
+    /// SSH target stored so Ctrl+T can open an interactive terminal on the
+    /// same host. `None` for local sessions. Shared via `Arc<RwLock>` so the
+    /// `!ssh` spawned task can write it alongside swapping the executor.
+    ssh_target: Arc<tokio::sync::RwLock<Option<filar_core::SshTarget>>>,
+}
+
+// ---------------------------------------------------------------------------
 // Panic hook guard
 // ---------------------------------------------------------------------------
 
@@ -261,17 +277,31 @@ async fn run_app(
     // Receiver for WARN/ERROR log lines mirrored into the chat.
     let mut log_rx = config.log_rx.take();
 
-    // Build SSH info string for the system prompt (e.g. "user@host:port").
-    let mut ssh_info = config.ssh_target.as_ref().map(|t| {
-        format!("{}@{}:{}", t.user, t.host, t.port)
-    });
-    let mut is_local = config.is_local;
-
-    // Create the TUI confirmer and executor wrappers.
+    // Create the TUI confirmer.
     let confirmer = Arc::new(TuiConfirmer::new(agent_tx.clone()));
-    let tui_executor = Arc::new(TuiExecutor {
+
+    // Per-session executors. The initial executor (from main.rs) is stored
+    // for the start-up session; new tabs get a LocalExecutor created on demand.
+    let initial_tui = Arc::new(TuiExecutor {
         inner: Arc::new(tokio::sync::RwLock::new(executor)),
     });
+    let initial_sid = app.sessions[0].id;
+    let mut executors: std::collections::HashMap<
+        crate::app::SessionId,
+        ExecutorEntry,
+    > = std::collections::HashMap::new();
+    executors.insert(
+        initial_sid,
+        ExecutorEntry {
+            executor: initial_tui,
+            ssh_target: Arc::new(tokio::sync::RwLock::new(config.ssh_target.clone())),
+        },
+    );
+    // Set initial ssh_info on the first session.
+    if let Some(ref target) = config.ssh_target {
+        app.sessions[0].ssh_info =
+            Some(format!("{}@{}:{}", target.user, target.host, target.port));
+    }
 
     // Crossterm event stream for async keyboard input.
     let mut events = EventStream::new();
@@ -366,8 +396,11 @@ async fn run_app(
                         let size = terminal.size().unwrap_or_default();
                         let cols = size.width;
                         let rows = ui::interactive_grid_rows(size.height);
+                        // Use the tab's own SSH target, not the global config.
+                        let ssh_target = executors.get(&toggle_sid)
+                            .and_then(|e| e.ssh_target.blocking_read().clone());
                         let term_result: Result<Arc<dyn InteractiveTerminal>> =
-                            if let Some(ref target) = config.ssh_target {
+                            if let Some(ref target) = ssh_target {
                                 SshInteractive::connect(target, cols, rows)
                                     .await
                                     .map(|t| Arc::new(t) as Arc<dyn InteractiveTerminal>)
@@ -427,13 +460,20 @@ async fn run_app(
                         // Shell escape: execute command directly without agent.
                         let cmd = stripped.trim().to_string();
                         if !cmd.is_empty() {
-                            let exec = tui_executor.clone();
+                            let sid = app.sessions[app.active].id;
+                            let exec = match executors.get(&sid) {
+                                Some(e) => e.executor.clone() as Arc<dyn CommandExecutor>,
+                                None => {
+                                    app.push_error("Tab executor not ready yet".into());
+                                    continue;
+                                }
+                            };
                             let provider = config.secret_provider.clone();
                             let sid = app.sessions[app.active].id;
                             let tx = agent_tx.clone();
                             tokio::spawn(async move {
                                 let wrapped = SecretSubstitutingExecutor::new(
-                                    exec as Arc<dyn CommandExecutor>,
+                                    exec,
                                     provider as Arc<dyn SecretProvider>,
                                 );
                                 let succeeded = match wrapped.run(&cmd).await {
@@ -481,22 +521,33 @@ async fn run_app(
                             app.agent_running = false;
                         }
                     } else {
+                        let sid = app.sessions[app.active].id;
+                        let (agent_exec, is_local, ssh_info) = match executors.get(&sid) {
+                            Some(e) => {
+                                let info = app.sessions[app.active].ssh_info.clone();
+                                (e.executor.clone() as Arc<dyn CommandExecutor>, info.is_none(), info)
+                            }
+                            None => {
+                                app.push_error("Tab executor not ready yet".into());
+                                continue;
+                            }
+                        };
                         // Create a cancellation token for this agent run.
                         let cancel_token = CancellationToken::new();
                         app.cancellation = Some(cancel_token.clone());
                         spawn_agent(
                             llm.clone(),
-                            tui_executor.clone(),
+                            agent_exec,
                             confirmer.clone(),
                             config.confirm_mode,
                             user_input,
                             app.messages.clone(),
                             agent_tx.clone(),
                             is_local,
-                            ssh_info.clone(),
+                            ssh_info,
                             cancel_token,
                             config.secret_provider.clone(),
-                            app.sessions[app.active].id,
+                            sid,
                         );
                     }
                 }
@@ -506,7 +557,8 @@ async fn run_app(
                     if let Some((user, host, port)) = app.pending_ssh.take() {
                         let sid = app.sessions[app.active].id;
                         let tx = agent_tx.clone();
-                        let exec_clone = tui_executor.clone();
+                        let exec_entry = executors.get(&sid)
+                            .map(|e| (e.executor.clone(), e.ssh_target.clone()));
                         tokio::spawn(async move {
                             let _ = tx.send(TuiEvent::Thinking);
                             let target = filar_core::SshTarget {
@@ -519,16 +571,21 @@ async fn run_app(
                                 },
                                 host_key_policy: filar_core::HostKeyPolicy::Tofu,
                             };
+                            let new_ssh_info = format!("{user}@{host}:{port}");
                             match filar_transport::SshExecutor::connect(&target).await {
                                 Ok(ssh_exec) => {
-                                    // Swap the executor to SSH.
-                                    exec_clone
-                                        .swap_executor(Arc::new(ssh_exec)
+                                    // Swap the executor for this session only.
+                                    if let Some((ref exec, ref st)) = exec_entry {
+                                        exec.swap_executor(Arc::new(ssh_exec)
                                             as Arc<dyn CommandExecutor>)
-                                        .await;
-                                    // Notify runner to update system prompt info.
-                                    let new_ssh_info = format!("{user}@{host}:{port}");
+                                            .await;
+                                        // Store the SshTarget so Ctrl+T can open a PTY
+                                        // on the same host for this tab.
+                                        *st.blocking_write() = Some(target.clone());
+                                    }
+                                    // Notify runner to update per-session info.
                                     let _ = tx.send(TuiEvent::TransportChanged {
+                                        session_id: sid,
                                         is_local: false,
                                         ssh_info: Some(new_ssh_info),
                                     });
@@ -560,6 +617,31 @@ async fn run_app(
                 let _ = term.close().await;
                 handle.abort();
             }
+            // Release the tab's executor so SSH connections don't leak.
+            executors.remove(&sid);
+        }
+
+        // Create local executors for new tabs signalled via new_tab().
+        for sid in app.take_pending_local_executors() {
+            match filar_transport::LocalExecutor::new().await {
+                Ok(local) => {
+                    executors.insert(
+                        sid,
+                        ExecutorEntry {
+                            executor: Arc::new(TuiExecutor {
+                                inner: Arc::new(tokio::sync::RwLock::new(Arc::new(local))),
+                            }),
+                            ssh_target: Arc::new(tokio::sync::RwLock::new(None)),
+                        },
+                    );
+                }
+                Err(e) => {
+                    warn!(error = %e, "failed to create local executor for sid={sid:?}");
+                    if let Some(s) = app.sessions.iter_mut().find(|s| s.id == sid) {
+                        s.ssh_info = None;
+                    }
+                }
+            }
         }
 
         if app.should_quit {
@@ -576,11 +658,16 @@ async fn run_app(
                 }
             } => {
                 if let Some(event) = maybe_agent_event {
-                    // Intercept TransportChanged to update system prompt info.
-                    if let TuiEvent::TransportChanged { is_local: new_local, ssh_info: new_ssh } = &event {
-                        is_local = *new_local;
-                        ssh_info = new_ssh.clone();
-                        app.target_name = new_ssh.clone().unwrap_or_else(|| "local".into());
+                    // Intercept TransportChanged to update per-session info.
+                    if let TuiEvent::TransportChanged { session_id, ref ssh_info, .. } = &event {
+                        if let Some(idx) = app.find_session_idx(*session_id) {
+                            app.sessions[idx].ssh_info = ssh_info.clone();
+                            // Also update display name for the tab label.
+                            app.sessions[idx].target_name =
+                                ssh_info.clone().unwrap_or_else(|| {
+                                    format!("local-{}", idx + 1)
+                                });
+                        }
                     }
                     // All agent events just need a redraw — the borderless
                     // layout handles transitions cleanly without full clear.


### PR DESCRIPTION
…ab (#140)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New tabs now always start with local command execution.
  * SSH connections and commands are scoped to the active tab instead of affecting all tabs.
  * Interactive terminals now open on the selected tab’s host.
  * Closing a tab correctly releases its associated session resources.
* **Tests**
  * Added coverage for per-tab execution, SSH state, new-tab behavior, and transport updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->