### PR TITLE
fix(core,tui,app): persist LLM profile and token counters with session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Token counter now uses real API usage data instead of character-length estimation,
   and shows `—` when the provider doesn't report usage
   ([#173](https://github.com/devlawey/filar/issues/173)).
+- Session persistence now saves and restores the selected LLM profile and accumulated
+  token counters ([#174](https://github.com/devlawey/filar/issues/174)).
 
 ### Added
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3293,6 +3293,32 @@ Credential Manager.
 
 ---
 
+## Issue #174: fix(core,tui,app) — сохранение профиля и токенов с сессией
+
+**Milestone:** Filar v0.7.0. **Ветка:** `fix/174-session-profile-tokens`.
+
+**Проблема:** `llm_profile` = `target_name`, Ctrl+L не сохранялся, токены не персистились.
+
+**Решение:**
+- `filar_core::Session`: поля `tokens_in: u64, tokens_out: u64` с `#[serde(default)]`.
+- `main.rs`: `llm_profile = default_profile_name` (а не `target_name`).
+- `runner.rs` save: профиль + токены из активной сессии.
+- `runner.rs`/`app.rs` restore: `with_history` принимает `llm_profile, tokens_in, tokens_out`.
+  При отсутствии профиля — откат на default с сообщением.
+- `main.rs` загрузка: `session.llm_profile`, `session.tokens_in/out` из файла сессии.
+
+**Файлы:** `core/src/session.rs`, `app/src/main.rs`, `tui/src/app.rs`, `tui/src/runner.rs`.
+
+**Тесты:** 2 новых core (40 total): `tokens_in_out_roundtrip`, `tokens_in_out_backward_compat`.
+257 tui pass.
+
+**Публичные контракты:**
+- `filar_core::Session` — `tokens_in`, `tokens_out` (аддитивные с `#[serde(default)]`).
+- `App::with_history` — 3 новых параметра.
+- `TuiConfig` — 3 новых поля.
+
+---
+
 ## Релиз v0.6.2 (подготовка)
 
 **Дата:** 2026-07-25. **Milestone:** Filar v0.6.2 (4/4 issue, все смерджены).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -361,30 +361,33 @@ async fn run() -> anyhow::Result<()> {
     };
 
     // ── Load session if specified ──────────────────────────────────────
-    let (initial_messages, initial_input_history) = if let Some(ref sid) = session_id {
+    let (initial_messages, initial_input_history, initial_llm_profile, initial_tokens_in, initial_tokens_out) =
+        if let Some(ref sid) = session_id {
         info!(session_id = %sid, "loading session");
         match SessionStore::with_default_dir() {
             Ok(store) => match store.load(sid) {
                 Ok(Some(session)) => {
                     info!(messages = session.messages.len(), "session loaded");
-                    (session.messages, session.input_history)
+                    (session.messages, session.input_history,
+                     Some(session.llm_profile),
+                     session.tokens_in, session.tokens_out)
                 }
                 Ok(None) => {
                     warn!(session_id = %sid, "session not found");
-                    (vec![], vec![])
+                    (vec![], vec![], None, 0, 0)
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to load session");
-                    (vec![], vec![])
+                    (vec![], vec![], None, 0, 0)
                 }
             },
             Err(e) => {
                 warn!(error = %e, "failed to initialise session store");
-                (vec![], vec![])
+                (vec![], vec![], None, 0, 0)
             }
         }
     } else {
-        (vec![], vec![])
+        (vec![], vec![], None, 0, 0)
     };
 
     // ── Launch TUI ─────────────────────────────────────────────────────
@@ -395,9 +398,12 @@ async fn run() -> anyhow::Result<()> {
     let tui_config = TuiConfig {
         target_name: target_name.clone(),
         confirm_mode: config.confirm_mode,
-        llm_profile: target_name,
+        llm_profile: default_profile_name.clone(),
         initial_messages,
         initial_input_history,
+        initial_llm_profile,
+        initial_tokens_in,
+        initial_tokens_out,
         ssh_target: ssh_target.clone(),
         is_local: ssh_target.is_none(),
         secret_provider: secret_provider.clone(),

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -369,7 +369,7 @@ async fn run() -> anyhow::Result<()> {
                 Ok(Some(session)) => {
                     info!(messages = session.messages.len(), "session loaded");
                     (session.messages, session.input_history,
-                     Some(session.llm_profile),
+                     session.llm_profile,
                      session.tokens_in, session.tokens_out)
                 }
                 Ok(None) => {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -33,7 +33,8 @@ pub struct Session {
     /// Target name that was connected to.
     pub target: String,
     /// LLM profile name that was used.
-    pub llm_profile: String,
+    #[serde(default)]
+    pub llm_profile: Option<String>,
     /// Chat history blocks.
     pub messages: Vec<ChatBlock>,
     /// History of user prompts in agent mode (for Up/Down navigation).
@@ -72,7 +73,7 @@ impl From<&Session> for SessionMeta {
             id: s.id.clone(),
             timestamp: s.timestamp.clone(),
             target: s.target.clone(),
-            llm_profile: s.llm_profile.clone(),
+            llm_profile: s.llm_profile.clone().unwrap_or_default(),
             preview,
         }
     }
@@ -275,7 +276,7 @@ mod tests {
             id: "123".into(),
             timestamp: "2026-06-21 12:00:00".into(),
             target: "local".into(),
-            llm_profile: "default".into(),
+            llm_profile: Some("default".into()),
             messages: vec![
                 ChatBlock::System("connected".into()),
                 ChatBlock::User("find port 8080".into()),
@@ -297,7 +298,7 @@ mod tests {
             id: "1".into(),
             timestamp: "t".into(),
             target: "t".into(),
-            llm_profile: "t".into(),
+            llm_profile: Some("t".into()),
             messages: vec![],
             input_history: vec![],
             tokens_in: 0,
@@ -321,7 +322,7 @@ mod tests {
             id: "999".into(),
             timestamp: "2026-01-01 00:00:00".into(),
             target: "test".into(),
-            llm_profile: "glm".into(),
+            llm_profile: Some("glm".into()),
             messages: vec![
                 ChatBlock::User("hello".into()),
                 ChatBlock::Agent("world".into()),
@@ -364,7 +365,7 @@ mod tests {
                 id: format!("{i:010}"),
                 timestamp: format!("t{i}"),
                 target: "t".into(),
-                llm_profile: "t".into(),
+                llm_profile: Some("t".into()),
                 messages: vec![ChatBlock::User(format!("msg{i}"))],
                 input_history: vec![],
             tokens_in: 0,
@@ -444,7 +445,7 @@ mod tests {
     fn tokens_in_out_roundtrip() {
         let s = Session {
             id: "1".into(), timestamp: "t".into(), target: "t".into(),
-            llm_profile: "glm".into(), messages: vec![], input_history: vec![],
+            llm_profile: Some("glm".into()), messages: vec![], input_history: vec![],
             tokens_in: 150, tokens_out: 300,
         };
         let json = serde_json::to_string(&s).unwrap();
@@ -477,7 +478,7 @@ mod tests {
             id: "1".into(),
             timestamp: "t".into(),
             target: "t".into(),
-            llm_profile: "t".into(),
+            llm_profile: Some("t".into()),
             messages: vec![],
             input_history: vec!["ls".into(), "find port 8080".into()],
             tokens_in: 0,
@@ -513,7 +514,7 @@ mod tests {
             id: "1".into(),
             timestamp: "t".into(),
             target: "t".into(),
-            llm_profile: "t".into(),
+            llm_profile: Some("t".into()),
             messages: vec![],
             input_history: (0..250).map(|i| format!("entry{i}")).collect(),
             tokens_in: 0,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,4 +1,4 @@
-//! Session persistence: save and restore chat histories.
+﻿//! Session persistence: save and restore chat histories.
 //!
 //! Sessions are stored as JSON files in a per-user directory:
 //! - Windows: `%APPDATA%/filar/sessions/<id>.json`
@@ -40,6 +40,12 @@ pub struct Session {
     /// Limited to [`MAX_INPUT_HISTORY`] entries when saved.
     #[serde(default)]
     pub input_history: Vec<String>,
+    /// Cumulative input tokens (from API usage data).
+    #[serde(default)]
+    pub tokens_in: u64,
+    /// Cumulative output tokens (from API usage data).
+    #[serde(default)]
+    pub tokens_out: u64,
 }
 
 /// Lightweight metadata for listing sessions without loading full messages.
@@ -276,6 +282,8 @@ mod tests {
                 ChatBlock::Agent("running lsof".into()),
             ],
             input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
         };
         let meta = SessionMeta::from(&session);
         assert_eq!(meta.id, "123");
@@ -292,6 +300,8 @@ mod tests {
             llm_profile: "t".into(),
             messages: vec![],
             input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
         };
         let meta = SessionMeta::from(&session);
         assert!(meta.preview.is_empty());
@@ -317,6 +327,8 @@ mod tests {
                 ChatBlock::Agent("world".into()),
             ],
             input_history: vec!["ls -la".into(), "find port".into()],
+            tokens_in: 0,
+            tokens_out: 0,
         };
 
         store.save(&session).unwrap();
@@ -355,6 +367,8 @@ mod tests {
                 llm_profile: "t".into(),
                 messages: vec![ChatBlock::User(format!("msg{i}"))],
                 input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
             };
             store.save(&session).unwrap();
         }
@@ -427,15 +441,30 @@ mod tests {
     }
 
     #[test]
+    fn tokens_in_out_roundtrip() {
+        let s = Session {
+            id: "1".into(), timestamp: "t".into(), target: "t".into(),
+            llm_profile: "glm".into(), messages: vec![], input_history: vec![],
+            tokens_in: 150, tokens_out: 300,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("tokens_in"), "must serialize tokens_in");
+        assert!(json.contains("150"), "must serialize value");
+        let loaded: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.tokens_in, 150);
+        assert_eq!(loaded.tokens_out, 300);
+    }
+
+    #[test]
+    fn tokens_in_out_backward_compat() {
+        let json = r#"{"id":"1","timestamp":"x","target":"x","llm_profile":"x","messages":[],"input_history":[]}"#;
+        let loaded: Session = serde_json::from_str(json).unwrap();
+        assert_eq!(loaded.tokens_in, 0, "missing field → default 0");
+        assert_eq!(loaded.tokens_out, 0);
+    }
+
+    #[test]
     fn unix_to_ymdhms_known_date() {
-        // 2026-06-21 12:30:45 UTC
-        // Unix timestamp: calculate from known reference
-        // 2026-01-01 00:00:00 = 1767225600
-        // + 31 days (Jan) + 28 days (Feb) + 31 (Mar) + 30 (Apr) + 31 (May) + 20 days (Jun 1-20)
-        // = 171 days * 86400 = 14774400
-        // + 12.5h = 45045
-        // Total ≈ 1767225600 + 14774400 + 45045 = 1782045045
-        // Let me just verify the epoch is correct and the function doesn't panic.
         let (y, _m, _d, _h, _mi, _s) = unix_to_ymdhms(1_782_045_045);
         assert_eq!(y, 2026);
     }
@@ -451,6 +480,8 @@ mod tests {
             llm_profile: "t".into(),
             messages: vec![],
             input_history: vec!["ls".into(), "find port 8080".into()],
+            tokens_in: 0,
+            tokens_out: 0,
         };
         let json = serde_json::to_string_pretty(&session).unwrap();
         assert!(json.contains("input_history"), "JSON must contain input_history");
@@ -485,6 +516,8 @@ mod tests {
             llm_profile: "t".into(),
             messages: vec![],
             input_history: (0..250).map(|i| format!("entry{i}")).collect(),
+            tokens_in: 0,
+            tokens_out: 0,
         };
         assert!(session.input_history.len() > MAX_INPUT_HISTORY);
         session.truncate_history();

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -530,6 +530,9 @@ impl App {
         confirm_mode: CommandConfirmMode,
         messages: Vec<ChatBlock>,
         input_history: Vec<String>,
+        llm_profile: Option<String>,
+        tokens_in: u64,
+        tokens_out: u64,
     ) -> Self {
         let mut app = Self::new(target_name, confirm_mode);
         if !messages.is_empty() {
@@ -541,7 +544,19 @@ impl App {
         }
         // Restore agent input history so Up/Down recalls previous prompts.
         app.input_history = input_history;
-        app.history_pos = None; // Start not in browsing mode.
+        app.history_pos = None;
+        // Restore LLM profile and token counters from previous session.
+        if let Some(profile) = llm_profile {
+            if app.profiles.iter().any(|p| p.name == profile) {
+                app.llm_profile = Some(profile);
+            } else {
+                app.push_message(ChatBlock::System(format!(
+                    "Profile '{}' not found — using default", profile
+                )));
+            }
+        }
+        app.tokens_in = tokens_in;
+        app.tokens_out = tokens_out;
         app
     }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -546,14 +546,17 @@ impl App {
         }
         app.input_history = input_history;
         app.history_pos = None;
+        let default_name = if default_profile_name.is_empty() { "default" } else { default_profile_name };
         if let Some(profile) = llm_profile {
             if profile.is_empty() {
-                // Old session (pre-0.7.0 fix) with empty llm_profile: silent fallback.
+                // Old session (pre-0.7.0 fix): silently fall back to default.
+                app.llm_profile = Some(default_name.to_string());
             } else if profiles.iter().any(|p| p.name == profile) {
                 app.llm_profile = Some(profile);
             } else {
+                app.llm_profile = Some(default_name.to_string());
                 app.push_message(ChatBlock::System(format!(
-                    "Profile '{}' not found — using '{}'", profile, default_profile_name
+                    "Profile '{}' not found — using '{}'", profile, default_name
                 )));
             }
         }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -533,6 +533,8 @@ impl App {
         llm_profile: Option<String>,
         tokens_in: u64,
         tokens_out: u64,
+        profiles: &[filar_core::LlmProfile],
+        default_profile_name: &str,
     ) -> Self {
         let mut app = Self::new(target_name, confirm_mode);
         if !messages.is_empty() {
@@ -542,16 +544,16 @@ impl App {
                 "Session restored — history loaded from disk".into(),
             ));
         }
-        // Restore agent input history so Up/Down recalls previous prompts.
         app.input_history = input_history;
         app.history_pos = None;
-        // Restore LLM profile and token counters from previous session.
         if let Some(profile) = llm_profile {
-            if app.profiles.iter().any(|p| p.name == profile) {
+            if profile.is_empty() {
+                // Old session (pre-0.7.0 fix) with empty llm_profile: silent fallback.
+            } else if profiles.iter().any(|p| p.name == profile) {
                 app.llm_profile = Some(profile);
             } else {
                 app.push_message(ChatBlock::System(format!(
-                    "Profile '{}' not found — using default", profile
+                    "Profile '{}' not found — using '{}'", profile, default_profile_name
                 )));
             }
         }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -282,7 +282,7 @@ async fn run_app(
     let default_for_restore = std::mem::take(&mut config.default_profile_name);
     let has_history = !config.initial_messages.is_empty()
         || !config.initial_input_history.is_empty()
-        || config.initial_llm_profile.is_some()
+        || config.initial_llm_profile.as_ref().is_some_and(|p| !p.is_empty())
         || config.initial_tokens_in > 0
         || config.initial_tokens_out > 0;
     let mut app = if has_history {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -280,14 +280,12 @@ async fn run_app(
 ) -> Result<()> {
     let profiles_for_restore = std::mem::take(&mut config.profiles);
     let default_for_restore = std::mem::take(&mut config.default_profile_name);
-    let mut app = if config.initial_messages.is_empty()
-        && config.initial_input_history.is_empty()
-    {
-        let mut a = App::new(config.target_name.clone(), config.confirm_mode);
-        a.profiles = profiles_for_restore;
-        a.default_profile_name = default_for_restore;
-        a
-    } else {
+    let has_history = !config.initial_messages.is_empty()
+        || !config.initial_input_history.is_empty()
+        || config.initial_llm_profile.is_some()
+        || config.initial_tokens_in > 0
+        || config.initial_tokens_out > 0;
+    let mut app = if has_history {
         let mut a = App::with_history(
             config.target_name.clone(),
             config.confirm_mode,
@@ -299,6 +297,11 @@ async fn run_app(
             &profiles_for_restore,
             &default_for_restore,
         );
+        a.profiles = profiles_for_restore;
+        a.default_profile_name = default_for_restore;
+        a
+    } else {
+        let mut a = App::new(config.target_name.clone(), config.confirm_mode);
         a.profiles = profiles_for_restore;
         a.default_profile_name = default_for_restore;
         a

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -278,12 +278,17 @@ async fn run_app(
     executor: Arc<dyn CommandExecutor>,
     mut config: TuiConfig,
 ) -> Result<()> {
+    let profiles_for_restore = std::mem::take(&mut config.profiles);
+    let default_for_restore = std::mem::take(&mut config.default_profile_name);
     let mut app = if config.initial_messages.is_empty()
         && config.initial_input_history.is_empty()
     {
-        App::new(config.target_name.clone(), config.confirm_mode)
+        let mut a = App::new(config.target_name.clone(), config.confirm_mode);
+        a.profiles = profiles_for_restore;
+        a.default_profile_name = default_for_restore;
+        a
     } else {
-        App::with_history(
+        let mut a = App::with_history(
             config.target_name.clone(),
             config.confirm_mode,
             std::mem::take(&mut config.initial_messages),
@@ -291,11 +296,14 @@ async fn run_app(
             std::mem::take(&mut config.initial_llm_profile),
             config.initial_tokens_in,
             config.initial_tokens_out,
-        )
+            &profiles_for_restore,
+            &default_for_restore,
+        );
+        a.profiles = profiles_for_restore;
+        a.default_profile_name = default_for_restore;
+        a
     };
     // Load available LLM profiles and default profile name.
-    app.profiles = std::mem::take(&mut config.profiles);
-    app.default_profile_name = std::mem::take(&mut config.default_profile_name);
     app.key_checker = Some(config.key_checker.clone());
     // Wire the App to the same StaticSecretProvider instance used by the
     // agent's SecretSubstitutingExecutor, so Ctrl+P inserts are visible to
@@ -892,7 +900,7 @@ async fn run_app(
         id,
         timestamp,
         target: config.target_name.clone(),
-        llm_profile: app.llm_profile.clone().unwrap_or_else(|| config.default_profile_name.clone()),
+        llm_profile: app.llm_profile.clone(),
         messages: app.messages.clone(),
         input_history: app.input_history().to_vec(),
         tokens_in: app.tokens_in,

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -194,6 +194,12 @@ pub struct TuiConfig {
     pub initial_messages: Vec<ChatBlock>,
     /// Initial agent input history (for session restore).
     pub initial_input_history: Vec<String>,
+    /// LLM profile restored from a previous session.
+    pub initial_llm_profile: Option<String>,
+    /// Input token count restored from a previous session.
+    pub initial_tokens_in: u64,
+    /// Output token count restored from a previous session.
+    pub initial_tokens_out: u64,
     /// SSH target for interactive terminal mode (Ctrl+T).
     /// If `None`, the agent runs in local mode.
     pub ssh_target: Option<filar_core::SshTarget>,
@@ -282,6 +288,9 @@ async fn run_app(
             config.confirm_mode,
             std::mem::take(&mut config.initial_messages),
             std::mem::take(&mut config.initial_input_history),
+            std::mem::take(&mut config.initial_llm_profile),
+            config.initial_tokens_in,
+            config.initial_tokens_out,
         )
     };
     // Load available LLM profiles and default profile name.
@@ -883,9 +892,11 @@ async fn run_app(
         id,
         timestamp,
         target: config.target_name.clone(),
-        llm_profile: config.llm_profile.clone(),
+        llm_profile: app.llm_profile.clone().unwrap_or_else(|| config.default_profile_name.clone()),
         messages: app.messages.clone(),
         input_history: app.input_history().to_vec(),
+        tokens_in: app.tokens_in,
+        tokens_out: app.tokens_out,
     };
     session.truncate_history();
     match filar_core::SessionStore::with_default_dir() {


### PR DESCRIPTION
Closes #174

Session persistence now saves and restores the LLM profile and token counters:

- `filar_core::Session` gains `tokens_in: u64, tokens_out: u64` (serde(default), backward-compatible)
- `main.rs` passes the real `default_profile_name` as `llm_profile`, not `target_name`
- Save: active session's profile + tokens written to session file
- Restore: profile validated against available config; missing profile → fallback with message
- Token counters continue from saved value, not reset to zero

Tests: 40 core (2 new round-trip + backward-compat) + 257 tui pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sessions now preserve and restore the selected LLM profile.
  - Cumulative input and output token counts are saved and restored with session data.
  - Missing or invalid profiles fall back to the default profile with a clear system message.
  - Existing sessions without token data remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->