### PR TITLE
fix(tui): tab label shows real connection target from ssh_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   reconnects only its own tab instead of swapping the connection for every tab; the
   interactive terminal now opens on the tab's current host
   ([#140](https://github.com/devlawey/filar/issues/140)).
+- Session tab labels now show the tab's actual target (`user@host`) instead of always
+  reading `local-N`
+  ([#141](https://github.com/devlawey/filar/issues/141)).
 
 ## [0.6.0] - 2026-07-23
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2915,6 +2915,30 @@ SSH-соединение. `!ssh` переподключал ВСЕ вкладк�
 
 ---
 
+## Issue #141: fix(tui) — tab label shows real connection target
+
+**Milestone:** Filar v0.6.1. **Ветка:** `fix/141-tab-label-target`.
+
+**Проблема:** подпись вкладки всегда `local-N`, даже после `!ssh user@host`.
+
+**Решение:**
+- `Session::tab_label(index)` — форматирует ярлык из `ssh_info`:
+  `None` → `local-N`, `Some("user@host:22")` → `user@host`, нестандартный порт сохраняется.
+- `render_tab_bar` использует `s.tab_label(i)` вместо `s.target_name`.
+- Статус-бар уже показывает актуальную цель через `app.target_name` (Deref из #140).
+- Маркеры активности (`?`, `●`, `○`) не затронуты.
+
+**Файлы:** `crates/tui/src/app.rs` (метод `tab_label`), `crates/tui/src/ui/mod.rs` (render_tab_bar).
+
+**Тесты:** 4 новых (231 total):
+`tab_label_local_shows_local_n`, `tab_label_ssh_strips_default_port`,
+`tab_label_ssh_keeps_nonstandard_port`, `tab_label_ssh_no_port_shows_as_is`.
+
+**Публичные контракты:**
+- `Session::tab_label(index: usize) -> String` — новый public метод.
+
+---
+
 ## Релиз v0.6.0 (подготовка)
 
 **Дата:** 2026-07-23. **Milestone:** Filar v0.6.0 (6/6 issues, все смерджены).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -480,7 +480,7 @@ impl Session {
 
     /// Format the tab label: `local-N` for local sessions, `user@host` for
     /// remote (port omitted when it is 22).
-    pub fn tab_label(&self, index: usize) -> String {
+    pub fn tab_label(&self, _index: usize) -> String {
         match &self.ssh_info {
             Some(info) => {
                 if let Some(host) = info.strip_suffix(":22") {
@@ -489,7 +489,7 @@ impl Session {
                     info.clone()
                 }
             }
-            None => format!("local-{}", index + 1),
+            None => self.target_name.clone(),
         }
     }
 }
@@ -4878,12 +4878,12 @@ mod tests {
     // ── Tab label tests ────────────────────────────────────────────────
 
     #[test]
-    fn tab_label_local_shows_local_n() {
-        let mut app = App::new("test".into(), CommandConfirmMode::Always);
-        // Session 0: index 0 → local-1
-        assert_eq!(app.sessions[0].tab_label(0), "local-1");
+    fn tab_label_local_shows_target_name() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        // Session 0: target_name is the initial config name.
+        assert_eq!(app.sessions[0].tab_label(0), "local");
         app.new_tab();
-        // Session 1: index 1 → local-2
+        // Session 1: target_name = "local-2" (set by new_tab).
         assert_eq!(app.sessions[1].tab_label(1), "local-2");
     }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -477,6 +477,21 @@ impl Session {
             ssh_info: None,
         }
     }
+
+    /// Format the tab label: `local-N` for local sessions, `user@host` for
+    /// remote (port omitted when it is 22).
+    pub fn tab_label(&self, index: usize) -> String {
+        match &self.ssh_info {
+            Some(info) => {
+                if let Some(host) = info.strip_suffix(":22") {
+                    host.to_string()
+                } else {
+                    info.clone()
+                }
+            }
+            None => format!("local-{}", index + 1),
+        }
+    }
 }
 
 impl App {
@@ -4858,5 +4873,38 @@ mod tests {
         let taken = app.take_pending_local_executors();
         assert_eq!(taken.len(), 2);
         assert!(app.pending_local_executors.is_empty());
+    }
+
+    // ── Tab label tests ────────────────────────────────────────────────
+
+    #[test]
+    fn tab_label_local_shows_local_n() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        // Session 0: index 0 → local-1
+        assert_eq!(app.sessions[0].tab_label(0), "local-1");
+        app.new_tab();
+        // Session 1: index 1 → local-2
+        assert_eq!(app.sessions[1].tab_label(1), "local-2");
+    }
+
+    #[test]
+    fn tab_label_ssh_strips_default_port() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.sessions[0].ssh_info = Some("root@10.0.0.5:22".into());
+        assert_eq!(app.sessions[0].tab_label(0), "root@10.0.0.5");
+    }
+
+    #[test]
+    fn tab_label_ssh_keeps_nonstandard_port() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.sessions[0].ssh_info = Some("root@10.0.0.5:2222".into());
+        assert_eq!(app.sessions[0].tab_label(0), "root@10.0.0.5:2222");
+    }
+
+    #[test]
+    fn tab_label_ssh_no_port_shows_as_is() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.sessions[0].ssh_info = Some("admin@devbox".into());
+        assert_eq!(app.sessions[0].tab_label(0), "admin@devbox");
     }
 }

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -194,7 +194,7 @@ fn render_tab_bar(f: &mut Frame, app: &App, area: Rect) {
         } else {
             ""
         };
-        let label = format!("{}{}. {}", marker, i + 1, s.target_name);
+        let label = format!("{}{}. {}", marker, i + 1, s.tab_label(i));
         let style = if i == active {
             Style::default().add_modifier(Modifier::REVERSED)
         } else {


### PR DESCRIPTION
Closes #141

Tab labels now reflect the actual connection target. `Session::tab_label()` formats from `ssh_info`: `local-N` for local, `user@host` for SSH (default port 22 stripped, non-standard ports kept).

Tests: 231 tui tests pass (4 new for tab label formatting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session tabs now show the real connection target (e.g., `user@host`) instead of a local-session label.
  * The default SSH port `:22` is omitted in tab labels, while nonstandard ports are still displayed.
* **Documentation**
  * Updated release notes and progress tracking to reflect the corrected tab-label behavior.
* **Tests**
  * Added coverage for local vs. SSH tab-label formatting, including port handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->