### PR TITLE
chore(core,docs): align SessionMeta.llm_profile with Session, re-export KeyringSecretProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,43 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [0.7.0] - 2026-07-27
 
+### Added
+
+- GUI launcher now has a Models tab with add/delete profile management; each profile
+  stores its API key in the OS credential store independently
+  ([#162](https://github.com/devlawey/filar/issues/162)).
+- Ctrl+L now cycles through LLM profiles per tab; each session can use a different
+  model without affecting other tabs
+  ([#163](https://github.com/devlawey/filar/issues/163)).
+- Clipboard paste now works via Ctrl+V and bracketed paste in agent input, interactive
+  terminal, and password prompt
+  ([#153](https://github.com/devlawey/filar/issues/153)).
+- Token usage counter shown in the status bar (v1: character-length estimation) per
+  session ([#164](https://github.com/devlawey/filar/issues/164)).
+- `config.toml` is now searched in `%APPDATA%\filar\` first (unified config location),
+  then CWD, then next to the executable
+  ([#161](https://github.com/devlawey/filar/issues/161)).
+
+### Changed
+
+- `config.toml` search order: CWD before app-data (local `./config.toml` now
+  overrides `%APPDATA%\filar\`)
+  ([#175](https://github.com/devlawey/filar/issues/175)).
+- README updated with all 0.7.0 features: Models tab, Ctrl+L, token counter,
+  config priority, key storage
+  ([#175](https://github.com/devlawey/filar/issues/175)).
+- Engine API: `SessionMeta.llm_profile` now matches `Session.llm_profile`
+  (`Option<String>`), and `KeyringSecretProvider` is re-exported alongside the
+  other secret providers ([#181](https://github.com/devlawey/filar/issues/181)).
+
 ### Fixed
 
+- API keys and SSH passwords are no longer written in plain text to
+  `pending_launch.json`; secrets are read from the OS credential store instead
+  ([#159](https://github.com/devlawey/filar/issues/159)).
+- `Settings::save` and `save_pending_launch` now create their parent directory before
+  writing, preventing silent data loss when `%APPDATA%\filar` doesn't exist
+  ([#160](https://github.com/devlawey/filar/issues/160)).
 - Switching LLM profiles with Ctrl+L now resolves the profile's API key from the OS
   credential store, not just the in-memory key of the launched profile
   ([#171](https://github.com/devlawey/filar/issues/171)).
@@ -27,39 +62,6 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   ([#173](https://github.com/devlawey/filar/issues/173)).
 - Session persistence now saves and restores the selected LLM profile and accumulated
   token counters ([#174](https://github.com/devlawey/filar/issues/174)).
-
-### Changed
-
-- `config.toml` search order: CWD before app-data (local `./config.toml` now
-  overrides `%APPDATA%\filar\`)
-  ([#175](https://github.com/devlawey/filar/issues/175)).
-- README updated with all 0.7.0 features: Models tab, Ctrl+L, token counter,
-  config priority, key storage
-  ([#175](https://github.com/devlawey/filar/issues/175)).
-
-### Added
-
-- GUI launcher now has a Models tab with add/delete profile management; each profile
-  stores its API key in the OS credential store independently
-  ([#162](https://github.com/devlawey/filar/issues/162)).
-- Ctrl+L now cycles through LLM profiles per tab; each session can use a different
-  model without affecting other tabs
-  ([#163](https://github.com/devlawey/filar/issues/163)).
-- Token usage counter now uses real API response data (`usage.prompt_tokens` /
-  `completion_tokens`) instead of character-length estimation
-  ([#173](https://github.com/devlawey/filar/issues/173)).
-
-### Fixed
-
-- API keys and SSH passwords are no longer written in plain text to
-  `pending_launch.json`; secrets are read from the OS credential store instead
-  ([#159](https://github.com/devlawey/filar/issues/159)).
-- `Settings::save` and `save_pending_launch` now create their parent directory before
-  writing, preventing silent data loss when `%APPDATA%\filar` doesn't exist
-  ([#160](https://github.com/devlawey/filar/issues/160)).
-- `config.toml` is now searched in `%APPDATA%\filar\` first (unified config location),
-  then CWD, then next to the executable
-  ([#161](https://github.com/devlawey/filar/issues/161)).
 
 ## [0.6.2] - 2026-07-25
 
@@ -118,15 +120,6 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   (supersedes the 0.5.1 exit-on-switch behavior)
   ([#115](https://github.com/devlawey/filar/issues/115)).
 
-### Fixed
-
-- Per-tab interactive terminals are torn down on tab close and app exit, and
-  background EOF/errors retire a tab's terminal without disturbing the active
-  tab ([#116](https://github.com/devlawey/filar/issues/116)).
-- Window resize now propagates to every live per-tab terminal (model and backend),
-  not just the active one, so background terminals stay correctly sized
-  ([#117](https://github.com/devlawey/filar/issues/117)).
-
 ### Added
 
 - Background terminal output marks its tab with a new-output indicator that
@@ -139,6 +132,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- Per-tab interactive terminals are torn down on tab close and app exit, and
+  background EOF/errors retire a tab's terminal without disturbing the active
+  tab ([#116](https://github.com/devlawey/filar/issues/116)).
+- Window resize now propagates to every live per-tab terminal (model and backend),
+  not just the active one, so background terminals stay correctly sized
+  ([#117](https://github.com/devlawey/filar/issues/117)).
 - Interactive scrollbar now responds to mouse drag; it was previously only
   controllable via PgUp/PgDn keys
   ([#119](https://github.com/devlawey/filar/issues/119)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Engine API consistency: `SessionMeta.llm_profile` now matches `Session.llm_profile`
+  (`Option<String>`), and `KeyringSecretProvider` is re-exported alongside the other
+  secret providers ([#181](https://github.com/devlawey/filar/issues/181)).
+
 ## [0.7.0] - 2026-07-27
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3347,9 +3347,11 @@ Credential Manager.
 - CHANGELOG 0.7.0 и 0.6.0: дубликаты `### Fixed` слиты, порядок разделов исправлен.
 - Задокументирована смена типа `llm_profile` в CHANGELOG.
 
-**Файлы:** `core/src/session.rs`, `core/src/lib.rs`, `app/src/main.rs`, `CHANGELOG.md`.
+**Файлы:** `crates/core/src/session.rs`, `crates/core/src/lib.rs`, `crates/app/src/main.rs`, `CHANGELOG.md`.
 
 **Тесты:** 410 pass, без регрессии. Поведение приложения не меняется.
+
+**Дальнейшие шаги:** нет. Задача завершена.
 
 ---
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3336,6 +3336,23 @@ Credential Manager.
 
 ---
 
+## Issue #181: chore(core,docs) — API consistency + CHANGELOG cleanup
+
+**Milestone:** Filar v0.7.1. **Ветка:** `chore/181-api-consistency`.
+
+**Решение:**
+- `SessionMeta.llm_profile` → `Option<String>` (согласован с `Session`).
+- `KeyringSecretProvider` ре-экспортирован из `filar_core`.
+- `main.rs` использует короткий путь `filar_core::KeyringSecretProvider`.
+- CHANGELOG 0.7.0 и 0.6.0: дубликаты `### Fixed` слиты, порядок разделов исправлен.
+- Задокументирована смена типа `llm_profile` в CHANGELOG.
+
+**Файлы:** `core/src/session.rs`, `core/src/lib.rs`, `app/src/main.rs`, `CHANGELOG.md`.
+
+**Тесты:** 410 pass, без регрессии. Поведение приложения не меняется.
+
+---
+
 ## Релиз v0.7.0 (подготовка)
 
 **Дата:** 2026-07-27. **Milestone:** Filar v0.7.0 (5/5 issue, все смерджены).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1,4 +1,4 @@
-//! `filar` — terminal with an AI agent over SSH.
+﻿//! `filar` — terminal with an AI agent over SSH.
 //!
 //! Entry point: initialise logging, load configuration, then either launch the
 //! GUI launcher (no CLI args) or go straight to the TUI (with `--target`,
@@ -254,7 +254,7 @@ async fn run() -> anyhow::Result<()> {
                 // (since the struct now excludes secrets from serialization).
                 let ssh_target = launch.ssh.map(|s| {
                     let password = if s.password.is_empty() {
-                        let cred = filar_core::secrets::KeyringSecretProvider::new();
+                        let cred = filar_core::KeyringSecretProvider::new();
                         let name = format!("ssh{}", s.slot);
                         cred.get(&name)
                             .inspect_err(|e| tracing::debug!(error = %e, %name, "no saved SSH password in keyring"))
@@ -276,7 +276,7 @@ async fn run() -> anyhow::Result<()> {
 
                 // Read API key from OS credential store using the profile's key_env.
                 let api_key = if launch.api_key.is_empty() {
-                    let cred = filar_core::secrets::KeyringSecretProvider::new();
+                    let cred = filar_core::KeyringSecretProvider::new();
                     let key_name = if launch.key_env.is_empty() { "api_key".to_string() } else { launch.key_env.clone() };
                     cred.get(&key_name)
                         .inspect_err(|e| tracing::warn!(error = %e, %key_name, "failed to read API key from OS credential store"))
@@ -416,7 +416,7 @@ async fn run() -> anyhow::Result<()> {
             let mut checked = "in-memory secret provider, ";
             let key = if key.is_empty() {
                 checked = "in-memory provider, OS credential store, ";
-                let keyring = filar_core::secrets::KeyringSecretProvider::new();
+                let keyring = filar_core::KeyringSecretProvider::new();
                 let kr_key = keyring.get(&profile.key_env).ok().unwrap_or_default();
                 if !kr_key.is_empty() {
                     // Cache for subsequent calls so we don't hit keyring again.
@@ -443,7 +443,7 @@ async fn run() -> anyhow::Result<()> {
         key_checker: Arc::new(move |profile: &filar_core::LlmProfile| {
             let key = key_checker_provider.get(&profile.key_env).unwrap_or_default();
             if !key.is_empty() { return None; }
-            let keyring = filar_core::secrets::KeyringSecretProvider::new();
+            let keyring = filar_core::KeyringSecretProvider::new();
             match keyring.get(&profile.key_env) {
                 Ok(k) if !k.is_empty() => {
                     key_checker_provider.insert(&profile.key_env, &k);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,5 +14,5 @@ pub mod session;
 pub use chat::ChatBlock;
 pub use config::{Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig, HostKeyPolicy};
 pub use error::{CoreError, Result};
-pub use secrets::{EnvSecretProvider, SecretProvider, StaticSecretProvider};
+pub use secrets::{EnvSecretProvider, KeyringSecretProvider, SecretProvider, StaticSecretProvider};
 pub use session::{default_base_dir, Session, SessionMeta, SessionStore};

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -55,7 +55,7 @@ pub struct SessionMeta {
     pub id: String,
     pub timestamp: String,
     pub target: String,
-    pub llm_profile: String,
+    pub llm_profile: Option<String>,
     /// Preview of the first user message (or system message).
     pub preview: String,
 }
@@ -73,7 +73,7 @@ impl From<&Session> for SessionMeta {
             id: s.id.clone(),
             timestamp: s.timestamp.clone(),
             target: s.target.clone(),
-            llm_profile: s.llm_profile.clone().unwrap_or_default(),
+            llm_profile: s.llm_profile.clone(),
             preview,
         }
     }


### PR DESCRIPTION
Closes #181

Four housekeeping fixes, no behavior change:

1. `SessionMeta.llm_profile` → `Option<String>` — aligned with `Session`
2. `KeyringSecretProvider` re-exported from `filar_core`; `main.rs` uses short path
3. CHANGELOG: duplicate `### Fixed` sections in 0.7.0 and 0.6.0 merged; section order fixed
4. Engine API consistency documented in CHANGELOG

Tests: 410 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the unreleased v0.7.0 changelog into clearer Added, Changed, and Fixed sections.
  * Documented GUI launcher models, per-tab profile switching, paste support, token usage reporting, configuration search order, and profile persistence updates.
  * Corrected the placement of earlier terminal teardown and window-resize fixes.
  * Added progress notes covering API consistency and credential-provider updates.

* **Changed**
  * Session metadata now preserves whether an LLM profile is selected, rather than representing an absent profile as an empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->