### PR TITLE
feat(core,app,gui): unified config.toml location in app-data directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - `Settings::save` and `save_pending_launch` now create their parent directory before
   writing, preventing silent data loss when `%APPDATA%\filar` doesn't exist
   ([#160](https://github.com/devlawey/filar/issues/160)).
+- `config.toml` is now searched in `%APPDATA%\filar\` first (unified config location),
+  then CWD, then next to the executable
+  ([#161](https://github.com/devlawey/filar/issues/161)).
 
 ## [0.6.2] - 2026-07-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "keyring",
  "serde",
  "serde_json",
+ "toml 0.8.23",
  "tracing",
 ]
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3144,6 +3144,26 @@ paste (`Event::Paste`) естественно доставляет текст в
 
 ---
 
+## Issue #161: feat(core,app,gui) — unified config.toml location
+
+**Milestone:** Filar v0.7.0. **Ветка:** `feat/161-unified-config-location`.
+
+**Проблема:** `config.toml` искался в CWD, не в `%APPDATA%\filar\`. При запуске из
+Загрузок/рабочего стола конфиг не находился.
+
+**Решение:**
+- `Config::load_default()`: `FILAR_CONFIG` → `%APPDATA%\filar\config.toml` → CWD →
+  exe dir → defaults.
+- `main.rs` упрощён до `Config::load_default()` (27 строк → 1 строка).
+- `save_config_toml()` в GUI: при сохранении настроек лаунчер пишет `[llm]` секцию
+  в `%APPDATA%\filar\config.toml`.
+
+**Файлы:** `core/src/config.rs`, `app/src/main.rs`, `gui/src/lib.rs`.
+
+**Тесты:** 413 pass, без регрессии.
+
+---
+
 ## Релиз v0.6.2 (подготовка)
 
 **Дата:** 2026-07-25. **Milestone:** Filar v0.6.2 (4/4 issue, все смерджены).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -167,28 +167,8 @@ async fn run() -> anyhow::Result<()> {
     info!(log_dir = %log_dir.display(), "filar starting up");
 
     // ── Config ─────────────────────────────────────────────────────────
-    // Try: FILAR_CONFIG env var → current dir → exe dir → built-in defaults.
-    let config = if let Ok(path) = std::env::var("FILAR_CONFIG") {
-        let path = PathBuf::from(path);
-        info!(path = %path.display(), "loading configuration from FILAR_CONFIG");
-        Config::load(&path).map_err(|e| anyhow::anyhow!(e))?
-    } else if std::path::Path::new("config.toml").exists() {
-        info!("loading config.toml from current directory");
-        Config::load("config.toml").map_err(|e| anyhow::anyhow!(e))?
-    } else if let Ok(exe) = std::env::current_exe() {
-        let exe_dir = exe.parent().unwrap_or(std::path::Path::new("."));
-        let path = exe_dir.join("config.toml");
-        if path.exists() {
-            info!(path = %path.display(), "loading config from exe directory");
-            Config::load(&path).map_err(|e| anyhow::anyhow!(e))?
-        } else {
-            info!("no config.toml found, using built-in defaults");
-            Config::default()
-        }
-    } else {
-        info!("no config.toml found, using built-in defaults");
-        Config::default()
-    };
+    // FILAR_CONFIG env var → appdata → CWD → exe dir → built-in defaults.
+    let config = Config::load_default().map_err(|e| anyhow::anyhow!(e))?;
 
     info!(
         model = %config.llm.model,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -650,4 +650,21 @@ temperature = 5.0
         let _ = std::fs::remove_file(&tmp);
         assert!(result.is_err(), "Config::load should reject temperature=5.0");
     }
+
+    #[test]
+    fn load_default_prefers_filar_config_env() {
+        // Write a minimal config to a temp file and set FILAR_CONFIG env.
+        let dir = std::env::temp_dir().join(format!("filar_cfg_test_{}", std::process::id()));
+        let path = dir.join("config.toml");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(&path, "[llm]\nmodel = \"env-model\"\napi_base_url = \"https://test.example.com\"\n").unwrap();
+
+        std::env::set_var("FILAR_CONFIG", path.to_str().unwrap());
+        let cfg = Config::load_default().unwrap();
+        assert_eq!(cfg.llm.model, "env-model", "FILAR_CONFIG must take priority");
+
+        std::env::remove_var("FILAR_CONFIG");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -327,9 +327,46 @@ impl Config {
         Ok(cfg)
     }
 
-    /// Convenience: load from `config.toml` in the current directory.
+    /// Convenience: load from `config.toml`.
+    ///
+    /// Search order:
+    /// 1. `FILAR_CONFIG` environment variable (explicit path)
+    /// 2. `%APPDATA%\filar\config.toml` (platform app-data directory)
+    /// 3. `config.toml` in the current working directory
+    /// 4. `config.toml` next to the executable
+    ///
+    /// Falls back to built-in defaults if no file is found anywhere.
     pub fn load_default() -> Result<Self> {
-        Self::load("config.toml")
+        // 1. FILAR_CONFIG env var.
+        if let Ok(explicit) = std::env::var("FILAR_CONFIG") {
+            let p = std::path::PathBuf::from(explicit);
+            tracing::info!(path = %p.display(), "loading config from FILAR_CONFIG");
+            return Self::load(&p);
+        }
+        // 2. App-data directory (unified config location).
+        if let Ok(base) = crate::default_base_dir() {
+            let app_config = base.join("config.toml");
+            if app_config.exists() {
+                tracing::info!(path = %app_config.display(), "loading config from app-data dir");
+                return Self::load(&app_config);
+            }
+        }
+        // 3. Current working directory.
+        if std::path::Path::new("config.toml").exists() {
+            tracing::info!("loading config.toml from current directory");
+            return Self::load("config.toml");
+        }
+        // 4. Next to the executable.
+        if let Ok(exe) = std::env::current_exe() {
+            let exe_dir = exe.parent().unwrap_or(std::path::Path::new("."));
+            let exe_config = exe_dir.join("config.toml");
+            if exe_config.exists() {
+                tracing::info!(path = %exe_config.display(), "loading config from exe directory");
+                return Self::load(&exe_config);
+            }
+        }
+        tracing::info!("no config.toml found, using built-in defaults");
+        Ok(Self::default())
     }
 
     /// Look up an SSH target by name.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -345,7 +345,7 @@ impl Config {
         }
         // 2. App-data directory (unified config location).
         if let Ok(base) = crate::default_base_dir() {
-            let app_config = base.join("config.toml");
+            let app_config = base.join("filar").join("config.toml");
             if app_config.exists() {
                 tracing::info!(path = %app_config.display(), "loading config from app-data dir");
                 return Self::load(&app_config);
@@ -358,11 +358,12 @@ impl Config {
         }
         // 4. Next to the executable.
         if let Ok(exe) = std::env::current_exe() {
-            let exe_dir = exe.parent().unwrap_or(std::path::Path::new("."));
-            let exe_config = exe_dir.join("config.toml");
-            if exe_config.exists() {
-                tracing::info!(path = %exe_config.display(), "loading config from exe directory");
-                return Self::load(&exe_config);
+            if let Some(exe_dir) = exe.parent() {
+                let exe_config = exe_dir.join("config.toml");
+                if exe_config.exists() {
+                    tracing::info!(path = %exe_config.display(), "loading config from exe directory");
+                    return Self::load(&exe_config);
+                }
             }
         }
         tracing::info!("no config.toml found, using built-in defaults");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -653,18 +653,31 @@ temperature = 5.0
 
     #[test]
     fn load_default_prefers_filar_config_env() {
-        // Write a minimal config to a temp file and set FILAR_CONFIG env.
         let dir = std::env::temp_dir().join(format!("filar_cfg_test_{}", std::process::id()));
         let path = dir.join("config.toml");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(&path, "[llm]\nmodel = \"env-model\"\napi_base_url = \"https://test.example.com\"\n").unwrap();
 
+        // Guard structs for cleanup.
+        struct DirGuard(std::path::PathBuf);
+        impl Drop for DirGuard { fn drop(&mut self) { let _ = std::fs::remove_dir_all(&self.0); } }
+        struct EnvGuard { key: &'static str, old: Option<String> }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.old {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+
+        let _dir_guard = DirGuard(dir);
+        let old_val = std::env::var("FILAR_CONFIG").ok();
         std::env::set_var("FILAR_CONFIG", path.to_str().unwrap());
+        let _env_guard = EnvGuard { key: "FILAR_CONFIG", old: old_val };
+
         let cfg = Config::load_default().unwrap();
         assert_eq!(cfg.llm.model, "env-model", "FILAR_CONFIG must take priority");
-
-        std::env::remove_var("FILAR_CONFIG");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/gui/Cargo.toml
+++ b/crates/gui/Cargo.toml
@@ -11,4 +11,5 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 keyring = { workspace = true }
+toml = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -250,7 +250,13 @@ fn save_config_toml(settings: &Settings) {
 
     // Load existing config to preserve non-LLM sections.
     let mut config: filar_core::Config = if path.exists() {
-        filar_core::Config::load(&path).unwrap_or_default()
+        match filar_core::Config::load(&path) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "config.toml exists but is invalid, not overwriting");
+                return;
+            }
+        }
     } else {
         filar_core::Config::default()
     };
@@ -267,7 +273,10 @@ fn save_config_toml(settings: &Settings) {
         config.llm.extra_body = serde_json::from_str(&settings.extra_body).ok();
     }
 
-    let _ = std::fs::create_dir_all(&app_dir);
+    if let Err(e) = std::fs::create_dir_all(&app_dir) {
+        tracing::warn!(path = %app_dir.display(), error = %e, "failed to create config directory");
+        return;
+    }
     match toml::to_string_pretty(&config) {
         Ok(data) => {
             if let Err(e) = std::fs::write(&path, &data) {
@@ -770,6 +779,32 @@ mod tests {
         let loaded: Settings = serde_json::from_str(&std::fs::read_to_string(&file).unwrap()).unwrap();
         assert_eq!(loaded.model, "test-model");
         assert_eq!(loaded.temperature, "0.5");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn config_save_preserves_existing_sections() {
+        let dir = std::env::temp_dir().join(format!("filar_test_cfg_{}", std::process::id()));
+        let app_dir = dir.join("filar");
+        let path = app_dir.join("config.toml");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // Write a config with non-LLM sections that must survive.
+        let existing = "[llm]\nmodel = \"old\"\napi_base_url = \"https://old.example.com\"\n\n[[ssh_targets]]\nname = \"dev\"\nhost = \"10.0.0.1\"\nuser = \"root\"\nauth = { type = \"agent\" }\n";
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(&path, existing).unwrap();
+
+        // Simulate what save_config_toml does after loading the config.
+        let mut config: filar_core::Config = filar_core::Config::load(&path).unwrap();
+        config.llm.model = "new".into();
+        let saved = toml::to_string_pretty(&config).unwrap();
+        std::fs::write(&path, &saved).unwrap();
+
+        let result = std::fs::read_to_string(&path).unwrap();
+        assert!(result.contains("model = \"new\""), "model must be updated");
+        assert!(result.contains("[[ssh_targets]]"), "ssh_targets must survive");
+        assert!(result.contains("dev"), "ssh target name must survive");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -230,32 +230,53 @@ impl Settings {
     }
 }
 
-/// Write `[llm]` settings to `config.toml` in the app-data directory
-/// so `filar-tui` invoked without the GUI launcher still picks them up.
+/// Write `[llm]` settings to `config.toml` in `%APPDATA%\filar\`
+/// so `filar-tui` invoked without the GUI launcher picks them up.
+///
+/// If a config.toml already exists, only the `[llm]` section is updated;
+/// other sections (SSH targets, profiles, etc.) are preserved.
 fn save_config_toml(settings: &Settings) {
     let base = match filar_core::default_base_dir() {
         Ok(b) => b,
         Err(_) => return,
     };
-    let path = base.join("config.toml");
-    // Only write if LLM fields are non-empty (don't overwrite a
-    // user-edited config.toml with an empty one).
-    if settings.model.is_empty() && settings.api_base_url.is_empty() {
+    let app_dir = base.join("filar");
+    let path = app_dir.join("config.toml");
+
+    // Only save if the model field is non-empty.
+    if settings.model.is_empty() {
         return;
     }
-    let _ = std::fs::create_dir_all(base);
-    let mut content = format!(
-        "[llm]\nmodel = \"{}\"\napi_base_url = \"{}\"\n",
-        settings.model, settings.api_base_url
-    );
+
+    // Load existing config to preserve non-LLM sections.
+    let mut config: filar_core::Config = if path.exists() {
+        filar_core::Config::load(&path).unwrap_or_default()
+    } else {
+        filar_core::Config::default()
+    };
+
+    // Update LLM section from GUI settings.
+    config.llm.model = settings.model.clone();
+    if !settings.api_base_url.is_empty() {
+        config.llm.api_base_url = settings.api_base_url.clone();
+    }
     if !settings.temperature.is_empty() {
-        content.push_str(&format!("temperature = \"{}\"\n", settings.temperature));
+        config.llm.temperature = settings.temperature.parse().ok();
     }
     if !settings.extra_body.is_empty() {
-        content.push_str(&format!("extra_body = \"{}\"\n", settings.extra_body));
+        config.llm.extra_body = serde_json::from_str(&settings.extra_body).ok();
     }
-    if let Err(e) = std::fs::write(&path, &content) {
-        tracing::warn!(path = %path.display(), error = %e, "failed to save config.toml");
+
+    let _ = std::fs::create_dir_all(&app_dir);
+    match toml::to_string_pretty(&config) {
+        Ok(data) => {
+            if let Err(e) = std::fs::write(&path, &data) {
+                tracing::warn!(path = %path.display(), error = %e, "failed to save config.toml");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to serialize config.toml");
+        }
     }
 }
 

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -230,6 +230,35 @@ impl Settings {
     }
 }
 
+/// Write `[llm]` settings to `config.toml` in the app-data directory
+/// so `filar-tui` invoked without the GUI launcher still picks them up.
+fn save_config_toml(settings: &Settings) {
+    let base = match filar_core::default_base_dir() {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+    let path = base.join("config.toml");
+    // Only write if LLM fields are non-empty (don't overwrite a
+    // user-edited config.toml with an empty one).
+    if settings.model.is_empty() && settings.api_base_url.is_empty() {
+        return;
+    }
+    let _ = std::fs::create_dir_all(base);
+    let mut content = format!(
+        "[llm]\nmodel = \"{}\"\napi_base_url = \"{}\"\n",
+        settings.model, settings.api_base_url
+    );
+    if !settings.temperature.is_empty() {
+        content.push_str(&format!("temperature = \"{}\"\n", settings.temperature));
+    }
+    if !settings.extra_body.is_empty() {
+        content.push_str(&format!("extra_body = \"{}\"\n", settings.extra_body));
+    }
+    if let Err(e) = std::fs::write(&path, &content) {
+        tracing::warn!(path = %path.display(), error = %e, "failed to save config.toml");
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LauncherApp
 // ---------------------------------------------------------------------------
@@ -483,6 +512,9 @@ impl LauncherApp {
             extra_body: self.extra_body.clone(),
         };
         settings.save();
+        // Also persist LLM settings to config.toml in the app-data directory
+        // so `filar-tui` (invoked without the GUI launcher) picks them up.
+        save_config_toml(&settings);
         save_secret(api_key_cred_name(), &self.api_key);
         for (i, slot) in self.ssh_slots.iter().enumerate() {
             if slot.save_password && !slot.password.is_empty() {


### PR DESCRIPTION
Closes #161

`config.toml` is now searched in the unified app-data directory first, with CWD and exe directory as fallbacks. The GUI launcher also saves LLM settings to `%APPDATA%\filar\config.toml` for standalone TUI use.

Search order: `FILAR_CONFIG` env → `%APPDATA%\filar\config.toml` → CWD → exe dir → defaults.

Tests: 413 pass, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration discovery with a consistent priority order, including the app data directory, current directory, and executable directory.
  * Added support for the `FILAR_CONFIG` environment variable to specify a configuration file.
  * GUI settings now save non-sensitive LLM configuration automatically to the app data configuration file.
  * Falls back to default settings when no configuration file is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->