### PR TITLE
feat(tui): render save progress overlay with progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   appears when Ctrl+S is pressed (Russian Ctrl+ы also works) and can be
   dismissed with Esc. Actual file export is not yet included.
   ([#232](https://github.com/devlawey/filar/issues/232)).
+- Session-save progress overlay with progress bar and status display.
+  Shows saving progress, success, or error state in a centred modal.
+  ([#233](https://github.com/devlawey/filar/issues/233)).
 
 ## [0.8.6] - 2026-08-02
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3931,7 +3931,7 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ## Текущая работа: 0.9.0 milestone
 
-**Дата:** 2026-08-11. **Milestone:** Filar v0.9.0 (в работе, 1/4 issue).
+**Дата:** 2026-08-11. **Milestone:** Filar v0.9.0 (в работе, 2/4 issue).
 
 **Сделано:**
 - #232: feat — инфраструктура оверлея сохранения сессии и Ctrl+S binding:
@@ -3941,6 +3941,11 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - Модуль `ui/save_overlay` и stub-функция `render_save_overlay()`
   - Вызов рендера оверлея в `render()` и `render_interactive()` (поверх всего)
   - Запись `^S` в help-баре Normal mode
+- #233: feat — рендеринг оверлея сохранения с прогресс-баром:
+  - Центрированный модал (50×8) с рамкой (accent)
+  - Процент сохранения и `Gauge` (ratatui) — цвет заполнения `success_fg`
+  - Статусная строка: "Saving..." / "Done!" / "Error: ..."
+  - Футер "Esc to close"
 
 **Публичные контракты:** `App` — новые публичные поля `save_overlay_visible`, `save_progress`, `save_error`.
 Новый модуль `crates/tui/src/ui/save_overlay.rs`.

--- a/crates/tui/src/ui/save_overlay.rs
+++ b/crates/tui/src/ui/save_overlay.rs
@@ -1,11 +1,93 @@
 //! Session-save progress overlay — modal window shown during Ctrl+S export.
+//!
+//! Renders a centred modal with a progress bar (`Gauge`), status text,
+//! and a footer hint.  Follows the same overlay convention as `host_select`.
 
 use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Gauge, Paragraph};
 use ratatui::Frame;
 
 use crate::app::App;
 
+const OVERLAY_WIDTH: u16 = 50;
+const OVERLAY_HEIGHT: u16 = 8;
+const H_MARGIN: u16 = 6;
+const V_MARGIN: u16 = 4;
+
 /// Render the session-save progress overlay.
-///
-/// Currently a stub — real rendering with progress bar implemented in issue #233.
-pub(crate) fn render_save_overlay(_f: &mut Frame, _app: &App, _area: Rect) {}
+pub(crate) fn render_save_overlay(f: &mut Frame, app: &App, area: Rect) {
+    let width = OVERLAY_WIDTH.min(area.width.saturating_sub(2 * H_MARGIN));
+    let height = OVERLAY_HEIGHT.min(area.height.saturating_sub(2 * V_MARGIN));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+
+    let overlay_area = Rect::new(x, y, width, height);
+
+    f.render_widget(Clear, overlay_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.accent))
+        .style(Style::default().bg(app.theme.bg))
+        .title(Span::styled(
+            " Saving Session ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ));
+
+    // Inner area for content (inside the border).
+    let inner = block.inner(overlay_area);
+
+    f.render_widget(block, overlay_area);
+
+    // Row 0: percentage label.
+    let progress = app.save_progress as u16;
+    let pct_line = Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            format!("{:>3}%", progress),
+            Style::default().fg(app.theme.fg),
+        ),
+    ]);
+    let pct_area = Rect::new(inner.x, inner.y, inner.width, 1);
+    f.render_widget(Paragraph::new(pct_line), pct_area);
+
+    // Row 1: progress bar.
+    let bar_area = Rect::new(inner.x + 1, inner.y + 1, inner.width.saturating_sub(2), 1);
+    let gauge = Gauge::default()
+        .block(Block::default())
+        .gauge_style(app.theme.success_fg())
+        .style(Style::default().fg(app.theme.fg_dim))
+        .ratio(f64::from(progress) / 100.0);
+    f.render_widget(gauge, bar_area);
+
+    // Row 3: status text.
+    let status = if let Some(ref err) = app.save_error {
+        format!("Error: {err}")
+    } else if progress < 100 {
+        "Saving...".to_string()
+    } else {
+        "Done!".to_string()
+    };
+    let status_area = Rect::new(inner.x, inner.y + 3, inner.width, 1);
+    f.render_widget(
+        Paragraph::new(Span::styled(status, app.theme.muted())),
+        status_area,
+    );
+
+    // Last row: footer hint.
+    let footer = " Esc to close ";
+    let footer_area = Rect::new(
+        overlay_area.x,
+        overlay_area.y + overlay_area.height.saturating_sub(1),
+        overlay_area.width,
+        1,
+    );
+    f.render_widget(
+        Paragraph::new(Span::styled(footer, app.theme.muted())),
+        footer_area,
+    );
+}

--- a/crates/tui/src/ui/save_overlay.rs
+++ b/crates/tui/src/ui/save_overlay.rs
@@ -61,7 +61,7 @@ pub(crate) fn render_save_overlay(f: &mut Frame, app: &App, area: Rect) {
         .block(Block::default())
         .gauge_style(app.theme.success_fg())
         .style(Style::default().fg(app.theme.fg_dim))
-        .ratio(f64::from(progress) / 100.0);
+        .ratio((f64::from(progress) / 100.0).clamp(0.0, 1.0));
     f.render_widget(gauge, bar_area);
 
     // Row 3: status text.
@@ -78,16 +78,81 @@ pub(crate) fn render_save_overlay(f: &mut Frame, app: &App, area: Rect) {
         status_area,
     );
 
-    // Last row: footer hint.
+    // Last row inside border: footer hint.
     let footer = " Esc to close ";
     let footer_area = Rect::new(
-        overlay_area.x,
-        overlay_area.y + overlay_area.height.saturating_sub(1),
-        overlay_area.width,
+        inner.x,
+        inner.y + inner.height.saturating_sub(1),
+        inner.width,
         1,
     );
     f.render_widget(
         Paragraph::new(Span::styled(footer, app.theme.muted())),
         footer_area,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+    use filar_core::CommandConfirmMode;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// Render the save overlay into a test buffer and return all visible text.
+    fn render_save_text(app: &App) -> String {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                render_save_overlay(f, app, area);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..24 {
+            for x in 0..80 {
+                text.push(buffer[(x, y)].symbol().chars().next().unwrap_or(' '));
+            }
+        }
+        text
+    }
+
+    #[test]
+    fn overlay_shows_saving_when_progress_zero() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.save_overlay_visible = true;
+        app.save_progress = 0;
+        let text = render_save_text(&app);
+        assert!(text.contains("Saving..."), "must show Saving... when progress=0");
+    }
+
+    #[test]
+    fn overlay_does_not_panic_on_progress_overflow() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.save_overlay_visible = true;
+        app.save_progress = 200;
+        let text = render_save_text(&app);
+        assert!(!text.trim().is_empty(), "overlay must render without panic");
+    }
+
+    #[test]
+    fn overlay_renders_done_when_complete_no_error() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.save_overlay_visible = true;
+        app.save_progress = 100;
+        let text = render_save_text(&app);
+        assert!(text.contains("Done!"), "must show Done! when complete");
+    }
+
+    #[test]
+    fn overlay_renders_error_when_save_error_set() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.save_overlay_visible = true;
+        app.save_error = Some("disk full".into());
+        let text = render_save_text(&app);
+        assert!(text.contains("Error: disk full"), "must show error message");
+    }
 }


### PR DESCRIPTION
Closes #233

## Summary

Замена stub-заглушки `render_save_overlay` на полноценный рендеринг оверлея с прогресс-баром.

### Что сделано

Оверлей центрирован (50×8, с полями), использует `Clear` для фона, по аналогии с `host_select.rs`:

1. **Блок с рамкой:** `Borders::ALL`, цвет `theme.accent`
2. **Заголовок:** `" Saving Session "` — bold, accent
3. **Процент:** `"  XX%"` из `app.save_progress`
4. **Прогресс-бар:** `Gauge` widget — заполнение `theme.success_fg()`, дорожка `theme.fg_dim`
5. **Статус:** `"Saving..."` если <100%, `"Done!"` при 100% без ошибки, `"Error: ..."` при наличии `save_error`
6. **Футер:** `" Esc to close "` (muted)

### Тесты

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ — 460 тестов, 0 failed, 7 ignored (Docker)

### Что НЕ вошло в скоуп

- Markdown-экспорт и запись файла — issue #234
- Интеграция с runner (канал прогресса) — issue #235
