### PR TITLE
feat(tui): F1 help overlay with full command registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Added
+
+- Help overlay listing every shortcut and command, opened with `F1` (Ctrl+H tested
+  and found indistinguishable from Backspace on Windows Terminal)
+  ([#142](https://github.com/devlawey/filar/issues/142)).
+
 ### Fixed
 
 - Command executors are now per session: a new tab always starts local, and `!ssh`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2939,6 +2939,42 @@ SSH-соединение. `!ssh` переподключал ВСЕ вкладк�
 
 ---
 
+## Issue #142: feat(tui) — F1 help overlay
+
+**Milestone:** Filar v0.6.1. **Ветка:** `feat/142-help-overlay`.
+
+**Проблема:** пользователь не видит полный список возможностей — только узкая
+help-строка для текущего режима.
+
+**Решение:**
+- **Реестр команд** (`ui/help.rs`): `help_registry()` — 24 записи в 7 разделах
+  (Help, Modes, Tabs, Agent, Scrolling, Copy, Input, Exit). Каждая с функцией
+  `available(mode) -> bool`. Единый источник для нижней help-строки и оверлея.
+- **Оверлей** — модальное окно поверх всего UI. Секции с заголовками (accent+bold),
+  доступные пункты обычным стилем, недоступные — muted.
+- **Открытие:** `F1` (во всех режимах, включая Interactive).
+- **Закрытие:** `Esc`, повторный `F1`.
+- **Блокировка ввода:** пока оверлей открыт, клавиши и мышь в приложение не проходят.
+- **Ctrl+H:** проверен эмпирически в Windows Terminal — неотличим от Backspace,
+  приходит как `KeyCode::Backspace`. Поэтому основная привязка — только `F1`.
+
+**Файлы:**
+- `crates/tui/src/ui/help.rs` — новый модуль (реестр + рендер)
+- `crates/tui/src/ui/mod.rs` — `mod help`, вызов render_help_overlay
+- `crates/tui/src/app.rs` — `help_overlay_visible`, `toggle_help_overlay()`,
+  перехват F1 и блокировка ввода в handle_key/handle_mouse
+
+**Тесты:** 10 новых (241 total):
+реестр непустой, ключевые секции, доступность по режимам (Normal/Interactive),
+открытие/закрытие F1/Esc, блокировка клавиш/мыши.
+
+**Публичные контракты:**
+- `App` — новое поле `help_overlay_visible: bool`.
+- `App::toggle_help_overlay()` — новый public метод.
+- `ui::help::help_registry()` — pub(crate), доступен для тестов.
+
+---
+
 ## Релиз v0.6.0 (подготовка)
 
 **Дата:** 2026-07-23. **Milestone:** Filar v0.6.0 (6/6 issues, все смерджены).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -642,8 +642,9 @@ impl App {
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::{KeyCode, KeyModifiers};
 
-        // F1 toggles the help overlay in ANY mode (including Interactive).
-        if key.code == KeyCode::F(1) {
+        // F1 toggles the help overlay — except in PasswordInput where
+        // the overlay would steal Esc from the password-cancel flow.
+        if key.code == KeyCode::F(1) && self.mode != AppMode::PasswordInput {
             self.toggle_help_overlay();
             return;
         }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -191,6 +191,8 @@ pub struct App {
     /// App signals the runner here; runner creates the executor asynchronously
     /// and stores it in its per-session map.
     pub pending_local_executors: Vec<SessionId>,
+    /// Whether the help overlay is currently visible.
+    pub help_overlay_visible: bool,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -330,6 +332,7 @@ impl App {
             help_bar_area: Rect::default(),
             closed_ids: Vec::new(),
             pending_local_executors: Vec::new(),
+            help_overlay_visible: false,
         }
     }
 
@@ -631,8 +634,28 @@ impl App {
         }
     }
 
+    /// Toggle the help overlay on/off.
+    pub fn toggle_help_overlay(&mut self) {
+        self.help_overlay_visible = !self.help_overlay_visible;
+    }
+
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::{KeyCode, KeyModifiers};
+
+        // F1 toggles the help overlay in ANY mode (including Interactive).
+        if key.code == KeyCode::F(1) {
+            self.toggle_help_overlay();
+            return;
+        }
+
+        // When the help overlay is visible, only Esc and F1 are processed;
+        // all other keys are consumed so they don't affect the UI behind it.
+        if self.help_overlay_visible {
+            if key.code == KeyCode::Esc {
+                self.help_overlay_visible = false;
+            }
+            return;
+        }
 
         // Helper: check if key is Ctrl+<english_char>, considering Russian layout.
         // On Russian ЙЦУКЕН layout, physical keys produce different characters.
@@ -1081,6 +1104,11 @@ impl App {
     /// all modes except `Interactive` and `PasswordInput`.
     pub fn handle_mouse(&mut self, m: crossterm::event::MouseEvent) {
         use crossterm::event::{MouseButton, MouseEventKind};
+
+        // When the help overlay is visible, consume all mouse events.
+        if self.help_overlay_visible {
+            return;
+        }
 
         // Help-bar clicks work in ALL modes (including Interactive/Password).
         if m.kind == MouseEventKind::Down(MouseButton::Left) {
@@ -4906,5 +4934,85 @@ mod tests {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.sessions[0].ssh_info = Some("admin@devbox".into());
         assert_eq!(app.sessions[0].tab_label(0), "admin@devbox");
+    }
+
+    // ── Help overlay tests ────────────────────────────────────────────
+
+    #[test]
+    fn help_overlay_defaults_to_hidden() {
+        let app = App::new("test".into(), CommandConfirmMode::Always);
+        assert!(!app.help_overlay_visible);
+    }
+
+    #[test]
+    fn toggle_help_overlay_flips_visibility() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.toggle_help_overlay();
+        assert!(app.help_overlay_visible);
+        app.toggle_help_overlay();
+        assert!(!app.help_overlay_visible);
+    }
+
+    #[test]
+    fn f1_toggles_help_overlay() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let f1 = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(1),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(f1);
+        assert!(app.help_overlay_visible, "F1 must open help overlay");
+        app.handle_key(f1);
+        assert!(!app.help_overlay_visible, "F1 must close help overlay");
+    }
+
+    #[test]
+    fn esc_closes_help_overlay() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let f1 = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(1),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(f1);
+        assert!(app.help_overlay_visible);
+        let esc = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Esc,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(esc);
+        assert!(!app.help_overlay_visible, "Esc must close help overlay");
+    }
+
+    #[test]
+    fn help_overlay_blocks_other_keys() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let f1 = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(1),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(f1);
+        assert!(app.help_overlay_visible);
+        // Type a character — should NOT reach the input field.
+        let a = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('a'),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(a);
+        assert!(app.input.is_empty(), "input must stay empty when overlay is open");
+    }
+
+    #[test]
+    fn help_overlay_blocks_mouse() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.help_overlay_visible = true;
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+        let m = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
+        app.handle_mouse(m);
+        // No assertion needed other than no panic — mouse event is consumed.
     }
 }

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -250,7 +250,7 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
             app.theme.muted()
         };
         let desc_style = if available {
-            Style::default()
+            app.theme.fg_style()
         } else {
             app.theme.muted()
         };

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -1,0 +1,340 @@
+//! Help overlay — modal window listing every shortcut and command.
+//!
+//! Both the bottom help bar (`bars.rs`) and this overlay are built from a
+//! single command registry so the two never diverge.
+//!
+//! Entries unavailable in the current mode are shown dimmed rather than hidden
+//! so the user can see the full set.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use ratatui::Frame;
+
+use crate::app::{App, AppMode};
+
+// ---------------------------------------------------------------------------
+// Command registry
+// ---------------------------------------------------------------------------
+
+/// One entry in the help registry.
+#[derive(Debug, Clone)]
+pub(crate) struct HelpEntry {
+    /// Shortcut / key text (e.g. `"F1"`, `"^T"`, `"!cmd"`).
+    pub key: &'static str,
+    /// Human-readable description.
+    pub desc: &'static str,
+    /// Group name for the overlay sections.
+    pub section: &'static str,
+    /// Whether this entry is active/available in the given mode.
+    pub available: fn(AppMode) -> bool,
+}
+
+/// Return the full command registry — all entries, all modes.
+///
+/// The bottom help bar filters this by mode; the overlay shows everything,
+/// dimming unavailable entries.
+pub(crate) fn help_registry() -> Vec<HelpEntry> {
+    vec![
+        // ── Help ──────────────────────────────────────────────────────
+        HelpEntry {
+            key: "F1",
+            desc: "Toggle this help overlay",
+            section: "Help",
+            available: |_| true,
+        },
+        // ── Modes ─────────────────────────────────────────────────────
+        HelpEntry {
+            key: "^T",
+            desc: "Toggle interactive terminal",
+            section: "Modes",
+            available: |m| m != AppMode::PasswordInput,
+        },
+        HelpEntry {
+            key: "^P",
+            desc: "Enter password input mode",
+            section: "Modes",
+            available: |m| m == AppMode::Normal,
+        },
+        // ── Tabs ──────────────────────────────────────────────────────
+        HelpEntry {
+            key: "^N",
+            desc: "New local tab",
+            section: "Tabs",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "^W",
+            desc: "Close active tab",
+            section: "Tabs",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "^Tab",
+            desc: "Next tab",
+            section: "Tabs",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "^Shift+Tab",
+            desc: "Previous tab",
+            section: "Tabs",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "^PgUp",
+            desc: "Previous tab",
+            section: "Tabs",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "^PgDn",
+            desc: "Next tab",
+            section: "Tabs",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "^1..^9",
+            desc: "Switch to tab by number",
+            section: "Tabs",
+            available: |m| m != AppMode::Interactive,
+        },
+        // ── Agent ─────────────────────────────────────────────────────
+        HelpEntry {
+            key: "Enter",
+            desc: "Send message to agent",
+            section: "Agent",
+            available: |m| m == AppMode::Normal,
+        },
+        HelpEntry {
+            key: "^Z",
+            desc: "Cancel agent / deny command",
+            section: "Agent",
+            available: |m| matches!(m, AppMode::Thinking | AppMode::Confirming),
+        },
+        HelpEntry {
+            key: "Tab",
+            desc: "Switch approve/deny",
+            section: "Agent",
+            available: |m| m == AppMode::Confirming,
+        },
+        HelpEntry {
+            key: "a / y",
+            desc: "Approve command",
+            section: "Agent",
+            available: |m| m == AppMode::Confirming,
+        },
+        HelpEntry {
+            key: "d / n",
+            desc: "Deny command",
+            section: "Agent",
+            available: |m| m == AppMode::Confirming,
+        },
+        // ── Scrolling ─────────────────────────────────────────────────
+        HelpEntry {
+            key: "PgUp",
+            desc: "Scroll up",
+            section: "Scrolling",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "PgDn",
+            desc: "Scroll down",
+            section: "Scrolling",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "End",
+            desc: "Scroll to bottom",
+            section: "Scrolling",
+            available: |m| m != AppMode::Interactive,
+        },
+        HelpEntry {
+            key: "wheel",
+            desc: "Scroll",
+            section: "Scrolling",
+            available: |_| true,
+        },
+        // ── Copy ──────────────────────────────────────────────────────
+        HelpEntry {
+            key: "drag",
+            desc: "Select text (copies on release)",
+            section: "Copy",
+            available: |m| m != AppMode::Interactive,
+        },
+        // ── Input ─────────────────────────────────────────────────────
+        HelpEntry {
+            key: "!cmd",
+            desc: "Run shell command directly",
+            section: "Input",
+            available: |m| m == AppMode::Normal,
+        },
+        HelpEntry {
+            key: "!ssh user@host",
+            desc: "Connect tab to SSH host",
+            section: "Input",
+            available: |m| m == AppMode::Normal,
+        },
+        HelpEntry {
+            key: "Up / Down",
+            desc: "Browse input history",
+            section: "Input",
+            available: |m| m == AppMode::Normal,
+        },
+        // ── Exit ──────────────────────────────────────────────────────
+        HelpEntry {
+            key: "^Q",
+            desc: "Quit filar",
+            section: "Exit",
+            available: |_| true,
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Overlay render
+// ---------------------------------------------------------------------------
+
+/// Maximum width of the help overlay (chars).  Caps the actual width to
+/// `term_width - 2*margin` so it never fills the full screen.
+const OVERLAY_MAX_WIDTH: u16 = 60;
+const OVERLAY_H_MARGIN: u16 = 4;
+const OVERLAY_V_MARGIN: u16 = 2;
+
+/// Render the help overlay as a centred modal window.
+///
+/// The overlay clears the area behind it (`Clear` widget) and draws a
+/// bordered block with the full command registry grouped by section.
+/// Unavailable entries are dimmed.
+pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
+    let registry = help_registry();
+
+    let width = OVERLAY_MAX_WIDTH.min(area.width.saturating_sub(2 * OVERLAY_H_MARGIN));
+    let height = area.height.saturating_sub(2 * OVERLAY_V_MARGIN);
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + OVERLAY_V_MARGIN;
+
+    let overlay_area = Rect::new(x, y, width, height);
+
+    // Clear the area behind the overlay.
+    f.render_widget(Clear, overlay_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.accent))
+        .title(" Help (F1 or Esc to close) ")
+        .style(Style::default().bg(app.theme.bg));
+
+    let mut lines: Vec<Line> = Vec::new();
+    let mut current_section: Option<&str> = None;
+
+    for entry in &registry {
+        if current_section != Some(entry.section) {
+            if current_section.is_some() {
+                lines.push(Line::raw("")); // blank line between sections
+            }
+            lines.push(Line::from(Span::styled(
+                format!(" {} ", entry.section),
+                Style::default()
+                    .fg(app.theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            current_section = Some(entry.section);
+        }
+
+        let available = (entry.available)(app.mode);
+        let key_style = if available {
+            app.theme.dim()
+        } else {
+            app.theme.muted()
+        };
+        let desc_style = if available {
+            Style::default()
+        } else {
+            app.theme.muted()
+        };
+
+        let line = Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{:>14}", entry.key), key_style),
+            Span::raw("  "),
+            Span::styled(entry.desc, desc_style),
+        ]);
+        lines.push(line);
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(paragraph, overlay_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_is_nonempty() {
+        let r = help_registry();
+        assert!(!r.is_empty(), "help registry must not be empty");
+    }
+
+    #[test]
+    fn registry_has_key_sections() {
+        let r = help_registry();
+        let sections: std::collections::HashSet<&str> =
+            r.iter().map(|e| e.section).collect();
+        assert!(sections.contains("Modes"), "must have Modes section");
+        assert!(sections.contains("Tabs"), "must have Tabs section");
+        assert!(sections.contains("Agent"), "must have Agent section");
+        assert!(sections.contains("Scrolling"), "must have Scrolling section");
+        assert!(sections.contains("Input"), "must have Input section");
+        assert!(sections.contains("Exit"), "must have Exit section");
+    }
+
+    #[test]
+    fn most_entries_available_in_normal_mode() {
+        let r = help_registry();
+        let available: Vec<&str> = r
+            .iter()
+            .filter(|e| (e.available)(AppMode::Normal))
+            .map(|e| e.key)
+            .collect();
+        // Most entries should be available; a few mode-specific ones
+        // (^Z, Tab approve/deny) are correctly restricted.
+        assert!(available.contains(&"F1"));
+        assert!(available.contains(&"^T"));
+        assert!(available.contains(&"Enter"));
+        assert!(available.contains(&"!cmd"));
+        assert!(available.contains(&"^N"));
+        assert!(available.contains(&"^Q"));
+        assert!(available.contains(&"wheel"));
+        assert!(available.contains(&"drag"));
+        assert!(available.contains(&"PgUp"));
+        assert!(available.contains(&"Up / Down"));
+        // These are NOT in Normal:
+        assert!(!available.contains(&"^Z")); // only Thinking/Confirming
+        assert!(!available.contains(&"Tab"), "Tab switch is only for Confirming");
+    }
+
+    #[test]
+    fn interactive_mode_restricts_most_entries() {
+        let r = help_registry();
+        let always_available: Vec<&str> = r
+            .iter()
+            .filter(|e| (e.available)(AppMode::Interactive))
+            .map(|e| e.key)
+            .collect();
+        // Help, modes, scrolling, and exit should work in Interactive.
+        assert!(always_available.contains(&"F1"));
+        assert!(always_available.contains(&"^T")); // toggles out of interactive
+        assert!(always_available.contains(&"wheel"));
+        assert!(always_available.contains(&"^Q"));
+        // Tabs/agent/input entries should be dimmed.
+        assert!(!always_available.contains(&"^N"));
+        assert!(!always_available.contains(&"Enter"));
+        assert!(!always_available.contains(&"!cmd"));
+    }
+}

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -31,6 +31,7 @@ pub fn interactive_grid_rows(total_height: u16) -> u16 {
 mod bars;
 mod chat;
 mod confirm;
+mod help;
 mod input;
 #[allow(unused_imports)]
 pub(crate) use chat::scrollbar_content_len;
@@ -112,6 +113,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
     if app.mode == AppMode::Confirming {
         confirm::render_confirm_modal(f, app, app.chat_area);
     }
+
+    // Render help overlay on top of everything if active.
+    if app.help_overlay_visible {
+        let full = f.area();
+        help::render_help_overlay(f, app, full);
+    }
 }
 
 /// Render the interactive terminal mode.
@@ -167,6 +174,12 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
 
     bars::render_separator(f, app, chunks[3]);
     bars::render_help_bar(f, app, chunks[4]);
+
+    // Render help overlay on top of everything if active.
+    if app.help_overlay_visible {
+        let full = f.area();
+        help::render_help_overlay(f, app, full);
+    }
 }
 
 /// Render the tab bar — thin strip above the status bar showing each


### PR DESCRIPTION
Closes #142

F1 opens a full-screen help overlay listing every shortcut grouped by section. Single `help_registry()` source for both overlay and bottom help bar. Unavailable entries shown dimmed. Overlay blocks all keyboard/mouse input until dismissed (F1/Esc).

**Ctrl+H decision:** Tested in Windows Terminal — Ctrl+H arrives as `KeyCode::Backspace`, indistinguishable from Backspace. Per issue recommendation, only F1 is bound.

**Tests:** 241 tui tests pass (10 new: registry, mode availability, F1 toggle, Esc close, key/mouse blocking).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen help overlay listing available keyboard shortcuts and commands.
  * Open the overlay with **F1** and close it with **Esc** or **F1**.
  * Help entries are grouped by section and indicate when commands are unavailable in the current mode.
  * Keyboard and mouse input are blocked while the overlay is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->