### PR TITLE
fix(tui): show close-tab shortcut (^W) in bottom hint bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - The F1 help overlay is now scrollable (PgUp/PgDn/arrows) instead of clipping entries
   that don't fit a small terminal window
   ([#151](https://github.com/devlawey/filar/issues/151)).
+- The close-tab shortcut (^W) is now shown in the bottom hint bar, not only in the F1
+  overlay ([#152](https://github.com/devlawey/filar/issues/152)).
 
 ## [0.6.1] - 2026-07-25
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3055,6 +3055,20 @@ Home reset, arrow keys, clamp формула.
 
 ---
 
+## Issue #152: fix(tui) — close-tab shortcut visible in bottom hint bar
+
+**Milestone:** Filar v0.6.2. **Ветка:** `fix/152-close-tab-hint`.
+
+**Проблема:** `^W` (закрытие вкладки) был только в F1-оверлее, не в нижней строке подсказок.
+
+**Решение:** добавлен `HelpItem { key: "^W", desc: "close" }` в `help_items(AppMode::Normal)` рядом с `^N`. Thinking и Confirming не затронуты (бары минимальны).
+
+**Файлы:** `crates/tui/src/ui/bars.rs`.
+
+**Тесты:** 1 новый (249 total): `normal_mode_help_includes_close_tab`.
+
+---
+
 ## Релиз v0.6.1 (подготовка)
 
 **Дата:** 2026-07-25. **Milestone:** Filar v0.6.1 (5/5 issue, все смерджены).

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -36,7 +36,6 @@ fn help_items(mode: AppMode) -> Vec<HelpItem> {
             HelpItem { key: "^Z", desc: "cancel", action: Some(HelpAction::CancelWork) },
             HelpItem { key: "^Q", desc: "quit", action: Some(HelpAction::Quit) },
             HelpItem { key: "wheel", desc: "scroll", action: None },
-            HelpItem { key: "wheel", desc: "scroll", action: None },
         ],
         AppMode::Confirming => vec![
             HelpItem { key: "tab", desc: "switch", action: Some(HelpAction::Switch) },

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -26,6 +26,7 @@ fn help_items(mode: AppMode) -> Vec<HelpItem> {
             HelpItem { key: "^T", desc: "terminal", action: Some(HelpAction::Terminal) },
             HelpItem { key: "^P", desc: "password", action: Some(HelpAction::Password) },
             HelpItem { key: "^N", desc: "tab", action: None },
+            HelpItem { key: "^W", desc: "close", action: None },
             HelpItem { key: "wheel", desc: "scroll", action: None },
             HelpItem { key: "click", desc: "expand", action: None },
             HelpItem { key: "drag", desc: "copy", action: None },
@@ -34,6 +35,7 @@ fn help_items(mode: AppMode) -> Vec<HelpItem> {
         AppMode::Thinking => vec![
             HelpItem { key: "^Z", desc: "cancel", action: Some(HelpAction::CancelWork) },
             HelpItem { key: "^Q", desc: "quit", action: Some(HelpAction::Quit) },
+            HelpItem { key: "wheel", desc: "scroll", action: None },
             HelpItem { key: "wheel", desc: "scroll", action: None },
         ],
         AppMode::Confirming => vec![
@@ -279,5 +281,14 @@ mod tests {
         ));
         let row = render_status_row(&mut app, 20);
         assert_eq!(row.chars().count(), 20, "row must fill exactly 20 columns");
+    }
+
+    #[test]
+    fn normal_mode_help_includes_close_tab() {
+        let items = help_items(AppMode::Normal);
+        let has_w = items.iter().any(|i| i.key == "^W" && i.desc == "close");
+        assert!(has_w, "Normal mode help must include ^W close");
+        let has_n = items.iter().any(|i| i.key == "^N");
+        assert!(has_n, "Normal mode help must include ^N (existing check)");
     }
 }


### PR DESCRIPTION
Closes #152

`^W close` now appears in the bottom hint bar in Normal mode (next to `^N tab`). The overlay already had it — this fixes discoverability.

Tests: 249 tui pass (1 new).