### PR TITLE
fix(agent,tui): use real API usage data for token counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   leaves its API key in the OS credential store, and adding a profile after a deletion
   no longer collides with an existing one
   ([#172](https://github.com/devlawey/filar/issues/172)).
+- Token counter now uses real API usage data instead of character-length estimation,
+  and shows `—` when the provider doesn't report usage
+  ([#173](https://github.com/devlawey/filar/issues/173)).
 
 ### Added
 
@@ -29,8 +32,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Ctrl+L now cycles through LLM profiles per tab; each session can use a different
   model without affecting other tabs
   ([#163](https://github.com/devlawey/filar/issues/163)).
-- Token usage counter shown in the status bar (estimated ~4 chars/token) per session
-  ([#164](https://github.com/devlawey/filar/issues/164)).
+- Token usage counter now uses real API response data (`usage.prompt_tokens` /
+  `completion_tokens`) instead of character-length estimation
+  ([#173](https://github.com/devlawey/filar/issues/173)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3266,6 +3266,33 @@ Credential Manager.
 
 ---
 
+## Issue #173: fix(agent,tui) — real token usage from API
+
+**Milestone:** Filar v0.7.0. **Ветка:** `fix/173-real-token-usage`.
+
+**Проблема:** chars/4 оценка не учитывает системный промпт, историю, схемы инструментов
+и промежуточные итерации. Цифра занижена в разы.
+
+**Решение:**
+- `ApiResponse::usage` — парсинг `prompt_tokens/completion_tokens/total_tokens`.
+- `ChatResponse::usage: Option<TokenUsage>` — аддитивное поле, `ChatResponse::text/tool_calls` получают `None`.
+- `AgentEvent::TokenUsage { tokens_in, tokens_out }` — на каждое обращение к модели.
+- В `agent_main` emit TokenUsage после получения response.
+- TUI: `app.rs` — удалена chars/4, прибавление из `TokenUsage`.
+- Статус-бар: при отсутствии данных `toks: —`.
+
+**Файлы:** `agent/src/lib.rs`, `agent/src/events.rs`, `agent/src/openai_compat.rs`,
+`agent/src/agent.rs`, `tui/src/app.rs`, `tui/src/ui/bars.rs`.
+
+**Тесты:** `deserialize_response_with_usage`, `deserialize_response_without_usage` (2 новых).
+257 tui pass. Токен-тесты переписаны под API-usage.
+
+**Публичные контракты:**
+- `ChatResponse.usage: Option<TokenUsage>` — новое аддитивное поле.
+- `AgentEvent::TokenUsage` — новый non-exhaustive вариант.
+
+---
+
 ## Релиз v0.6.2 (подготовка)
 
 **Дата:** 2026-07-25. **Milestone:** Filar v0.6.2 (4/4 issue, все смерджены).

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -420,6 +420,14 @@ impl Agent {
                 with_cancellation(self.cancellation.as_ref(), self.llm.chat(&request)).await?
             };
 
+            // Emit token usage if the provider reported it.
+            if let Some(ref u) = response.usage {
+                self.emit(AgentEvent::TokenUsage {
+                    tokens_in: u.prompt_tokens.unwrap_or(0),
+                    tokens_out: u.completion_tokens.unwrap_or(0),
+                });
+            }
+
             if response.has_tool_calls() {
                 let tool_calls = response.tool_calls.clone();
                 info!(iteration, count = tool_calls.len(), "LLM requested tool calls");

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -52,6 +52,14 @@ pub enum AgentEvent {
     /// The agent finished and produced a final answer.
     Finished(String),
 
+    /// Token usage reported by the LLM provider for the current exchange.
+    /// Each call to the model produces one of these events (intermediate
+    /// tool-call iterations each get their own).
+    TokenUsage {
+        tokens_in: u64,
+        tokens_out: u64,
+    },
+
     /// The agent encountered an error (network, LLM, transport).
     Error(String),
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -176,6 +176,14 @@ pub struct ToolDef {
     pub parameters: serde_json::Value,
 }
 
+/// Token usage from the API response.
+#[derive(Debug, Clone, Default)]
+pub struct TokenUsage {
+    pub prompt_tokens: Option<u64>,
+    pub completion_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+}
+
 /// The model's response, containing both text and optional tool calls.
 ///
 /// Both fields are always present — `text` may be empty when the model only
@@ -188,6 +196,8 @@ pub struct ChatResponse {
     pub text: String,
     /// Tool calls requested by the model (empty for a final text response).
     pub tool_calls: Vec<ToolCall>,
+    /// Token usage reported by the provider, if available.
+    pub usage: Option<TokenUsage>,
 }
 
 impl ChatResponse {
@@ -196,6 +206,7 @@ impl ChatResponse {
         Self {
             text: text.into(),
             tool_calls: Vec::new(),
+            usage: None,
         }
     }
 
@@ -204,12 +215,19 @@ impl ChatResponse {
         Self {
             text: text.into(),
             tool_calls,
+            usage: None,
         }
     }
 
     /// Returns `true` if the response contains tool calls.
     pub fn has_tool_calls(&self) -> bool {
         !self.tool_calls.is_empty()
+    }
+
+    /// Attach token usage data. Chainable.
+    pub fn with_usage(mut self, usage: TokenUsage) -> Self {
+        self.usage = Some(usage);
+        self
     }
 }
 

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -688,6 +688,8 @@ impl ApiResponse {
 struct SseEvent {
     #[serde(default)]
     choices: Vec<SseChoice>,
+    #[serde(default)]
+    usage: Option<ApiUsage>,
 }
 
 #[derive(Deserialize)]
@@ -735,6 +737,7 @@ struct SseState {
     full_text: String,
     tool_calls: BTreeMap<usize, StreamToolCall>,
     done: bool,
+    streamed_usage: Option<ApiUsage>,
 }
 
 impl SseState {
@@ -744,6 +747,7 @@ impl SseState {
             full_text: String::new(),
             tool_calls: BTreeMap::new(),
             done: false,
+            streamed_usage: None,
         }
     }
 
@@ -769,6 +773,9 @@ impl SseState {
 
             match serde_json::from_str::<SseEvent>(data) {
                 Ok(event) => {
+                    if let Some(u) = event.usage {
+                        self.streamed_usage = Some(u);
+                    }
                     if let Some(choice) = event.choices.into_iter().next() {
                         if let Some(content) = choice.delta.content {
                             if !content.is_empty() {
@@ -818,26 +825,26 @@ impl SseState {
 
     /// Build the final [`ChatResponse`] from accumulated state.
     fn into_response(self) -> Result<ChatResponse> {
-        if !self.tool_calls.is_empty() {
-            let calls: Vec<ToolCall> = self
-                .tool_calls
-                .values()
-                .map(|tc| {
-                    let arguments = serde_json::from_str(&tc.arguments).unwrap_or_else(|e| {
-                        warn!(error = %e, id = %tc.id, name = %tc.name, "failed to parse accumulated tool call arguments");
-                        serde_json::Value::Null
-                    });
-                    ToolCall {
-                        id: tc.id.clone(),
-                        name: tc.name.clone(),
-                        arguments,
-                    }
-                })
-                .collect();
-            Ok(ChatResponse::tool_calls(self.full_text, calls))
+        let mut resp = if !self.tool_calls.is_empty() {
+            let calls: Vec<ToolCall> = self.tool_calls.values().map(|tc| {
+                let arguments = serde_json::from_str(&tc.arguments).unwrap_or_else(|e| {
+                    warn!(error = %e, id = %tc.id, name = %tc.name, "failed to parse accumulated tool call arguments");
+                    serde_json::Value::Null
+                });
+                ToolCall { id: tc.id.clone(), name: tc.name.clone(), arguments }
+            }).collect();
+            ChatResponse::tool_calls(self.full_text, calls)
         } else {
-            Ok(ChatResponse::text(self.full_text))
+            ChatResponse::text(self.full_text)
+        };
+        if let Some(u) = self.streamed_usage {
+            resp = resp.with_usage(crate::TokenUsage {
+                prompt_tokens: u.prompt_tokens,
+                completion_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+            });
         }
+        Ok(resp)
     }
 }
 

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -591,6 +591,18 @@ struct ApiToolCallFunction {
 #[derive(Deserialize)]
 struct ApiResponse {
     choices: Vec<ApiChoice>,
+    #[serde(default)]
+    usage: Option<ApiUsage>,
+}
+
+#[derive(Deserialize, Default)]
+struct ApiUsage {
+    #[serde(default)]
+    prompt_tokens: Option<u64>,
+    #[serde(default)]
+    completion_tokens: Option<u64>,
+    #[serde(default)]
+    total_tokens: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -629,6 +641,12 @@ impl ApiResponse {
             .next()
             .ok_or_else(|| CoreError::Other("API returned no choices".into()))?;
 
+        let usage = self.usage.map(|u| crate::TokenUsage {
+            prompt_tokens: u.prompt_tokens,
+            completion_tokens: u.completion_tokens,
+            total_tokens: u.total_tokens,
+        });
+
         // If the model returned tool calls, parse them.
         if let Some(tool_calls) = choice.message.tool_calls {
             if !tool_calls.is_empty() {
@@ -644,16 +662,20 @@ impl ApiResponse {
                         }
                     })
                     .collect();
-                return Ok(ChatResponse::tool_calls(
+                let mut resp = ChatResponse::tool_calls(
                     choice.message.content.unwrap_or_default(),
                     parsed,
-                ));
+                );
+                if let Some(u) = usage { resp = resp.with_usage(u); }
+                return Ok(resp);
             }
         }
 
         // Otherwise, return the text content.
         let text = choice.message.content.unwrap_or_default();
-        Ok(ChatResponse::text(text))
+        let mut resp = ChatResponse::text(text);
+        if let Some(u) = usage { resp = resp.with_usage(u); }
+        Ok(resp)
     }
 }
 
@@ -1388,5 +1410,22 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         let client = crate::GlmClient::new_with_key(&config, Duration::from_secs(1), "dummy-key")
             .unwrap();
         assert_same_type(&client);
+    }
+
+    #[test]
+    fn deserialize_response_with_usage() {
+        let json = r#"{"choices":[{"message":{"role":"assistant","content":"hello"}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"#;
+        let resp: ApiResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, Some(10));
+        assert_eq!(usage.completion_tokens, Some(5));
+        assert_eq!(usage.total_tokens, Some(15));
+    }
+
+    #[test]
+    fn deserialize_response_without_usage() {
+        let json = r#"{"choices":[{"message":{"role":"assistant","content":"hello"}}]}"#;
+        let resp: ApiResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.usage.is_none(), "usage must be None when absent");
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -2016,7 +2016,7 @@ impl App {
 
         let mut auto_scroll = true;
         match event {
-            TuiEvent::Agent { event: agent_event, .. } => match agent_event {
+            TuiEvent::Agent { session_id, event: agent_event } => match agent_event {
                 filar_agent::AgentEvent::Started => {
                     self.mode = AppMode::Thinking;
                     self.active_session_mut().background_activity = true;
@@ -2098,8 +2098,10 @@ impl App {
                     self.active_session_mut().background_activity = false;
                 }
                 filar_agent::AgentEvent::TokenUsage { tokens_in, tokens_out } => {
-                    self.tokens_in += tokens_in;
-                    self.tokens_out += tokens_out;
+                    if let Some(s) = self.sessions.iter_mut().find(|s| s.id == session_id) {
+                        s.tokens_in += tokens_in;
+                        s.tokens_out += tokens_out;
+                    }
                 }
                 filar_agent::AgentEvent::Error(err) => {
                     if self.streaming {

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -906,7 +906,6 @@ impl App {
                             }
                         } else {
                             self.push_message(ChatBlock::User(text.clone()));
-                            self.tokens_in += (text.chars().count() as u64).div_ceil(4);
                             self.scroll = 0;
                             self.input.clear();
                             self.cursor_pos = 0;
@@ -2079,7 +2078,6 @@ impl App {
                     self.pending_proposal = None;
                 }
                 filar_agent::AgentEvent::Finished(text) => {
-                    let text_len = text.chars().count();
                     if self.streaming {
                         if !text.is_empty() {
                             if let Some(ChatBlock::Agent(ref mut existing)) = self.messages.last_mut() {
@@ -2097,8 +2095,11 @@ impl App {
                     self.mode = AppMode::Normal;
                     self.agent_running = false;
                     self.cancellation = None;
-                    self.tokens_out += (text_len as u64).div_ceil(4);
                     self.active_session_mut().background_activity = false;
+                }
+                filar_agent::AgentEvent::TokenUsage { tokens_in, tokens_out } => {
+                    self.tokens_in += tokens_in;
+                    self.tokens_out += tokens_out;
                 }
                 filar_agent::AgentEvent::Error(err) => {
                     if self.streaming {
@@ -2111,6 +2112,8 @@ impl App {
                     self.agent_running = false;
                     self.cancellation = None;
                     self.active_session_mut().background_activity = false;
+                }
+                filar_agent::AgentEvent::Cancelled => {
                 }
                 _ => {}
             },
@@ -5301,30 +5304,31 @@ mod tests {
 
     #[test]
     fn token_counter_increments_on_enter() {
+        // Enter no longer counts tokens — token counters come from
+        // real API usage (AgentEvent::TokenUsage).
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.input = "hello world".into();
         app.handle_key(crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::NONE,
         ));
-        // "hello world" = 11 chars → ceil(11/4) = 3
-        assert_eq!(app.tokens_in, 3);
+        assert_eq!(app.tokens_in, 0, "tokens_in unchanged until API returns usage");
         assert_eq!(app.tokens_out, 0);
     }
 
     #[test]
     fn token_counter_is_per_session() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
-        app.new_tab(); // active = 1, new session gets index 1
-        app.switch_to_tab(1); // back to session 0 (1-based index for tab 1)
+        // Token counters are updated via AgentEvent::TokenUsage only.
+        // Simulate receiving usage for session 0.
+        app.handle_agent_event(TuiEvent::Agent {
+            session_id: app.sessions[0].id,
+            event: filar_agent::AgentEvent::TokenUsage { tokens_in: 10, tokens_out: 20 },
+        });
+        assert_eq!(app.sessions[0].tokens_in, 10);
+        app.new_tab();
+        app.switch_to_tab(1); // back to session 0
         assert_eq!(app.active, 0);
-        // Session 0: add tokens
-        app.input = "abcd".into();
-        app.handle_key(crossterm::event::KeyEvent::new(
-            crossterm::event::KeyCode::Enter,
-            crossterm::event::KeyModifiers::NONE,
-        ));
-        assert_eq!(app.sessions[0].tokens_in, 1); // "abcd" = 4 chars → 1 token
         // Session 1 must still be at zero.
         assert_eq!(app.sessions[1].tokens_in, 0);
     }

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -96,11 +96,16 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
         spans.push(Span::styled(mt, app.theme.mode_badge_style(mode_color)));
     }
 
-    // Token counter — right-aligned.
+    // Token counter. Uses real API usage data; shows — when no data yet.
+    spans.push(Span::raw("   "));
     if app.tokens_in > 0 || app.tokens_out > 0 {
-        spans.push(Span::raw("   "));
         spans.push(Span::styled(
             format!("toks: {}↑ {}↓", app.tokens_in, app.tokens_out),
+            app.theme.muted(),
+        ));
+    } else {
+        spans.push(Span::styled(
+            "toks: —",
             app.theme.muted(),
         ));
     }


### PR DESCRIPTION
Closes #173

Replaces the chars/4 character-length estimation with real API `usage` data:

- `TokenUsage` struct in agent lib with `prompt_tokens`, `completion_tokens`, `total_tokens` (all optional)
- `ApiResponse::usage` parsed from OpenAI-compatible responses
- `ChatResponse::usage: Option<TokenUsage>` — additive field, constructors default to None
- `AgentEvent::TokenUsage` emitted per-model-call (including intermediate tool-call iterations)
- Status bar shows `toks: —` when provider doesn't report usage

Tests: 64 agent + 257 tui pass (2 new: usage serialization with/without).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token counts now reflect usage reported by the AI provider rather than estimates based on text length.
  * Token usage is tracked separately for each active session.
  * The status bar now displays token usage consistently, including `toks: —` when data is unavailable.

* **Bug Fixes**
  * Improved compatibility with responses that omit usage details or provide only partial token counts.
  * Added support for displaying usage from both standard responses and tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->