### PR TITLE
feat(agent,tui): token usage counter per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Ctrl+L now cycles through LLM profiles per tab; each session can use a different
   model without affecting other tabs
   ([#163](https://github.com/devlawey/filar/issues/163)).
+- Token usage counter shown in the status bar (estimated ~4 chars/token) per session
+  ([#164](https://github.com/devlawey/filar/issues/164)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3205,6 +3205,27 @@ paste (`Event::Paste`) естественно доставляет текст в
 
 ---
 
+## Issue #164: feat(agent,tui) — token usage counter per session
+
+**Milestone:** Filar v0.7.0. **Ветка:** `feat/164-token-usage-counter`.
+
+**Проблема:** пользователь не видит расход токенов.
+
+**Решение (v1 — оценочное):**
+- `Session::tokens_in: u64`, `tokens_out: u64` — накопительный счётчик.
+- При Enter: `tokens_in += input.len().div_ceil(4)` (~4 chars/token).
+- При `AgentEvent::Finished`: `tokens_out += text.len().div_ceil(4)`.
+- Статус-бар: `toks: N↑ M↓` (muted стиль) справа от режима.
+
+**Файлы:** `tui/src/app.rs` (+8 строк), `tui/src/ui/bars.rs` (+8 строк).
+
+**Тесты:** 255 pass, без регрессии.
+
+**Вне скоупа:** точный подсчёт из API-ответа (usage.prompt_tokens/completion_tokens) —
+требует сквозного пайплайна через провайдер → ChatResponse → AgentEvent → TuiEvent.
+
+---
+
 ## Релиз v0.6.2 (подготовка)
 
 **Дата:** 2026-07-25. **Milestone:** Filar v0.6.2 (4/4 issue, все смерджены).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -312,6 +312,10 @@ pub struct Session {
     pub ssh_info: Option<String>,
     /// LLM profile selected via Ctrl+L. None = use App default.
     pub llm_profile: Option<String>,
+    /// Cumulative input tokens consumed by this session.
+    pub tokens_in: u64,
+    /// Cumulative output tokens generated for this session.
+    pub tokens_out: u64,
 }
 
 impl App {
@@ -490,6 +494,8 @@ impl Session {
             awaiting_confirmation: false,
             ssh_info: None,
             llm_profile: None,
+            tokens_in: 0,
+            tokens_out: 0,
         }
     }
 
@@ -891,6 +897,7 @@ impl App {
                             }
                         } else {
                             self.push_message(ChatBlock::User(text.clone()));
+                            self.tokens_in += (text.len() as u64).div_ceil(4);
                             self.scroll = 0;
                             self.input.clear();
                             self.cursor_pos = 0;
@@ -2063,6 +2070,7 @@ impl App {
                     self.pending_proposal = None;
                 }
                 filar_agent::AgentEvent::Finished(text) => {
+                    let text_len = text.len();
                     if self.streaming {
                         if !text.is_empty() {
                             if let Some(ChatBlock::Agent(ref mut existing)) = self.messages.last_mut() {
@@ -2080,6 +2088,7 @@ impl App {
                     self.mode = AppMode::Normal;
                     self.agent_running = false;
                     self.cancellation = None;
+                    self.tokens_out += (text_len as u64).div_ceil(4);
                     self.active_session_mut().background_activity = false;
                 }
                 filar_agent::AgentEvent::Error(err) => {

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -897,7 +897,7 @@ impl App {
                             }
                         } else {
                             self.push_message(ChatBlock::User(text.clone()));
-                            self.tokens_in += (text.len() as u64).div_ceil(4);
+                            self.tokens_in += (text.chars().count() as u64).div_ceil(4);
                             self.scroll = 0;
                             self.input.clear();
                             self.cursor_pos = 0;
@@ -2070,7 +2070,7 @@ impl App {
                     self.pending_proposal = None;
                 }
                 filar_agent::AgentEvent::Finished(text) => {
-                    let text_len = text.len();
+                    let text_len = text.chars().count();
                     if self.streaming {
                         if !text.is_empty() {
                             if let Some(ChatBlock::Agent(ref mut existing)) = self.messages.last_mut() {
@@ -5288,5 +5288,35 @@ mod tests {
         // Third → wrap to first.
         app.handle_key(ctrl_l);
         assert_eq!(app.llm_profile.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn token_counter_increments_on_enter() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.input = "hello world".into();
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        // "hello world" = 11 chars → ceil(11/4) = 3
+        assert_eq!(app.tokens_in, 3);
+        assert_eq!(app.tokens_out, 0);
+    }
+
+    #[test]
+    fn token_counter_is_per_session() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.new_tab(); // active = 1, new session gets index 1
+        app.switch_to_tab(1); // back to session 0 (1-based index for tab 1)
+        assert_eq!(app.active, 0);
+        // Session 0: add tokens
+        app.input = "abcd".into();
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.sessions[0].tokens_in, 1); // "abcd" = 4 chars → 1 token
+        // Session 1 must still be at zero.
+        assert_eq!(app.sessions[1].tokens_in, 0);
     }
 }

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -96,6 +96,15 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
         spans.push(Span::styled(mt, app.theme.mode_badge_style(mode_color)));
     }
 
+    // Token counter — right-aligned.
+    if app.tokens_in > 0 || app.tokens_out > 0 {
+        spans.push(Span::raw("   "));
+        spans.push(Span::styled(
+            format!("toks: {}↑ {}↓", app.tokens_in, app.tokens_out),
+            app.theme.muted(),
+        ));
+    }
+
     // Right side: `confirm_mode`, then an optional toast (e.g. "· copied")
     // pinned to the far right. Space for the toast is reserved *before* the
     // padding is computed — otherwise the padding fills the whole line and the


### PR DESCRIPTION
Closes #164

Token usage shown per session in the status bar as `toks: N↑ M↓`.

v1 uses character-length estimation (~4 chars per token). Input counted on Enter, output on AgentEvent::Finished. Accurate API-usage tracking (usage.prompt_tokens/completion_tokens) deferred to a follow-up issue.

Tests: 255 tui pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-session token usage counter to the status bar.
  * Displays estimated input and output usage in the format `toks: N↑ M↓`.
  * Counters update as messages are submitted and responses are completed.

* **Documentation**
  * Added release and progress notes describing token usage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->