### PR TITLE
fix(tui): make help overlay scrollable with PgUp/PgDn/arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- The F1 help overlay is now scrollable (PgUp/PgDn/arrows) instead of clipping entries
+  that don't fit a small terminal window
+  ([#151](https://github.com/devlawey/filar/issues/151)).
+
 ## [0.6.1] - 2026-07-25
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3036,6 +3036,25 @@ help-строка для текущего режима.
 
 ---
 
+## Issue #151: fix(tui) — scrollable help overlay
+
+**Milestone:** Filar v0.6.2. **Ветка:** `fix/151-help-overlay-scroll`.
+
+**Проблема:** оверлей F1 не прокручивался — содержимое обрезалось по высоте, PgUp/PgDn не работали.
+
+**Решение:**
+- `App::help_scroll: u16` — смещение прокрутки, сбрасывается в 0 при открытии.
+- `handle_key` в режиме оверлея: PgDn/↓ +1, PgUp/↑ −1 (saturating), Home→0, End→MAX.
+- `render_help_overlay`: клэмп `scroll = min(help_scroll, total_lines - visible)`,
+  `Paragraph::scroll((scroll, 0))`, индикатор `"N/M"` в заголовке.
+
+**Файлы:** `crates/tui/src/app.rs`, `crates/tui/src/ui/help.rs`.
+
+**Тесты:** 7 новых (248 total): открытие сбрасывает scroll, PgDn/PgUp меняют, saturation at 0,
+Home reset, arrow keys, clamp формула.
+
+---
+
 ## Релиз v0.6.1 (подготовка)
 
 **Дата:** 2026-07-25. **Milestone:** Filar v0.6.1 (5/5 issue, все смерджены).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -193,6 +193,8 @@ pub struct App {
     pub pending_local_executors: Vec<SessionId>,
     /// Whether the help overlay is currently visible.
     pub help_overlay_visible: bool,
+    /// Scroll offset (in lines) for the help overlay.
+    pub help_scroll: u16,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -333,6 +335,7 @@ impl App {
             closed_ids: Vec::new(),
             pending_local_executors: Vec::new(),
             help_overlay_visible: false,
+            help_scroll: 0,
         }
     }
 
@@ -642,9 +645,12 @@ impl App {
         }
     }
 
-    /// Toggle the help overlay on/off.
+    /// Toggle the help overlay on/off. Resets scroll to top when opening.
     pub fn toggle_help_overlay(&mut self) {
         self.help_overlay_visible = !self.help_overlay_visible;
+        if self.help_overlay_visible {
+            self.help_scroll = 0;
+        }
     }
 
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
@@ -657,11 +663,20 @@ impl App {
             return;
         }
 
-        // When the help overlay is visible, only Esc and F1 are processed;
-        // all other keys are consumed so they don't affect the UI behind it.
+        // When the help overlay is visible, only navigation and close keys
+        // are processed; all other keys are consumed.
         if self.help_overlay_visible {
-            if key.code == KeyCode::Esc {
-                self.help_overlay_visible = false;
+            match key.code {
+                KeyCode::Esc => self.help_overlay_visible = false,
+                KeyCode::PageDown | KeyCode::Down => {
+                    self.help_scroll = self.help_scroll.saturating_add(1);
+                }
+                KeyCode::PageUp | KeyCode::Up => {
+                    self.help_scroll = self.help_scroll.saturating_sub(1);
+                }
+                KeyCode::Home => self.help_scroll = 0,
+                KeyCode::End => self.help_scroll = u16::MAX,
+                _ => {}
             }
             return;
         }
@@ -5023,5 +5038,98 @@ mod tests {
         };
         app.handle_mouse(m);
         // No assertion needed other than no panic — mouse event is consumed.
+    }
+
+    #[test]
+    fn help_overlay_opening_resets_scroll_to_zero() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.help_scroll = 5;
+        app.toggle_help_overlay();
+        assert!(app.help_overlay_visible);
+        assert_eq!(app.help_scroll, 0, "opening overlay must reset scroll");
+    }
+
+    #[test]
+    fn help_overlay_pgdn_increases_scroll() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.help_overlay_visible = true;
+        let pgdn = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::PageDown,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(pgdn);
+        assert_eq!(app.help_scroll, 1);
+        app.handle_key(pgdn);
+        assert_eq!(app.help_scroll, 2);
+    }
+
+    #[test]
+    fn help_overlay_pgup_decreases_scroll() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.help_overlay_visible = true;
+        app.help_scroll = 5;
+        let pgup = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::PageUp,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(pgup);
+        assert_eq!(app.help_scroll, 4);
+    }
+
+    #[test]
+    fn help_overlay_scroll_saturates_at_zero() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.help_overlay_visible = true;
+        app.help_scroll = 1;
+        let pgup = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::PageUp,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(pgup);
+        app.handle_key(pgup);
+        assert_eq!(app.help_scroll, 0, "scroll must saturate at 0");
+    }
+
+    #[test]
+    fn help_overlay_home_resets_scroll() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.help_overlay_visible = true;
+        app.help_scroll = 10;
+        let home = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Home,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(home);
+        assert_eq!(app.help_scroll, 0);
+    }
+
+    #[test]
+    fn help_overlay_arrow_keys_scroll() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.help_overlay_visible = true;
+        let down = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Down,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(down);
+        assert_eq!(app.help_scroll, 1);
+        let up = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Up,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        app.handle_key(up);
+        assert_eq!(app.help_scroll, 0);
+    }
+
+    #[test]
+    fn help_overlay_scroll_clamp_formula() {
+        let clamp = |scroll: usize, total: usize, visible: usize| -> usize {
+            let max = total.saturating_sub(visible);
+            scroll.min(max)
+        };
+        assert_eq!(clamp(0, 30, 20), 0);
+        assert_eq!(clamp(5, 30, 20), 5);
+        assert_eq!(clamp(15, 30, 20), 10, "15 clamped to max 10");
+        assert_eq!(clamp(0, 10, 20), 0, "total < visible, max = 0");
     }
 }

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -263,7 +263,7 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
         .border_style(Style::default().fg(app.theme.accent))
         .style(Style::default().bg(app.theme.bg));
     let inner_area = inner.inner(overlay_area);
-    let visible = inner_area.height.saturating_sub(1) as usize; // one row for margins
+    let visible = inner_area.height as usize;
     let total = lines.len();
     let max_scroll = total.saturating_sub(visible);
     let scroll = (app.help_scroll as usize).min(max_scroll) as u16;
@@ -272,7 +272,7 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
     let title = if total > visible {
         format!(
             " Help (F1/Esc close, {}/{}, PgUp/PgDn scroll) ",
-            scroll.saturating_add(inner_area.height.saturating_sub(1)),
+            scroll.saturating_add(1),
             total
         )
     } else {

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -220,12 +220,6 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
     // Clear the area behind the overlay.
     f.render_widget(Clear, overlay_area);
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(app.theme.accent))
-        .title(" Help (F1 or Esc to close) ")
-        .style(Style::default().bg(app.theme.bg));
-
     let mut lines: Vec<Line> = Vec::new();
     let mut current_section: Option<&str> = None;
 
@@ -264,8 +258,32 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
         lines.push(line);
     }
 
+    let inner = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.accent))
+        .style(Style::default().bg(app.theme.bg));
+    let inner_area = inner.inner(overlay_area);
+    let visible = inner_area.height.saturating_sub(1) as usize; // one row for margins
+    let total = lines.len();
+    let max_scroll = total.saturating_sub(visible);
+    let scroll = (app.help_scroll as usize).min(max_scroll) as u16;
+
+    // Title with scroll indicator if content overflows.
+    let title = if total > visible {
+        format!(
+            " Help (F1/Esc close, {}/{}, PgUp/PgDn scroll) ",
+            scroll.saturating_add(inner_area.height.saturating_sub(1)),
+            total
+        )
+    } else {
+        " Help (F1 or Esc to close) ".into()
+    };
+
+    let block = inner.title(title);
+
     let paragraph = Paragraph::new(lines)
         .block(block)
+        .scroll((scroll, 0))
         .wrap(Wrap { trim: false });
 
     f.render_widget(paragraph, overlay_area);


### PR DESCRIPTION
Closes #151

F1 help overlay now scrolls with PgUp/PgDn/Up/Down/Home/End. Scroll offset clamped to visible area, resets to top on every open. Title shows current position (N/M).

Tests: 248 tui pass (7 new for scroll, clamp, key handling).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The F1 help overlay is now scrollable in small terminal windows.
  * Use Page Up/Page Down, arrow keys, Home, or End to navigate help content.
  * Added a scroll progress indicator when help content exceeds the available space.
  * Help content now resets to the top whenever the overlay is reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->