### PR TITLE
fix(core,security): redact secret names in error messages to prevent key leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - LLM client construction passed the resolved API key where a secret *name* was
   expected, so every agent request failed and the key value was shown in the error
   message ([#183](https://github.com/devlawey/filar/issues/183)).
+- Secret lookup failures no longer embed the looked-up name in the error message,
+  closing a path that leaked an API key into the UI
+  ([#184](https://github.com/devlawey/filar/issues/184)).
 
 ### Changed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3388,6 +3388,40 @@ Credential Manager.
 
 ---
 
+## Issue #184: fix(core,security) — имя секрета не должно попадать в текст ошибки
+
+**Milestone:** Filar v0.7.1 (блокер). **Ветка:** `fix/184-redact-secret-names`.
+
+**Проблема:** `EnvSecretProvider::get` и `StaticSecretProvider::get` подставляли
+искомое имя напрямую в `.ok_or_else(|| CoreError::Secret(format!("{name} not set or empty")))`.
+Если в позицию имени попадёт значение ключа (как в #183: `new_with_provider(&key_value, ...)`),
+ключ окажется в тексте ошибки на экране. Канал утечки был открыт по построению.
+
+**Решение:**
+1. Хелпер `redact(s: &str) -> String` в `filar_core::secrets`: первые 4 символа + `… (len N)`.
+   Диагностируемость сохраняется (видно префикс и длину), значение в сообщение не попадает.
+2. Применён в трёх провайдерах: `EnvSecretProvider::get`, `StaticSecretProvider::get`,
+   `KeyringSecretProvider::get` — все три места подстановки `{name}` и `{name}: {e}`.
+3. Применён в `main.rs::build_llm_client_from_profile` для `profile.name`.
+4. Аудит остальных `CoreError::Secret` — в `transport/ssh.rs` имя не подставляется
+   (оборачивается `{e}` из провайдера), безопасно.
+5. Тесты: `redact_normal_name_keeps_prefix_and_shows_length`, `redact_short_name`,
+   `error_message_does_not_contain_secret_value` (ключ `sk-or-v1-...` не попадает в ошибку),
+   `env_provider_redacted_on_missing_secret`, `static_provider_redacted_on_missing_secret`.
+
+**Изменённые файлы:**
+- `crates/core/src/secrets.rs` — `redact()` + применение в 3 провайдерах + 5 тестов
+- `crates/core/src/lib.rs` — ре-экспорт `redact`
+- `crates/app/src/main.rs` — `redact(&profile.name)`
+
+**Публичные контракты:** `filar_core::secrets::redact(s: &str) -> String` — новая
+публичная функция (экспортируется из `filar_core`).
+
+**DoD (требует ручной проверки):** запуск бинарника с несуществующим именем секрета
+в профиле → осмысленная ошибка без секретных данных.
+
+---
+
 ## Релиз v0.7.0 (подготовка)
 
 **Дата:** 2026-07-27. **Milestone:** Filar v0.7.0 (5/5 issue, все смерджены).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -110,7 +110,7 @@ pub fn build_llm_client_from_profile(
     if key.is_empty() {
         return Err(filar_core::CoreError::Secret(format!(
             "no API key found for profile {}",
-            filar_core::redact(&profile.name)
+            profile.name
         )));
     }
     let llm_config: filar_core::LlmConfig = profile.into();

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -110,7 +110,7 @@ pub fn build_llm_client_from_profile(
     if key.is_empty() {
         return Err(filar_core::CoreError::Secret(format!(
             "no API key found for profile {}",
-            profile.name
+            filar_core::redact(&profile.name)
         )));
     }
     let llm_config: filar_core::LlmConfig = profile.into();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,5 +14,5 @@ pub mod session;
 pub use chat::ChatBlock;
 pub use config::{Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig, HostKeyPolicy};
 pub use error::{CoreError, Result};
-pub use secrets::{EnvSecretProvider, KeyringSecretProvider, SecretProvider, StaticSecretProvider};
+pub use secrets::{EnvSecretProvider, KeyringSecretProvider, SecretProvider, StaticSecretProvider, redact};
 pub use session::{default_base_dir, Session, SessionMeta, SessionStore};

--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -75,7 +75,7 @@ impl SecretProvider for EnvSecretProvider {
         std::env::var(env_name)
             .ok()
             .filter(|v| !v.is_empty())
-            .ok_or_else(|| CoreError::Secret(format!("{name} not set or empty")))
+            .ok_or_else(|| CoreError::Secret(format!("{} not set or empty", redact(name))))
     }
 
     fn secret_names(&self) -> Vec<String> {
@@ -166,7 +166,7 @@ impl SecretProvider for StaticSecretProvider {
             .get(name)
             .filter(|v| !v.is_empty())
             .cloned()
-            .ok_or_else(|| CoreError::Secret(format!("{name} not set or empty")))
+            .ok_or_else(|| CoreError::Secret(format!("{} not set or empty", redact(name))))
     }
 
     fn secret_names(&self) -> Vec<String> {
@@ -190,6 +190,30 @@ impl Drop for StaticSecretProvider {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Redaction helper
+// ---------------------------------------------------------------------------
+
+/// Redact a potentially sensitive string for use in error messages.
+///
+/// Shows the first 4 characters and the total length, e.g. `"glm_… (len 11)"`.
+/// Preserves diagnostics (you can tell which secret is missing) while ensuring
+/// that a full secret value cannot appear in user-facing text even if passed by
+/// mistake in place of a secret name.
+///
+/// # Examples
+///
+/// ```
+/// use filar_core::secrets::redact;
+/// assert_eq!(redact("GLM_API_KEY"), "GLM_… (len 11)".to_string());
+/// assert_eq!(redact("sk-or-v1-abc123def456"), "sk-o… (len 21)".to_string());
+/// ```
+pub fn redact(s: &str) -> String {
+    let prefix: String = s.chars().take(4).collect();
+    let len = s.len();
+    format!("{prefix}… (len {len})")
 }
 
 // ---------------------------------------------------------------------------
@@ -257,7 +281,7 @@ impl SecretProvider for KeyringSecretProvider {
             .map_err(|e| CoreError::Secret(format!("keyring entry error: {e}")))?;
         entry
             .get_password()
-            .map_err(|e| CoreError::Secret(format!("keyring get failed for {name}: {e}")))
+            .map_err(|e| CoreError::Secret(format!("keyring get failed for {}: {e}", redact(name))))
     }
 
     fn secret_names(&self) -> Vec<String> {
@@ -410,5 +434,59 @@ mod tests {
         assert!(names.contains(&"$FILAR_SECRET_TEST_B".to_string()));
         std::env::remove_var("FILAR_SECRET_TEST_A");
         std::env::remove_var("FILAR_SECRET_TEST_B");
+    }
+
+    // ── Redaction tests (#184) ─────────────────────────────────────────
+
+    #[test]
+    fn redact_normal_name_keeps_prefix_and_shows_length() {
+        let result = redact("GLM_API_KEY");
+        assert_eq!(result, "GLM_… (len 11)");
+    }
+
+    #[test]
+    fn redact_short_name_shows_all_chars() {
+        let result = redact("ab");
+        assert_eq!(result, "ab… (len 2)");
+    }
+
+    #[test]
+    fn error_message_does_not_contain_secret_value() {
+        let key_value = "sk-or-v1-1234567890abcdef1234567890abcdef";
+        let provider = StaticSecretProvider::new();
+        // Mistakenly pass the key value as if it were the name.
+        let err = provider.get(key_value).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            !msg.contains(key_value),
+            "error must NOT contain the full key value '{key_value}', got: {msg}"
+        );
+        // The redacted form (prefix + length) should be present.
+        assert!(
+            msg.contains("sk-o"),
+            "error must contain the redacted prefix, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn env_provider_redacted_on_missing_secret() {
+        let name = "sk-or-v1-leaked-key-12345678";
+        let provider = EnvSecretProvider::new();
+        let err = provider.get(name).unwrap_err();
+        let msg = format!("{err}");
+        let expected_prefix = redact(name);
+        assert!(!msg.contains(name));
+        assert!(msg.contains(&expected_prefix));
+    }
+
+    #[test]
+    fn static_provider_redacted_on_missing_secret() {
+        let name = "another-secret-key-that-could-leak";
+        let provider = StaticSecretProvider::new();
+        let err = provider.get(name).unwrap_err();
+        let msg = format!("{err}");
+        let expected_prefix = redact(name);
+        assert!(!msg.contains(name));
+        assert!(msg.contains(&expected_prefix));
     }
 }

--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -212,7 +212,7 @@ impl Drop for StaticSecretProvider {
 /// ```
 pub fn redact(s: &str) -> String {
     let prefix: String = s.chars().take(4).collect();
-    let len = s.len();
+    let len = s.chars().count();
     format!("{prefix}… (len {len})")
 }
 


### PR DESCRIPTION
Closes #184

## Summary

`EnvSecretProvider::get`, `StaticSecretProvider::get`, and `KeyringSecretProvider::get` embedded the raw lookup name (`{name}`) in `CoreError::Secret` messages. If a key **value** ended up in the name position (as happened in #183), the full key appeared in the UI error text.

This PR introduces a `redact()` helper that shows only the first 4 characters + `… (len N)`, preserving diagnostics while making it impossible for a full secret value to appear even if passed by mistake.

## Changes

1. **`redact(s: &str) -> String`** — new public function in `filar_core::secrets`. Shows prefix (4 chars) + length. Re-exported from `filar_core`.
2. **Applied in all 3 secret providers:**
   - `EnvSecretProvider::get`: `{name} not set or empty` → `{redacted} not set or empty`
   - `StaticSecretProvider::get`: same
   - `KeyringSecretProvider::get`: `keyring get failed for {name}: {e}` → `keyring get failed for {redacted}: {e}`
3. **`build_llm_client_from_profile` in `main.rs`** — `profile.name` also redacted for defense-in-depth.
4. **Audited other `CoreError::Secret` sites** — `ssh.rs` wraps `{e}` from provider (already redacted), no raw names exposed.

## Test results

| Crate | Tests |
|-------|-------|
| filar-agent | 64 passed |
| filar-app | 8 passed |
| filar-core | 46 passed (41 existing + 5 new) |
| filar-gui | 8 passed |
| filar-transport | 24 passed, 7 ignored (Docker) |
| filar-tui | 257 passed |
| Doc-tests | 2 passed |

**Total: 407 passed, 0 failed, 7 ignored (Docker sshd)**

New tests:
- `redact_normal_name_keeps_prefix_and_shows_length` — `GLM_… (len 11)`
- `redact_short_name_shows_all_chars` — `ab… (len 2)`
- `error_message_does_not_contain_secret_value` — key-like string `sk-or-v1-…` not in error
- `env_provider_redacted_on_missing_secret` — redacted in env provider
- `static_provider_redacted_on_missing_secret` — redacted in static provider

New tests were verified to **fail on old code** by temporarily reverting the `redact()` call.

## Manual smoke test (required)

- [ ] Build: `cargo build --release`
- [ ] Profile with non-existent secret name → error is meaningful and free of secret-looking data

## Public contracts

- NEW: `filar_core::secrets::redact(s: &str) -> String` — public helper for redacting sensitive strings