### PR TITLE
feat(core,tui): persist agent input history with session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Help overlay listing every shortcut and command, opened with `F1` (Ctrl+H tested
   and found indistinguishable from Backspace on Windows Terminal)
   ([#142](https://github.com/devlawey/filar/issues/142)).
+- Agent-mode input history is now saved with the session and restored on reopen, so
+  Up/Down recalls previous prompts
+  ([#143](https://github.com/devlawey/filar/issues/143)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3011,6 +3011,8 @@ help-строка для текущего режима.
 - `filar_tui::TuiConfig` — новое поле `initial_input_history: Vec<String>`.
 - `filar_tui::Session::input_history()` — новый public метод.
 
+**Дальнейшие шаги:** нет. Функциональность завершена.
+
 ---
 
 ## Релиз v0.6.0 (подготовка)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2975,6 +2975,44 @@ help-строка для текущего режима.
 
 ---
 
+## Issue #143: feat(core,tui) — persist agent input history with session
+
+**Milestone:** Filar v0.6.1. **Ветка:** `feat/143-persist-input-history`.
+
+**Проблема:** история ввода агента жила только в памяти, при перезапуске терялась.
+`↑`/`↓` в восстановленной сессии показывали пустой список.
+
+**Решение:**
+- **Персистентная модель** (`crates/core/src/session.rs`): поле `input_history: Vec<String>`
+  с `#[serde(default)]` — обратная совместимость со старыми файлами.
+  Константа `MAX_INPUT_HISTORY = 200`.
+- **Сохранение** (`runner.rs`): при выходе обрезает историю до последних 200 записей
+  и кладёт в `filar_core::Session`.
+- **Восстановление** (`app.rs`, `runner.rs`, `main.rs`): `App::with_history` принимает
+  `input_history`, `TuiConfig` несёт `initial_input_history`, `main.rs` загружает
+  поле из файла сессии.
+- **Безопасность:** пароли в историю не попадают — ввод через `Ctrl+P` обрабатывается
+  отдельно от `Enter` в Normal-режиме, где пополняется `input_history`.
+- **Дубликаты:** сохранено существующее правило (не добавлять одинаковый ввод подряд).
+
+**Файлы:**
+- `crates/core/src/session.rs` — поле `input_history` + `MAX_INPUT_HISTORY`
+- `crates/tui/src/app.rs` — `Session::input_history()`, `App::with_history(input_history)`
+- `crates/tui/src/runner.rs` — `TuiConfig.initial_input_history`, сохранение с обрезкой
+- `crates/app/src/main.rs` — загрузка `input_history` из файла сессии
+
+**Тесты:** 3 новых в core (37 total): round-trip сериализации, загрузка JSON без поля
+(обратная совместимость), обрезка по MAX_INPUT_HISTORY. 241 tui — без регрессии.
+7 ignored (Docker sshd).
+
+**Публичные контракты:**
+- `filar_core::Session` — новое поле `input_history: Vec<String>` с `#[serde(default)]`.
+- `filar_core::session::MAX_INPUT_HISTORY` — новая константа.
+- `filar_tui::TuiConfig` — новое поле `initial_input_history: Vec<String>`.
+- `filar_tui::Session::input_history()` — новый public метод.
+
+---
+
 ## Релиз v0.6.0 (подготовка)
 
 **Дата:** 2026-07-23. **Milestone:** Filar v0.6.0 (6/6 issues, все смерджены).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -357,30 +357,30 @@ async fn run() -> anyhow::Result<()> {
     };
 
     // ── Load session if specified ──────────────────────────────────────
-    let initial_messages = if let Some(ref sid) = session_id {
+    let (initial_messages, initial_input_history) = if let Some(ref sid) = session_id {
         info!(session_id = %sid, "loading session");
         match SessionStore::with_default_dir() {
             Ok(store) => match store.load(sid) {
                 Ok(Some(session)) => {
                     info!(messages = session.messages.len(), "session loaded");
-                    session.messages
+                    (session.messages, session.input_history)
                 }
                 Ok(None) => {
                     warn!(session_id = %sid, "session not found");
-                    vec![]
+                    (vec![], vec![])
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to load session");
-                    vec![]
+                    (vec![], vec![])
                 }
             },
             Err(e) => {
                 warn!(error = %e, "failed to initialise session store");
-                vec![]
+                (vec![], vec![])
             }
         }
     } else {
-        vec![]
+        (vec![], vec![])
     };
 
     // ── Launch TUI ─────────────────────────────────────────────────────
@@ -389,6 +389,7 @@ async fn run() -> anyhow::Result<()> {
         confirm_mode: config.confirm_mode,
         llm_profile: target_name,
         initial_messages,
+        initial_input_history,
         ssh_target: ssh_target.clone(),
         is_local: ssh_target.is_none(),
         secret_provider,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -73,6 +73,22 @@ impl From<&Session> for SessionMeta {
 }
 
 // ---------------------------------------------------------------------------
+// Session methods
+// ---------------------------------------------------------------------------
+
+impl Session {
+    /// Truncate `input_history` to at most [`MAX_INPUT_HISTORY`] entries,
+    /// keeping the most recent.
+    pub fn truncate_history(&mut self) {
+        let max = MAX_INPUT_HISTORY;
+        if self.input_history.len() > max {
+            let excess = self.input_history.len() - max;
+            self.input_history.drain(0..excess);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // SessionStore
 // ---------------------------------------------------------------------------
 
@@ -461,12 +477,18 @@ mod tests {
 
     #[test]
     fn truncate_input_history_keeps_last_entries() {
-        use super::MAX_INPUT_HISTORY;
-        let mut history: Vec<String> = (0..250).map(|i| format!("entry{i}")).collect();
-        assert!(history.len() > MAX_INPUT_HISTORY);
-        history = history.split_off(history.len() - MAX_INPUT_HISTORY);
-        assert_eq!(history.len(), MAX_INPUT_HISTORY);
-        assert_eq!(history[0], "entry50"); // first kept
-        assert_eq!(history.last().unwrap(), "entry249"); // last kept
+        let mut session = Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "t".into(),
+            llm_profile: "t".into(),
+            messages: vec![],
+            input_history: (0..250).map(|i| format!("entry{i}")).collect(),
+        };
+        assert!(session.input_history.len() > MAX_INPUT_HISTORY);
+        session.truncate_history();
+        assert_eq!(session.input_history.len(), MAX_INPUT_HISTORY);
+        assert_eq!(session.input_history[0], "entry50");
+        assert_eq!(session.input_history.last().unwrap(), "entry249");
     }
 }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -324,6 +324,7 @@ mod tests {
         assert_eq!(loaded.id, "999");
         assert_eq!(loaded.target, "test");
         assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.input_history, session.input_history);
 
         let metas = store.list().unwrap();
         assert_eq!(metas.len(), 1);

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -16,6 +16,9 @@ use crate::error::{CoreError, Result};
 /// Maximum number of sessions to retain on disk.
 pub const MAX_SESSIONS: usize = 10;
 
+/// Maximum number of input history entries to persist per session.
+pub const MAX_INPUT_HISTORY: usize = 200;
+
 // ---------------------------------------------------------------------------
 // Session
 // ---------------------------------------------------------------------------
@@ -33,6 +36,10 @@ pub struct Session {
     pub llm_profile: String,
     /// Chat history blocks.
     pub messages: Vec<ChatBlock>,
+    /// History of user prompts in agent mode (for Up/Down navigation).
+    /// Limited to [`MAX_INPUT_HISTORY`] entries when saved.
+    #[serde(default)]
+    pub input_history: Vec<String>,
 }
 
 /// Lightweight metadata for listing sessions without loading full messages.
@@ -252,6 +259,7 @@ mod tests {
                 ChatBlock::User("find port 8080".into()),
                 ChatBlock::Agent("running lsof".into()),
             ],
+            input_history: vec![],
         };
         let meta = SessionMeta::from(&session);
         assert_eq!(meta.id, "123");
@@ -267,6 +275,7 @@ mod tests {
             target: "t".into(),
             llm_profile: "t".into(),
             messages: vec![],
+            input_history: vec![],
         };
         let meta = SessionMeta::from(&session);
         assert!(meta.preview.is_empty());
@@ -291,6 +300,7 @@ mod tests {
                 ChatBlock::User("hello".into()),
                 ChatBlock::Agent("world".into()),
             ],
+            input_history: vec!["ls -la".into(), "find port".into()],
         };
 
         store.save(&session).unwrap();
@@ -327,6 +337,7 @@ mod tests {
                 target: "t".into(),
                 llm_profile: "t".into(),
                 messages: vec![ChatBlock::User(format!("msg{i}"))],
+                input_history: vec![],
             };
             store.save(&session).unwrap();
         }
@@ -410,5 +421,52 @@ mod tests {
         // Let me just verify the epoch is correct and the function doesn't panic.
         let (y, _m, _d, _h, _mi, _s) = unix_to_ymdhms(1_782_045_045);
         assert_eq!(y, 2026);
+    }
+
+    // ── input_history tests ────────────────────────────────────────────
+
+    #[test]
+    fn input_history_serialize_roundtrip() {
+        let session = Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "t".into(),
+            llm_profile: "t".into(),
+            messages: vec![],
+            input_history: vec!["ls".into(), "find port 8080".into()],
+        };
+        let json = serde_json::to_string_pretty(&session).unwrap();
+        assert!(json.contains("input_history"), "JSON must contain input_history");
+        assert!(json.contains("find port 8080"), "must contain history entries");
+        let loaded: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.input_history.len(), 2);
+        assert_eq!(loaded.input_history[0], "ls");
+        assert_eq!(loaded.input_history[1], "find port 8080");
+    }
+
+    #[test]
+    fn input_history_backward_compat_no_field() {
+        // JSON from a session saved by the old version — no input_history field.
+        let json = r#"{
+            "id":"123",
+            "timestamp":"2026-01-01 00:00:00",
+            "target":"test",
+            "llm_profile":"glm",
+            "messages":[{"User":"hello"},{"Agent":"world"}]
+        }"#;
+        let session: Session = serde_json::from_str(json).unwrap();
+        assert_eq!(session.id, "123");
+        assert!(session.input_history.is_empty(), "missing field → default empty");
+    }
+
+    #[test]
+    fn truncate_input_history_keeps_last_entries() {
+        use super::MAX_INPUT_HISTORY;
+        let mut history: Vec<String> = (0..250).map(|i| format!("entry{i}")).collect();
+        assert!(history.len() > MAX_INPUT_HISTORY);
+        history = history.split_off(history.len() - MAX_INPUT_HISTORY);
+        assert_eq!(history.len(), MAX_INPUT_HISTORY);
+        assert_eq!(history[0], "entry50"); // first kept
+        assert_eq!(history.last().unwrap(), "entry249"); // last kept
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -495,6 +495,11 @@ impl Session {
             None => self.target_name.clone(),
         }
     }
+
+    /// Reference to the input history (for persistence).
+    pub fn input_history(&self) -> &[String] {
+        &self.input_history
+    }
 }
 
 impl App {
@@ -503,16 +508,19 @@ impl App {
         target_name: String,
         confirm_mode: CommandConfirmMode,
         messages: Vec<ChatBlock>,
+        input_history: Vec<String>,
     ) -> Self {
         let mut app = Self::new(target_name, confirm_mode);
         if !messages.is_empty() {
             app.messages = messages;
-            // Bump rev for the wholesale replacement so the cache rebuilds.
             app.message_rev = app.message_rev.wrapping_add(1);
             app.push_message(ChatBlock::System(
                 "Session restored — history loaded from disk".into(),
             ));
         }
+        // Restore agent input history so Up/Down recalls previous prompts.
+        app.input_history = input_history;
+        app.history_pos = None; // Start not in browsing mode.
         app
     }
 

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -262,12 +262,11 @@ async fn run_app(
     let mut app = if config.initial_messages.is_empty() {
         App::new(config.target_name.clone(), config.confirm_mode)
     } else {
-        let history = std::mem::take(&mut config.initial_input_history);
         App::with_history(
             config.target_name.clone(),
             config.confirm_mode,
-            std::mem::take(&mut config.initial_messages),
-            history,
+            config.initial_messages,
+            config.initial_input_history,
         )
     };
     // Wire the App to the same StaticSecretProvider instance used by the
@@ -825,20 +824,15 @@ async fn run_app(
 
     // Save session to disk for future restore.
     let (id, timestamp) = filar_core::session::now_session_id();
-    let mut history: Vec<String> = app.input_history().to_vec();
-    let max_history = filar_core::session::MAX_INPUT_HISTORY;
-    if history.len() > max_history {
-        // Keep the most recent entries.
-        history = history.split_off(history.len() - max_history);
-    }
-    let session = filar_core::Session {
+    let mut session = filar_core::Session {
         id,
         timestamp,
         target: config.target_name.clone(),
         llm_profile: config.llm_profile.clone(),
         messages: app.messages.clone(),
-        input_history: history,
+        input_history: app.input_history().to_vec(),
     };
+    session.truncate_history();
     match filar_core::SessionStore::with_default_dir() {
         Ok(store) => {
             if let Err(e) = store.save(&session) {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -191,6 +191,8 @@ pub struct TuiConfig {
     pub confirm_mode: CommandConfirmMode,
     pub llm_profile: String,
     pub initial_messages: Vec<ChatBlock>,
+    /// Initial agent input history (for session restore).
+    pub initial_input_history: Vec<String>,
     /// SSH target for interactive terminal mode (Ctrl+T).
     /// If `None`, the agent runs in local mode.
     pub ssh_target: Option<filar_core::SshTarget>,
@@ -260,10 +262,12 @@ async fn run_app(
     let mut app = if config.initial_messages.is_empty() {
         App::new(config.target_name.clone(), config.confirm_mode)
     } else {
+        let history = std::mem::take(&mut config.initial_input_history);
         App::with_history(
             config.target_name.clone(),
             config.confirm_mode,
             std::mem::take(&mut config.initial_messages),
+            history,
         )
     };
     // Wire the App to the same StaticSecretProvider instance used by the
@@ -821,12 +825,19 @@ async fn run_app(
 
     // Save session to disk for future restore.
     let (id, timestamp) = filar_core::session::now_session_id();
+    let mut history: Vec<String> = app.input_history().to_vec();
+    let max_history = filar_core::session::MAX_INPUT_HISTORY;
+    if history.len() > max_history {
+        // Keep the most recent entries.
+        history = history.split_off(history.len() - max_history);
+    }
     let session = filar_core::Session {
         id,
         timestamp,
         target: config.target_name.clone(),
         llm_profile: config.llm_profile.clone(),
         messages: app.messages.clone(),
+        input_history: history,
     };
     match filar_core::SessionStore::with_default_dir() {
         Ok(store) => {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -259,14 +259,16 @@ async fn run_app(
     executor: Arc<dyn CommandExecutor>,
     mut config: TuiConfig,
 ) -> Result<()> {
-    let mut app = if config.initial_messages.is_empty() {
+    let mut app = if config.initial_messages.is_empty()
+        && config.initial_input_history.is_empty()
+    {
         App::new(config.target_name.clone(), config.confirm_mode)
     } else {
         App::with_history(
             config.target_name.clone(),
             config.confirm_mode,
-            config.initial_messages,
-            config.initial_input_history,
+            std::mem::take(&mut config.initial_messages),
+            std::mem::take(&mut config.initial_input_history),
         )
     };
     // Wire the App to the same StaticSecretProvider instance used by the


### PR DESCRIPTION
Closes #143

Agent-mode input history is now saved with the session and restored on reopen. Up/Down immediately recalls previous prompts.

- `filar_core::Session` gains `input_history: Vec<String>` (serde(default), backward-compatible)
- Limited to last 200 entries (`MAX_INPUT_HISTORY`)
- Passwords never reach input_history (separate code path)
- No-duplicate rule preserved

Tests: 37 core (3 new: round-trip, backward compat, truncation) + 241 tui. 7 ignored (Docker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-mode input history is now saved with sessions and restored when reopening them.
  * Use the Up and Down keys to recall recent prompts across sessions.
  * History is limited to the most recent 200 entries.

* **Bug Fixes**
  * Existing sessions without saved input history continue to open normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->