### PR TITLE
feat(app,tui): support password targets in Ctrl+O via keyring/env/interactive prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - `Ctrl+O` cycles through SSH targets defined in `config.toml` (plus `local`),
   showing the target alias in the status bar and reconnecting only the active tab
   ([#200](https://github.com/devlawey/filar/issues/200)).
+- SSH targets using password authentication are now supported by `Ctrl+O`, with
+  the password resolved from the OS credential store, environment, or an
+  interactive prompt ([#201](https://github.com/devlawey/filar/issues/201)).
 
 ## [0.7.4] - 2026-07-31
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3623,6 +3623,41 @@ ChatResponse), transport (SshConnection). Тег `engine-v0.7.0` ставитс�
 
 ---
 
+## Issue #201: feat(app,tui,gui) — парольные цели при Ctrl+O
+
+**Milestone:** Filar v0.8.0. **Ветка:** `feat/201-password-targets`.
+
+**Цель:** довести `Ctrl+O` до полного набора целей — `SshAuth::Password`.
+
+**Первопричина:** в #200 парольные цели намеренно отклонялись с сообщением.
+
+**Решение:**
+1. Порядок разрешения пароля (runner.rs): явный в конфиге (с warn! в лог) →
+   `ssh_target:<name>` в OS keyring → `SSH_PASSWORD` env → `PasswordNeeded`.
+2. `TuiEvent::PasswordNeeded { session_id, target }` — переключает UI в режим
+   ввода пароля (как `Ctrl+P`), сохраняет цель в `ctrl_o_pending_target`.
+3. После ввода пароля → `ctrl_o_needs_connect = true`, `pending_ssh_password = Some(...)`.
+4. Runner подхватывает пароль + цель и выполняет подключение.
+5. Пароли из конфига логируются с предупреждением (но не в тексте ошибок).
+6. Тесты: `password_needed` выставляет pending state; пароль retriggers connect.
+
+**Вне текущего скоупа:**
+- Сохранение пароля в keyring после успешного коннекта (отдельно).
+- Раздел целей в лаунчере (отдельно).
+
+**Изменённые файлы:**
+- `crates/tui/src/event.rs` — `PasswordNeeded` variant
+- `crates/tui/src/app.rs` — `ctrl_o_pending_target`, handler, 2 теста
+- `crates/tui/src/runner.rs` — password resolution + re-trigger connect
+
+**Публичные контракты:** `TuiEvent::PasswordNeeded` — новый variant (аддитивно).
+
+**DoD (требует ручной проверки):** цель с паролем в keyring → без вопросов;
+`SSH_PASSWORD` → работает; без пароля → запрос → подключение; пароля нет в
+config.toml и логах. Прогон невозможен без SSH-целей.
+
+---
+
 ## Релиз v0.7.4 (подготовка)
 
 **Дата:** 2026-07-31. **Milestone:** Filar v0.7.4 (1/1 issue, смерджен).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -210,6 +210,8 @@ pub struct App {
     pub ctrl_o_needs_connect: bool,
     /// Cancellation token for an in-flight Ctrl+O connection attempt.
     pub ctrl_o_cancel: Option<tokio_util::sync::CancellationToken>,
+    /// Pending Ctrl+O target that needs a password before connecting.
+    pub ctrl_o_pending_target: Option<filar_core::SshTarget>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -376,6 +378,7 @@ impl App {
             ctrl_o_selection: None,
             ctrl_o_needs_connect: false,
             ctrl_o_cancel: None,
+            ctrl_o_pending_target: None,
         }
     }
 
@@ -1252,14 +1255,18 @@ impl App {
                 KeyCode::Enter => {
                     let password = self.input.clone();
                     if !password.is_empty() {
-                        // Check if this password is for an SSH connection.
-                        if self.pending_ssh.is_some() {
-                            // SSH password — store for runner to pick up.
+                        if self.pending_ssh.is_some() || self.ctrl_o_pending_target.is_some() {
                             self.pending_ssh_password = Some(password);
                             self.input.clear();
                             self.cursor_pos = 0;
-                            self.mode = AppMode::Thinking;
-                            self.agent_running = true;
+                            if self.ctrl_o_pending_target.is_some() {
+                                // Ctrl+O password entry — trigger delayed connect.
+                                self.ctrl_o_needs_connect = true;
+                                self.mode = AppMode::Normal;
+                            } else {
+                                self.mode = AppMode::Thinking;
+                                self.agent_running = true;
+                            }
                         } else {
                             // Regular secret variable — never sent to the LLM.
                             self.secret_counter += 1;
@@ -2117,6 +2124,7 @@ impl App {
             TuiEvent::Thinking => self.sessions[self.active].id,
             TuiEvent::ConfirmationRequest { .. } => self.sessions[self.active].id,
             TuiEvent::TransportChanged { .. } => self.sessions[self.active].id,
+            TuiEvent::PasswordNeeded { session_id, .. } => *session_id,
         };
 
         // Dispatch to the originating session. Save the active index so we can
@@ -2276,6 +2284,13 @@ impl App {
             }
             TuiEvent::TransportChanged { .. } => {
                 // Handled by the runner before reaching here — no-op.
+            }
+            TuiEvent::PasswordNeeded { target, .. } => {
+                // Ctrl+O selected a password target — switch to password entry.
+                self.pending_ssh = Some((target.user.clone(), target.host.clone(), target.port));
+                self.ctrl_o_pending_target = Some(target);
+                self.mode = AppMode::PasswordInput;
+                self.agent_running = false;
             }
         }
         // Auto-scroll to bottom on new content (unless user scrolled up during streaming).
@@ -5632,5 +5647,40 @@ mod tests {
         app.active = 1;
         assert_eq!(app.target_name, tab1_name, "tab 1 target_name unchanged after switch");
         assert!(!tab1_name.starts_with("~local"), "tab 1 should have cycled to a target");
+    }
+
+    #[test]
+    fn password_needed_sets_pending_and_switches_mode() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let target = filar_core::SshTarget {
+            name: "srv".into(), host: "h".into(), port: 22, user: "u".into(),
+            auth: filar_core::SshAuth::Password { password: None },
+            host_key_policy: filar_core::HostKeyPolicy::Tofu,
+        };
+        app.handle_agent_event(TuiEvent::PasswordNeeded {
+            session_id: app.sessions[0].id,
+            target: target.clone(),
+        });
+        assert!(app.pending_ssh.is_some(), "pending_ssh must be set");
+        assert!(app.ctrl_o_pending_target.is_some(), "pending ctrl+o target must be set");
+        assert_eq!(app.mode, AppMode::PasswordInput);
+    }
+
+    #[test]
+    fn password_entry_for_ctrl_o_retriggers_connect() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.ctrl_o_pending_target = Some(filar_core::SshTarget {
+            name: "srv".into(), host: "h".into(), port: 22, user: "u".into(),
+            auth: filar_core::SshAuth::Password { password: None },
+            host_key_policy: filar_core::HostKeyPolicy::Tofu,
+        });
+        app.mode = AppMode::PasswordInput;
+        app.input = "test-pw".to_string();
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(app.pending_ssh_password.is_some());
+        assert!(app.ctrl_o_needs_connect, "ctrl_o_needs_connect must be set for runner");
+        assert_eq!(app.mode, AppMode::Normal);
+        assert!(app.ctrl_o_pending_target.is_some(), "pending target consumed by runner, not app");
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -212,6 +212,8 @@ pub struct App {
     pub ctrl_o_cancel: Option<tokio_util::sync::CancellationToken>,
     /// Pending Ctrl+O target that needs a password before connecting.
     pub ctrl_o_pending_target: Option<filar_core::SshTarget>,
+    /// Session ID of the tab that initiated a password-needed connection.
+    pub ctrl_o_pending_session_id: Option<SessionId>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -379,6 +381,7 @@ impl App {
             ctrl_o_needs_connect: false,
             ctrl_o_cancel: None,
             ctrl_o_pending_target: None,
+            ctrl_o_pending_session_id: None,
         }
     }
 
@@ -1288,9 +1291,10 @@ impl App {
                     }
                 }
                 KeyCode::Esc => {
-                    // Cancel — go back to normal input.
                     self.input.clear();
                     self.cursor_pos = 0;
+                    self.ctrl_o_pending_target = None;
+                    self.ctrl_o_pending_session_id = None;
                     self.mode = AppMode::Normal;
                 }
                 KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -2285,10 +2289,9 @@ impl App {
             TuiEvent::TransportChanged { .. } => {
                 // Handled by the runner before reaching here — no-op.
             }
-            TuiEvent::PasswordNeeded { target, .. } => {
-                // Ctrl+O selected a password target — switch to password entry.
-                self.pending_ssh = Some((target.user.clone(), target.host.clone(), target.port));
+            TuiEvent::PasswordNeeded { session_id, target } => {
                 self.ctrl_o_pending_target = Some(target);
+                self.ctrl_o_pending_session_id = Some(session_id);
                 self.mode = AppMode::PasswordInput;
                 self.agent_running = false;
             }
@@ -5661,8 +5664,8 @@ mod tests {
             session_id: app.sessions[0].id,
             target: target.clone(),
         });
-        assert!(app.pending_ssh.is_some(), "pending_ssh must be set");
         assert!(app.ctrl_o_pending_target.is_some(), "pending ctrl+o target must be set");
+        assert!(app.ctrl_o_pending_session_id.is_some(), "pending session id must be set");
         assert_eq!(app.mode, AppMode::PasswordInput);
     }
 

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -48,6 +48,14 @@ pub enum TuiEvent {
         /// When set, overrides the ssh_info-derived name.
         alias: Option<String>,
     },
+
+    /// Ctrl+O encountered a password target with no cached password.
+    /// The UI must switch to password entry mode.
+    PasswordNeeded {
+        session_id: SessionId,
+        /// The target the user wants to connect to.
+        target: filar_core::SshTarget,
+    },
 }
 
 #[cfg(test)]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -719,12 +719,18 @@ async fn run_app(
             // If we have a pending password entry target, use it directly.
             if let (Some(mut target), Some(password)) = (app.ctrl_o_pending_target.take(), app.pending_ssh_password.take()) {
                 target.auth = filar_core::SshAuth::Password { password: Some(password) };
-                let sid = app.sessions[app.active].id;
+                let sid = app.ctrl_o_pending_session_id.take().unwrap_or(app.sessions[app.active].id);
                 let exec_entry = executors.get(&sid)
                     .map(|e| (e.executor.clone(), e.ssh_target.clone()));
                 let tx = agent_tx.clone();
                 let alias = target.name.clone();
+                let token = CancellationToken::new();
+                app.ctrl_o_cancel = Some(token.clone());
                 tokio::spawn(async move {
+                    tokio::select! {
+                        _ = token.cancelled() => return,
+                        _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {}
+                    }
                     let new_info = format!("{}@{}:{}", target.user, target.host, target.port);
                     match filar_transport::SshExecutor::connect(&target).await {
                         Ok(ssh_exec) => {
@@ -740,10 +746,10 @@ async fn run_app(
                                 event: filar_agent::AgentEvent::Finished(format!("Connected to {} (password)", alias)),
                             });
                         }
-                        Err(e) => {
+                        Err(_) => {
                             let _ = tx.send(TuiEvent::Agent {
                                 session_id: sid,
-                                event: filar_agent::AgentEvent::Error(format!("SSH connection failed: {e}")),
+                                event: filar_agent::AgentEvent::Error("SSH connection failed — authentication error".into()),
                             });
                         }
                     }
@@ -809,7 +815,6 @@ async fn run_app(
                                 return;
                             }
                         }
-                        let target = t.clone();
                         let new_info = format!("{}@{}:{}", target.user, target.host, target.port);
                         match filar_transport::SshExecutor::connect(&target).await {
                             Ok(ssh_exec) => {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -716,6 +716,41 @@ async fn run_app(
         // ── Ctrl+O delayed host connection ─────────────────────────
         if app.ctrl_o_needs_connect {
             app.ctrl_o_needs_connect = false;
+            // If we have a pending password entry target, use it directly.
+            if let (Some(mut target), Some(password)) = (app.ctrl_o_pending_target.take(), app.pending_ssh_password.take()) {
+                target.auth = filar_core::SshAuth::Password { password: Some(password) };
+                let sid = app.sessions[app.active].id;
+                let exec_entry = executors.get(&sid)
+                    .map(|e| (e.executor.clone(), e.ssh_target.clone()));
+                let tx = agent_tx.clone();
+                let alias = target.name.clone();
+                tokio::spawn(async move {
+                    let new_info = format!("{}@{}:{}", target.user, target.host, target.port);
+                    match filar_transport::SshExecutor::connect(&target).await {
+                        Ok(ssh_exec) => {
+                            if let Some((ref exec, ref st)) = exec_entry {
+                                exec.swap_executor(Arc::new(ssh_exec) as Arc<dyn CommandExecutor>).await;
+                                *st.write().await = Some(target);
+                            }
+                            let _ = tx.send(TuiEvent::TransportChanged {
+                                session_id: sid, is_local: false, ssh_info: Some(new_info), alias: Some(alias.clone()),
+                            });
+                            let _ = tx.send(TuiEvent::Agent {
+                                session_id: sid,
+                                event: filar_agent::AgentEvent::Finished(format!("Connected to {} (password)", alias)),
+                            });
+                        }
+                        Err(e) => {
+                            let _ = tx.send(TuiEvent::Agent {
+                                session_id: sid,
+                                event: filar_agent::AgentEvent::Error(format!("SSH connection failed: {e}")),
+                            });
+                        }
+                    }
+                });
+                continue;
+            }
+            app.ctrl_o_needs_connect = false;
             let token = CancellationToken::new();
             app.ctrl_o_cancel = Some(token.clone());
             let selection = app.ctrl_o_selection;
@@ -752,14 +787,27 @@ async fn run_app(
                         return;
                     }
                     if let Some(t) = targets.get(idx - 1) {
-                        if matches!(t.auth, filar_core::SshAuth::Password { .. }) {
-                            let _ = tx.send(TuiEvent::Agent {
-                                session_id: sid,
-                                event: filar_agent::AgentEvent::Error(format!(
-                                    "Target '{}' requires a password. Ctrl+O is not yet supported for password targets. Use !ssh for this host.", t.name
-                                )),
-                            });
-                            return;
+                        let mut target = t.clone();
+                        // Resolve password for Password-auth targets.
+                        if let filar_core::SshAuth::Password { ref password } = target.auth {
+                            let keyring_name = format!("ssh_target:{}", target.name);
+                            let resolved = password.clone()
+                                .or_else(|| {
+                                    let kr = filar_core::KeyringSecretProvider::new();
+                                    kr.get(&keyring_name).ok().filter(|v| !v.is_empty())
+                                })
+                                .or_else(|| std::env::var("SSH_PASSWORD").ok().filter(|v| !v.is_empty()));
+                            if let Some(pw) = resolved {
+                                if password.is_some() {
+                                    warn!(target = %target.name, "password in config.toml for SSH target — consider moving to OS credential store");
+                                }
+                                target.auth = filar_core::SshAuth::Password { password: Some(pw) };
+                            } else {
+                                let _ = tx.send(TuiEvent::PasswordNeeded {
+                                    session_id: sid, target: target.clone(),
+                                });
+                                return;
+                            }
                         }
                         let target = t.clone();
                         let new_info = format!("{}@{}:{}", target.user, target.host, target.port);

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -746,10 +746,10 @@ async fn run_app(
                                 event: filar_agent::AgentEvent::Finished(format!("Connected to {} (password)", alias)),
                             });
                         }
-                        Err(_) => {
+                        Err(e) => {
                             let _ = tx.send(TuiEvent::Agent {
                                 session_id: sid,
-                                event: filar_agent::AgentEvent::Error("SSH connection failed — authentication error".into()),
+                                event: filar_agent::AgentEvent::Error(format!("SSH connection failed: {e}")),
                             });
                         }
                     }


### PR DESCRIPTION
Closes #201

## Summary

`Ctrl+O` now supports password-based SSH targets. Password resolution order: explicit in config (with warning) → OS keyring (`ssh_target:<name>`) → `SSH_PASSWORD` env → interactive prompt (same flow as `Ctrl+P`).

## Changes

1. **Password resolution** in runner.rs Ctrl+O connect path:
   - `SshAuth::Password { password: Some(p) }` → used with `warn!` about plaintext
   - `KeyringSecretProvider::get("ssh_target:<name>")` → primary OS-native path
   - `$SSH_PASSWORD` env → fallback
   - None → `TuiEvent::PasswordNeeded` triggers interactive prompt
2. **`TuiEvent::PasswordNeeded`** — new variant carrying the full `SshTarget`
3. **`App::ctrl_o_pending_target`** — stores the pending password target
4. **PasswordInput mode** extended: when `ctrl_o_pending_target` is set, Enter stores the password and sets `ctrl_o_needs_connect = true` instead of switching to Thinking mode
5. Runner picks up `pending_ssh_password` + `ctrl_o_pending_target` on next loop iteration and completes the connection
6. **Tests:** password_needed state setup; password entry retriggers connect

## Test results

| Crate | Tests |
|-------|-------|
| filar-agent | 67 |
| filar-app | 14 |
| filar-core | 49 |
| filar-gui | 8 |
| filar-transport | 24 (+7 ignored) |
| filar-tui | 273 (271 + 2 new) |
| Doc-tests | 2 |

**437 passed, 0 failed**

## Manual smoke test

⚠️ Needs SSH targets with password auth. User verify:
- Password in keyring → connects without prompt
- `SSH_PASSWORD` → connects
- No password → prompt appears → enter → connects
- Password NOT in config.toml, logs, or error messages
- Rejecting prompt → stays on previous target

## Out of scope
- Save password to keyring after first connect (separate issue)
- GUI launcher section for targets (separate issue)