### PR TITLE
feat(tui): per-session LLM profile switching via Ctrl+L

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - GUI launcher now has a Models tab with add/delete profile management; each profile
   stores its API key in the OS credential store independently
   ([#162](https://github.com/devlawey/filar/issues/162)).
+- Ctrl+L now cycles through LLM profiles per tab; each session can use a different
+  model without affecting other tabs
+  ([#163](https://github.com/devlawey/filar/issues/163)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3185,6 +3185,26 @@ paste (`Event::Paste`) естественно доставляет текст в
 
 ---
 
+## Issue #163: feat(tui) — per-session LLM profile with Ctrl+L
+
+**Milestone:** Filar v0.7.0. **Ветка:** `feat/163-per-session-llm-profile`.
+
+**Проблема:** одна модель на всё приложение. Нельзя было иметь разные модели в разных вкладках.
+
+**Решение:**
+- `Session::llm_profile: Option<String>` — выбранный профиль (None = default).
+- `App::profiles: Vec<LlmProfile>`, `default_profile_name` — загружаются из config.
+- `Ctrl+L` в Normal циклически переключает профили (Ctrl+Д на ЙЦУКЕН).
+- `TuiConfig::llm_factory` — фабрика клиентов LLM (closure из main.rs).
+- При `spawn_agent` строится новый `Arc<dyn LlmClient>` через factory для профиля сессии.
+- `help_registry`: запись `^L Cycle LLM profile`.
+
+**Файлы:** `tui/src/app.rs`, `tui/src/runner.rs`, `tui/src/ui/help.rs`, `app/src/main.rs`.
+
+**Тесты:** 420 pass, без регрессии.
+
+---
+
 ## Релиз v0.6.2 (подготовка)
 
 **Дата:** 2026-07-25. **Milestone:** Filar v0.6.2 (4/4 issue, все смерджены).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -388,6 +388,9 @@ async fn run() -> anyhow::Result<()> {
     };
 
     // ── Launch TUI ─────────────────────────────────────────────────────
+    let default_profile_name = config.llm_profiles.first()
+        .map(|p| p.name.clone())
+        .unwrap_or_else(|| "default".into());
     let tui_config = TuiConfig {
         target_name: target_name.clone(),
         confirm_mode: config.confirm_mode,
@@ -396,8 +399,21 @@ async fn run() -> anyhow::Result<()> {
         initial_input_history,
         ssh_target: ssh_target.clone(),
         is_local: ssh_target.is_none(),
-        secret_provider,
+        secret_provider: secret_provider.clone(),
         log_rx,
+        profiles: config.llm_profiles.clone(),
+        default_profile_name,
+        llm_factory: Arc::new(move |profile: &filar_core::LlmProfile, sp: &filar_core::StaticSecretProvider| {
+            let key = sp.get(&profile.key_env).unwrap_or_default();
+            let key = if key.is_empty() { std::env::var(&profile.key_env).unwrap_or_default() } else { key };
+            let llm_config: filar_core::LlmConfig = profile.into();
+            Ok(Arc::new(OpenAiCompatClient::new_with_provider(
+                &llm_config,
+                Duration::from_secs(300),
+                &key,
+                sp as &dyn filar_core::SecretProvider,
+            ).map_err(|e| filar_core::CoreError::Other(format!("LLM client error: {e}")))?))
+        }),
     };
 
     info!("launching TUI");

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -406,6 +406,11 @@ async fn run() -> anyhow::Result<()> {
         llm_factory: Arc::new(move |profile: &filar_core::LlmProfile, sp: &filar_core::StaticSecretProvider| {
             let key = sp.get(&profile.key_env).unwrap_or_default();
             let key = if key.is_empty() { std::env::var(&profile.key_env).unwrap_or_default() } else { key };
+            if key.is_empty() {
+                return Err(filar_core::CoreError::Secret(
+                    format!("no API key found for profile {} (checked credential store '{}' and env)", profile.name, profile.key_env)
+                ));
+            }
             let llm_config: filar_core::LlmConfig = profile.into();
             Ok(Arc::new(OpenAiCompatClient::new_with_provider(
                 &llm_config,

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -754,9 +754,15 @@ impl App {
             && !self.profiles.is_empty()
         {
             let current = self.llm_profile.as_deref();
-            let idx = self.profiles.iter()
+            let idx = match self.profiles.iter()
                 .position(|p| Some(p.name.as_str()) == current)
-                .map_or(self.profiles.len().saturating_sub(1), |i| (i + 1) % self.profiles.len());
+            {
+                Some(i) => (i + 1) % self.profiles.len(),
+                // First Ctrl+L: start from the default profile, not the last one.
+                None => self.profiles.iter()
+                    .position(|p| p.name == self.default_profile_name)
+                    .unwrap_or(0),
+            };
             self.llm_profile = Some(self.profiles[idx].name.clone());
             self.push_message(ChatBlock::System(format!(
                 "Switched to LLM profile: {}",
@@ -5250,5 +5256,28 @@ mod tests {
         app.input = "before".into();
         app.paste_text("pasted");
         assert_eq!(app.input, "before", "paste must be no-op in Thinking mode");
+    }
+
+    #[test]
+    fn ctrl_l_cycles_llm_profiles() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.profiles = vec![
+            filar_core::LlmProfile { name: "glm".into(), model: "g".into(), api_base_url: "u".into(), max_tokens: 4096, key_env: "k1".into(), temperature: None, top_p: None, extra_body: None },
+            filar_core::LlmProfile { name: "ds".into(), model: "d".into(), api_base_url: "u".into(), max_tokens: 4096, key_env: "k2".into(), temperature: None, top_p: None, extra_body: None },
+        ];
+        app.default_profile_name = "glm".into();
+
+        // First Ctrl+L with None profile → jumps to default.
+        let ctrl_l = crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Char('l'), crossterm::event::KeyModifiers::CONTROL);
+        app.handle_key(ctrl_l);
+        assert_eq!(app.llm_profile.as_deref(), Some("glm"));
+
+        // Second → next profile.
+        app.handle_key(ctrl_l);
+        assert_eq!(app.llm_profile.as_deref(), Some("ds"));
+
+        // Third → wrap to first.
+        app.handle_key(ctrl_l);
+        assert_eq!(app.llm_profile.as_deref(), Some("glm"));
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -195,6 +195,10 @@ pub struct App {
     pub help_overlay_visible: bool,
     /// Scroll offset (in lines) for the help overlay.
     pub help_scroll: u16,
+    /// Available LLM profiles (from config).
+    pub profiles: Vec<filar_core::LlmProfile>,
+    /// Default profile name when session doesn't specify one.
+    pub default_profile_name: String,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -306,6 +310,8 @@ pub struct Session {
     /// SSH connection info for this tab (e.g. "user@host:port"). None = local.
     /// Set when `!ssh` succeeds for this tab. Used for display and system prompt.
     pub ssh_info: Option<String>,
+    /// LLM profile selected via Ctrl+L. None = use App default.
+    pub llm_profile: Option<String>,
 }
 
 impl App {
@@ -336,6 +342,8 @@ impl App {
             pending_local_executors: Vec::new(),
             help_overlay_visible: false,
             help_scroll: 0,
+            profiles: Vec::new(),
+            default_profile_name: String::new(),
         }
     }
 
@@ -481,6 +489,7 @@ impl Session {
             has_new: false,
             awaiting_confirmation: false,
             ssh_info: None,
+            llm_profile: None,
         }
     }
 
@@ -736,6 +745,23 @@ impl App {
                     }
                 }
             }
+            return;
+        }
+
+        // Ctrl+L — cycle LLM profiles for this session.
+        if ctrl_key('l', 'д')
+            && self.mode == AppMode::Normal
+            && !self.profiles.is_empty()
+        {
+            let current = self.llm_profile.as_deref();
+            let idx = self.profiles.iter()
+                .position(|p| Some(p.name.as_str()) == current)
+                .map_or(self.profiles.len().saturating_sub(1), |i| (i + 1) % self.profiles.len());
+            self.llm_profile = Some(self.profiles[idx].name.clone());
+            self.push_message(ChatBlock::System(format!(
+                "Switched to LLM profile: {}",
+                self.profiles[idx].name
+            )));
             return;
         }
 

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -574,8 +574,8 @@ async fn run_app(
                             let profile_name = app.sessions[app.active]
                                 .llm_profile
                                 .as_deref()
-                                .unwrap_or(&config.default_profile_name);
-                            let profile = config.profiles.iter()
+                                .unwrap_or(&app.default_profile_name);
+                            let profile = app.profiles.iter()
                                 .find(|p| p.name == profile_name);
                             match profile {
                                 Some(p) => match (config.llm_factory)(p, &config.secret_provider) {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -203,6 +203,12 @@ pub struct TuiConfig {
     /// Shared between the TUI (for dynamic `$FILAR_SECRET_N` insertion via
     /// Ctrl+P) and the agent (via `SecretSubstitutingExecutor`).
     pub secret_provider: Arc<StaticSecretProvider>,
+    /// All configured LLM profiles loaded from config.
+    pub profiles: Vec<filar_core::LlmProfile>,
+    /// Name of the default (startup) profile.
+    pub default_profile_name: String,
+    /// Factory for creating per-session LLM clients from profiles.
+    pub llm_factory: Arc<dyn Fn(&filar_core::LlmProfile, &StaticSecretProvider) -> std::result::Result<Arc<dyn LlmClient>, CoreError> + Send + Sync>,
     /// Receiver for WARN/ERROR log lines forwarded from the tracing subscriber
     /// (see [`crate::log_layer`]). The runner polls it and shows each line as a
     /// `System` block, so important logs surface in the chat instead of being
@@ -212,7 +218,7 @@ pub struct TuiConfig {
 
 /// Run the TUI with the given LLM client, executor, and configuration.
 pub async fn run(
-    llm: Arc<dyn LlmClient>,
+    _llm: Arc<dyn LlmClient>,
     executor: Arc<dyn CommandExecutor>,
     config: TuiConfig,
 ) -> Result<()> {
@@ -242,7 +248,7 @@ pub async fn run(
     let mut terminal = Terminal::new(backend)
         .map_err(|e| CoreError::Other(format!("failed to create terminal: {e}")))?;
 
-    let result = run_app(&mut terminal, llm, executor, config).await;
+    let result = run_app(&mut terminal, _llm, executor, config).await;
 
     // Restore the original panic hook before terminal teardown.
     // The custom hook is no longer needed — teardown uses .ok() and
@@ -260,7 +266,7 @@ pub async fn run(
 /// The main application loop.
 async fn run_app(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-    llm: Arc<dyn LlmClient>,
+    _llm: Arc<dyn LlmClient>,
     executor: Arc<dyn CommandExecutor>,
     mut config: TuiConfig,
 ) -> Result<()> {
@@ -276,6 +282,9 @@ async fn run_app(
             std::mem::take(&mut config.initial_input_history),
         )
     };
+    // Load available LLM profiles and default profile name.
+    app.profiles = std::mem::take(&mut config.profiles);
+    app.default_profile_name = std::mem::take(&mut config.default_profile_name);
     // Wire the App to the same StaticSecretProvider instance used by the
     // agent's SecretSubstitutingExecutor, so Ctrl+P inserts are visible to
     // command substitution and output sanitisation.
@@ -560,8 +569,30 @@ async fn run_app(
                         // Create a cancellation token for this agent run.
                         let cancel_token = CancellationToken::new();
                         app.cancellation = Some(cancel_token.clone());
+                        // Resolve the LLM client for this session's profile.
+                        let session_llm = {
+                            let profile_name = app.sessions[app.active]
+                                .llm_profile
+                                .as_deref()
+                                .unwrap_or(&config.default_profile_name);
+                            let profile = config.profiles.iter()
+                                .find(|p| p.name == profile_name);
+                            match profile {
+                                Some(p) => match (config.llm_factory)(p, &config.secret_provider) {
+                                    Ok(c) => c,
+                                    Err(e) => {
+                                        app.push_error(format!("Failed to create LLM client: {e}"));
+                                        continue;
+                                    }
+                                },
+                                None => {
+                                    app.push_error(format!("Profile '{profile_name}' not found"));
+                                    continue;
+                                }
+                            }
+                        };
                         spawn_agent(
-                            llm.clone(),
+                            session_llm,
                             agent_exec,
                             confirmer.clone(),
                             config.confirm_mode,

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -165,6 +165,13 @@ pub(crate) fn help_registry() -> Vec<HelpEntry> {
         },
         // ── Input ─────────────────────────────────────────────────────
         HelpEntry {
+            key: "^L",
+            desc: "Cycle LLM profile for this tab",
+            section: "Agent",
+            available: |m| m == AppMode::Normal,
+        },
+        // ── Input ─────────────────────────────────────────────────────
+        HelpEntry {
             key: "^V",
             desc: "Paste from clipboard",
             section: "Input",


### PR DESCRIPTION
Closes #163

Ctrl+L cycles through configured LLM profiles per tab. Each session can use a different model.

- `Session::llm_profile` — selected profile, None = default
- `App::profiles` + `default_profile_name` from config
- `TuiConfig::llm_factory` — closure from main.rs for building per-profile LLM clients
- Help registry updated with ^L entry

Tests: 420 pass.