### PR TITLE
fix(gui): sync keyring key between launcher and runner — ssh_target:{name}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - The status bar no longer shows "Connected to: local" after a failed
   `Ctrl+O` connection — error is in the chat, not the transport label
   ([#221](https://github.com/devlawey/filar/issues/221)).
+- SSH password keyring key now matches between the launcher and the TUI
+  runner, so saved passwords are found on `Ctrl+O` without re-prompting
+  ([#226](https://github.com/devlawey/filar/issues/226)).
 
 ## [0.8.4] - 2026-08-02
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3873,6 +3873,20 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ---
 
+## Issue #226: fix(gui) — ключ keyring не совпадает между лаунчером и runner
+
+**Milestone:** Filar v0.8.5. **Ветка:** `fix/226-keyring-key-mismatch`.
+
+**Симптом:** пароль сохранён в лаунчере, но Ctrl+O запрашивает его заново.
+
+**Решение:** `ssh_cred_name(slot, alias)` теперь генерирует `ssh_target:{name}`
+(где name = alias или `SSH{slot+1}`), что совпадает с ключом в runner.rs
+(`format!("ssh_target:{}", target.name)`).
+
+**DoD:** сохранить пароль в лаунчере → Ctrl+O → подключение без запроса.
+
+---
+
 ## Релиз v0.8.4 (подготовка)
 
 **Дата:** 2026-08-02. **Milestone:** Filar v0.8.4 (3/3 issue, все смерджены).

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -85,9 +85,16 @@ fn unique_profile_name(existing: &[LlmProfileData], prefix: &str) -> String {
     }
 }
 
-/// Credential key for SSH slot N (0-based).
-fn ssh_cred_name(slot: usize) -> String {
-    format!("ssh{slot}")
+/// Credential key for SSH slot N. Uses the same naming convention as
+/// the TUI runner: `ssh_target:{name}` where name is the alias (or
+/// `SSH{slot+1}` if no alias is set).
+fn ssh_cred_name(slot: usize, alias: &str) -> String {
+    let name = if alias.is_empty() {
+        format!("SSH{}", slot + 1)
+    } else {
+        alias.to_string()
+    };
+    format!("ssh_target:{name}")
 }
 
 /// Migration: fix duplicate profile names and key_env entries in a loaded list.
@@ -421,7 +428,7 @@ struct SshSlot {
 impl SshSlot {
     fn from_profile(p: &SshProfile, slot_idx: usize) -> Self {
         let password = if p.save_password {
-            load_secret(&ssh_cred_name(slot_idx))
+            load_secret(&ssh_cred_name(slot_idx, &p.alias))
         } else {
             String::new()
         };
@@ -722,8 +729,8 @@ impl LauncherApp {
             if !prof.api_key.is_empty() { save_secret(&prof.key_env, &prof.api_key); }
         }
         for (i, slot) in self.ssh_slots.iter().enumerate() {
-            if slot.save_password && !slot.password.is_empty() { save_secret(&ssh_cred_name(i), &slot.password); }
-            else { delete_secret(&ssh_cred_name(i)); }
+            if slot.save_password && !slot.password.is_empty() { save_secret(&ssh_cred_name(i, &slot.alias), &slot.password); }
+            else { delete_secret(&ssh_cred_name(i, &slot.alias)); }
         }
         let session_id = self.selected_session.map(|i| self.sessions[i].id.clone());
         let cfg = LaunchConfig {

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -88,6 +88,11 @@ fn unique_profile_name(existing: &[LlmProfileData], prefix: &str) -> String {
 /// Credential key for SSH slot N. Uses the same naming convention as
 /// the TUI runner: `ssh_target:{name}` where name is the alias (or
 /// `SSH{slot+1}` if no alias is set).
+///
+/// **Contract:** the `name` produced here MUST match the `target.name`
+/// field in `build_ssh_targets_from_profiles`, because the runner looks
+/// up the password under `format!("ssh_target:{}", target.name)`.
+/// Both functions use `SSH{slot+1}` as the fallback for empty alias.
 fn ssh_cred_name(slot: usize, alias: &str) -> String {
     let name = if alias.is_empty() {
         format!("SSH{}", slot + 1)
@@ -1144,6 +1149,24 @@ mod tests {
         assert_ne!(profiles[0].name, profiles[1].name);
         assert_ne!(profiles[1].name, profiles[2].name);
         assert_ne!(profiles[0].name, profiles[2].name, "all three must be unique after dedup");
+    }
+
+    #[test]
+    fn ssh_cred_name_empty_alias_uses_slot() {
+        assert_eq!(ssh_cred_name(0, ""), "ssh_target:SSH1");
+        assert_eq!(ssh_cred_name(4, ""), "ssh_target:SSH5");
+    }
+
+    #[test]
+    fn ssh_cred_name_nonempty_alias_uses_alias() {
+        assert_eq!(ssh_cred_name(0, "VPS DE"), "ssh_target:VPS DE");
+        assert_eq!(ssh_cred_name(2, "prod-web"), "ssh_target:prod-web");
+    }
+
+    #[test]
+    fn ssh_cred_name_special_chars_preserved() {
+        assert_eq!(ssh_cred_name(0, "my server!"), "ssh_target:my server!");
+        assert_eq!(ssh_cred_name(1, "сервер"), "ssh_target:сервер");
     }
 }
 


### PR DESCRIPTION
Closes #226

## Summary

The launcher saved SSH passwords under keyring key `"ssh{slot}"` (e.g. `"ssh0"`), but the TUI runner looked them up under `"ssh_target:{name}"` (e.g. `"ssh_target:VPS DE"`). These never matched, so saved passwords were never found — Ctrl+O always re-prompted.

## Changes

- `ssh_cred_name(slot, alias)` now generates `ssh_target:{name}` where `name` = alias (or `SSH{slot+1}` if no alias)
- All 3 call sites updated: `from_profile` (load), save loop (save), delete loop (delete)
- The key now matches `format!("ssh_target:{}", target.name)` in runner.rs exactly

## Test results

446 passed, 0 failed, 7 ignored (Docker)

## Manual smoke test

- [ ] Save SSH profile with password in launcher → Launch → Ctrl+O → select target → connects without password prompt