### PR TITLE
fix(gui): use SshAuth::Key instead of Agent for launcher SSH targets

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3800,6 +3800,22 @@ TUI: `Ctrl+O` видит цель. Удалить профиль → цель и
 
 ---
 
+## Issue #215: fix(gui,tui) — Key auth вместо Agent для Ctrl+O
+
+**Milestone:** Filar v0.8.4. **Ветка:** `fix/215-key-auth-instead-of-agent`.
+
+**Симптом:** выбор `VPS DE` → `Enter` → ошибка «SSH agent authentication not yet implemented».
+
+**Первопричина:** `merge_ssh_targets` хардкодил `SshAuth::Agent`. Filar не поддерживает
+SSH agent — только `SshAuth::Key` (файл приватного ключа) и `SshAuth::Password`.
+
+**Решение:** `SshAuth::Agent` → `SshAuth::Key { path: None }`. При `key_path == None`
+SSH-коннектор использует `~/.ssh/id_rsa` по умолчанию.
+
+**DoD:** выбор хоста → Enter → подключение по ключу работает; `Ctrl+T` на хосте.
+
+---
+
 ## Релиз v0.8.2 (подготовка)
 
 **Дата:** 2026-08-02. **Milestone:** Filar v0.8.2 (2/2 issue, все смерджены).

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -356,7 +356,7 @@ fn merge_ssh_targets(
             host: profile.host.clone(),
             port,
             user: profile.user.clone(),
-            auth: filar_core::SshAuth::Agent,
+            auth: filar_core::SshAuth::Key { path: None },
             host_key_policy: filar_core::HostKeyPolicy::Tofu,
         });
     }
@@ -1178,3 +1178,4 @@ mod tests {
         assert_ne!(profiles[0].name, profiles[2].name, "all three must be unique after dedup");
     }
 }
+


### PR DESCRIPTION
Closes #215

## Summary

Launcher-generated `[[ssh_targets]]` used `SshAuth::Agent` which filar does not support. This caused "SSH agent authentication not yet implemented" errors on every `Ctrl+O` connection attempt.

## Changes

`SshAuth::Agent` → `SshAuth::Key { path: None }` in `merge_ssh_targets`. When `path` is `None`, the SSH connector defaults to `~/.ssh/id_rsa`.

## Test results

446 passed, 0 failed, 7 ignored (Docker)

## Manual smoke test

- [ ] Configure SSH host in launcher → Launch → `Ctrl+O` → select target → Enter → connection works
- [ ] `Ctrl+T` on the same host → terminal works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSH connections launched from the GUI to use key-based authentication.
  * When no private key is specified, the default SSH key path is now used automatically.
  * Improved compatibility with environments where SSH agent authentication is unsupported.

* **Documentation**
  * Added documentation for the SSH host selection fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->