### PR TITLE
fix(gui,core): use Password auth for save_password profiles instead of Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Launcher-generated `[[ssh_targets]]` now replace ALL previous targets on every
   save, eliminating stale entries like `prod-web` with old addresses
   ([#222](https://github.com/devlawey/filar/issues/222)).
+- Ctrl+O targets now use the correct authentication type: password-based
+  authentication when `save_password` is set in the launcher, key-based
+  otherwise ([#220](https://github.com/devlawey/filar/issues/220)).
 
 ## [0.8.4] - 2026-08-02
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3845,6 +3845,20 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ---
 
+## Issue #220: fix(gui,core) — правильный тип аутентификации в зависимости от `save_password`
+
+**Milestone:** Filar v0.8.5. **Ветка:** `fix/220-password-auth`.
+
+**Симптом:** лаунчер подключается по паролю, но Ctrl+O — ошибка «publickey rejected».
+
+**Решение:** `build_ssh_targets_from_profiles` выбирает auth по `profile.save_password`:
+- `true` → `SshAuth::Password { password: None }` (резолвится через keyring в runner.rs)
+- `false` → `SshAuth::Key { path: None }`
+
+**DoD:** профиль с паролем → Ctrl+O подключается по паролю.
+
+---
+
 ## Релиз v0.8.4 (подготовка)
 
 **Дата:** 2026-08-02. **Milestone:** Filar v0.8.4 (3/3 issue, все смерджены).

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -331,7 +331,10 @@ fn build_ssh_targets_from_profiles(profiles: &[SshProfile]) -> Vec<filar_core::S
             host: profile.host.clone(),
             port,
             user: profile.user.clone(),
-            auth: filar_core::SshAuth::Key { path: None },
+            auth: match profile.save_password {
+                true => filar_core::SshAuth::Password { password: None },
+                false => filar_core::SshAuth::Key { path: None },
+            },
             host_key_policy: filar_core::HostKeyPolicy::Tofu,
         });
     }
@@ -1047,6 +1050,9 @@ mod tests {
         assert_eq!(result[1].name, "prod-web", "alias overrides slot name");
         assert_eq!(result[1].host, "10.0.0.2");
         assert_eq!(result[1].port, 22);
+        // Auth type follows save_password flag from the profile.
+        assert!(matches!(result[0].auth, filar_core::SshAuth::Key { .. }), "save_password=false → Key auth");
+        assert!(matches!(result[1].auth, filar_core::SshAuth::Password { .. }), "save_password=true → Password auth");
     }
 
     #[test]


### PR DESCRIPTION
Closes #220

## Summary

Launcher-generated SSH targets always used `SshAuth::Key`, causing "publickey authentication rejected" errors when the user configured password-based auth in the launcher. Now the auth type follows `profile.save_password`.

## Changes

- `build_ssh_targets_from_profiles`: `save_password: true` → `SshAuth::Password { password: None }`, `false` → `SshAuth::Key { path: None }`
- The password is resolved at connection time through the existing keyring/env/prompt pipeline (from #201)
- Test assertion added for auth type selection

## Test results

446 passed, 0 failed, 7 ignored (Docker)

## Manual smoke test

- [ ] Profile with `save_password` → Ctrl+O connects with password
- [ ] Profile without `save_password` → Ctrl+O connects with key