### PR TITLE
feat(tui): implement session-to-markdown export and async file save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Session-save progress overlay with progress bar and status display.
   Shows saving progress, success, or error state in a centred modal.
   ([#233](https://github.com/devlawey/filar/issues/233)).
+- Session-to-Markdown export and async file save. Messages are converted
+  to Markdown, saved to the working directory with a slug+timestamp
+  filename, and progress is reported via the save overlay.
+  ([#234](https://github.com/devlawey/filar/issues/234)).
 
 ## [0.8.6] - 2026-08-02
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -339,13 +339,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 ## 8. Тесты
 
-- **460 unit-тестов** проходят (включая doc-тесты):
+- **470 unit-тестов** проходят (включая doc-тесты):
   - filar-agent: 67 тестов
   - filar-app: 14 тестов
   - filar-core: 49 тестов + 2 doc-теста
   - filar-gui: 16 тестов
   - filar-transport: 26 тестов (7 ignored — требуют Docker sshd)
-  - filar-tui: 286 тестов
+  - filar-tui: 296 тестов
 - **0 failures**, 7 ignored (Docker)
 
 ```powershell
@@ -3931,7 +3931,7 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ## Текущая работа: 0.9.0 milestone
 
-**Дата:** 2026-08-11. **Milestone:** Filar v0.9.0 (в работе, 2/4 issue).
+**Дата:** 2026-08-11. **Milestone:** Filar v0.9.0 (в работе, 3/4 issue).
 
 **Сделано:**
 - #232: feat — инфраструктура оверлея сохранения сессии и Ctrl+S binding:
@@ -3946,9 +3946,14 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - Процент сохранения и `Gauge` (ratatui) — цвет заполнения `success_fg`
   - Статусная строка: "Saving..." / "Done!" / "Error: ..."
   - Футер "Esc to close"
+- #234: feat — Markdown-экспорт и асинхронная запись файла:
+  - `messages_to_markdown()` — все типы ChatBlock в Markdown
+  - `generate_save_filename()` — slug + UTC timestamp, избегает перезаписи (-N суффикс)
+  - `SaveProgress` enum и `App::start_save()` — spawn tokio::task с прогрессом
+  - Поле `App::save_tx` (пока None, wiring в #235)
 
-**Публичные контракты:** `App` — новые публичные поля `save_overlay_visible`, `save_progress`, `save_error`.
-Новый модуль `crates/tui/src/ui/save_overlay.rs`.
+**Публичные контракты:** `App` — новые поля `save_overlay_visible`, `save_progress`, `save_error`, `save_tx`.
+Новый тип `SaveProgress`. Новый модуль `crates/tui/src/ui/save_overlay.rs`.
 
 **Engine:** не менялся (только tui). Тег engine НЕ ставится.
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -224,6 +224,8 @@ pub struct App {
     pub save_progress: u8,
     /// Error message if the last save failed.
     pub save_error: Option<String>,
+    /// Whether an async save task is currently in flight.
+    pub save_in_flight: bool,
     /// Channel sender for save progress events. Set by the runner (#235).
     pub save_tx: Option<tokio::sync::mpsc::UnboundedSender<SaveProgress>>,
 }
@@ -399,6 +401,7 @@ impl App {
             save_overlay_visible: false,
             save_progress: 0,
             save_error: None,
+            save_in_flight: false,
             save_tx: None,
         }
     }
@@ -695,16 +698,19 @@ fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &O
             ChatBlock::Command { command, output, .. } => {
                 md.push_str(&format!("**$ {command}**\n"));
                 if let Some(out) = output {
-                    // Use a 4-backtick fence when the output itself contains ```.
-                    let contains_fence = out.contains("```");
-                    let fence = if contains_fence { "````" } else { "```" };
-                    md.push_str(fence);
+                    let max_ticks = out
+                        .split(|ch| ch != '`')
+                        .map(str::len)
+                        .max()
+                        .unwrap_or(0);
+                    let fence = "`".repeat((max_ticks + 1).max(3));
+                    md.push_str(&fence);
                     md.push('\n');
                     md.push_str(out);
                     if !out.ends_with('\n') {
                         md.push('\n');
                     }
-                    md.push_str(fence);
+                    md.push_str(&fence);
                     md.push('\n');
                 }
                 md.push('\n');
@@ -994,11 +1000,13 @@ impl App {
     /// Spawns a background task that converts messages to Markdown and writes
     /// the file asynchronously. Progress is reported via `self.save_tx`.
     pub fn start_save(&mut self) {
-        // Guard against concurrent saves.
-        if self.save_overlay_visible {
+        // Guard against concurrent saves — separate from overlay visibility
+        // so that Esc can hide the overlay while the task completes.
+        if self.save_in_flight {
             return;
         }
 
+        self.save_in_flight = true;
         self.save_overlay_visible = true;
         self.save_progress = 0;
         self.save_error = None;
@@ -1032,6 +1040,12 @@ impl App {
                 }
             }
         });
+    }
+
+    /// Called by the runner when a save completes (success or error).
+    /// Resets the in-flight guard so a new save can be started.
+    pub fn finish_save(&mut self) {
+        self.save_in_flight = false;
     }
 
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
@@ -6134,5 +6148,15 @@ mod tests {
         assert!(app.save_overlay_visible, "start_save must open overlay");
         assert_eq!(app.save_progress, 0, "save_progress must reset");
         assert!(app.save_error.is_none(), "save_error must clear");
+        assert!(app.save_in_flight, "save_in_flight must be set");
+        // Second call must be blocked by save_in_flight guard.
+        app.save_overlay_visible = false;
+        app.save_progress = 99;
+        app.start_save();
+        assert!(!app.save_overlay_visible, "second start_save must be no-op");
+        assert_eq!(app.save_progress, 99, "state must not reset on blocked call");
+        // finish_save must allow a new save.
+        app.finish_save();
+        assert!(!app.save_in_flight, "finish_save must clear the flag");
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -224,6 +224,8 @@ pub struct App {
     pub save_progress: u8,
     /// Error message if the last save failed.
     pub save_error: Option<String>,
+    /// Channel sender for save progress events. Set by the runner (#235).
+    pub save_tx: Option<tokio::sync::mpsc::UnboundedSender<SaveProgress>>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -397,6 +399,7 @@ impl App {
             save_overlay_visible: false,
             save_progress: 0,
             save_error: None,
+            save_tx: None,
         }
     }
 
@@ -572,6 +575,136 @@ impl Session {
     pub fn input_history(&self) -> &[String] {
         &self.input_history
     }
+}
+
+// ── Session-save helpers (Ctrl+S, #234) ──────────────────────────────
+
+/// Progress event sent from the background save task to the runner.
+#[derive(Debug)]
+pub enum SaveProgress {
+    Started,
+    Writing,
+    Done(String),   // display filename
+    Error(String),  // error message
+}
+
+/// Convert a Unix timestamp (seconds) to broken-down UTC time.
+/// Minimal implementation — avoids pulling in `chrono`.
+fn unix_to_ymdhms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let hour = (rem / 3600) as u32;
+    let min = ((rem % 3600) / 60) as u32;
+    let sec = (rem % 60) as u32;
+
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let year = if m <= 2 { y + 1 } else { y } as u32;
+
+    (year, m, d, hour, min, sec)
+}
+
+/// Current UTC timestamp formatted as `YYYY-MM-DD.HHMMSS`.
+fn format_now_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let (year, month, day, hour, min, sec) = unix_to_ymdhms(secs);
+    format!("{year:04}-{month:02}-{day:02}.{hour:02}{min:02}{sec:02}")
+}
+
+/// Slugify a string for use in a filename:
+/// replace non-alphanumeric (except `._-`) with `-`, limit length to 80.
+fn slugify(s: &str) -> String {
+    let mut result = String::new();
+    let mut prev_dash = false;
+    for ch in s.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-' {
+            result.push(ch);
+            prev_dash = ch == '-';
+        } else if !prev_dash {
+            result.push('-');
+            prev_dash = true;
+        }
+    }
+    result.trim_matches('-').chars().take(80).collect()
+}
+
+/// Generate a save filename: `{slug}.{date}.{time}.md`
+fn generate_save_filename(session_name: &str, ssh_info: &Option<String>) -> String {
+    let base = ssh_info.as_deref().unwrap_or(session_name);
+    let slug = slugify(base);
+    let ts = format_now_utc();
+    let mut name = format!("{slug}.{ts}.md");
+    // Avoid overwriting: append -1, -2, … if file already exists.
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    if cwd.join(&name).exists() {
+        for n in 1u32.. {
+            let alt = format!("{slug}.{ts}-{n}.md");
+            if !cwd.join(&alt).exists() {
+                name = alt;
+                break;
+            }
+        }
+    }
+    name
+}
+
+/// Convert a list of [`ChatBlock`] messages into a Markdown string.
+fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &Option<String>) -> String {
+    let mut md = String::new();
+    md.push_str(&format!("# Session: {session_name}\n\n"));
+    let ts = {
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let (y, mo, d, h, mi, s) = unix_to_ymdhms(secs);
+        format!("{y:04}-{mo:02}-{d:02} {h:02}:{mi:02}:{s:02}")
+    };
+    md.push_str(&format!("Date: {ts}\n"));
+    if let Some(ref info) = ssh_info {
+        md.push_str(&format!("Target: {info}\n"));
+    }
+    md.push_str("\n---\n\n");
+
+    for block in messages {
+        match block {
+            ChatBlock::User(s) => {
+                md.push_str(&format!("**You:** {s}\n\n"));
+            }
+            ChatBlock::Agent(s) => {
+                md.push_str(&format!("**Agent:** {s}\n\n"));
+            }
+            ChatBlock::Command { command, output, .. } => {
+                md.push_str(&format!("**$ {command}**\n"));
+                if let Some(out) = output {
+                    md.push_str("```\n");
+                    md.push_str(out);
+                    if !out.ends_with('\n') {
+                        md.push('\n');
+                    }
+                    md.push_str("```\n");
+                }
+                md.push('\n');
+            }
+            ChatBlock::Error(s) => {
+                md.push_str(&format!("**Error:** {s}\n\n"));
+            }
+            ChatBlock::System(s) => {
+                md.push_str(&format!("*{s}*\n\n"));
+            }
+        }
+    }
+    md
 }
 
 impl App {
@@ -843,6 +976,46 @@ impl App {
         }
     }
 
+    /// Start saving the current session as a Markdown file.
+    ///
+    /// Spawns a background task that converts messages to Markdown and writes
+    /// the file asynchronously. Progress is reported via `self.save_tx`.
+    pub fn start_save(&mut self) {
+        self.save_overlay_visible = true;
+        self.save_progress = 0;
+        self.save_error = None;
+
+        let Some(ref tx) = self.save_tx else {
+            return;
+        };
+
+        let session_name = self.sessions[self.active].target_name.clone();
+        let ssh_info = self.sessions[self.active].ssh_info.clone();
+        let messages = self.sessions[self.active].messages.clone();
+        let tx = tx.clone();
+
+        tokio::spawn(async move {
+            tx.send(SaveProgress::Started).ok();
+
+            let filename = generate_save_filename(&session_name, &ssh_info);
+            let md_content = messages_to_markdown(&messages, &session_name, &ssh_info);
+
+            tx.send(SaveProgress::Writing).ok();
+
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let filepath = cwd.join(&filename);
+
+            match tokio::fs::write(&filepath, &md_content).await {
+                Ok(_) => {
+                    tx.send(SaveProgress::Done(filename)).ok();
+                }
+                Err(e) => {
+                    tx.send(SaveProgress::Error(format!("Failed to write file: {e}"))).ok();
+                }
+            }
+        });
+    }
+
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -969,9 +1142,7 @@ impl App {
 
         // Ctrl+S — save current session as Markdown.
         if ctrl_key('s', 'ы') && self.mode == AppMode::Normal {
-            self.save_overlay_visible = true;
-            self.save_progress = 0;
-            self.save_error = None;
+            self.start_save();
             return;
         }
 
@@ -5881,5 +6052,69 @@ mod tests {
         app.mode = AppMode::Thinking;
         app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
         assert!(!app.save_overlay_visible, "Ctrl+S must not open overlay in Thinking mode");
+    }
+
+    // ── Session-save export helpers (#234) ────────────────────────────
+
+    #[test]
+    fn slugify_replaces_special_chars() {
+        let s = slugify("user@host:22");
+        assert_eq!(s, "user-host-22", "slug must replace @ and : with dashes");
+    }
+
+    #[test]
+    fn slugify_collapses_consecutive_nonalphanum() {
+        let s = slugify("a@#b");
+        assert_eq!(s, "a-b", "consecutive special chars must collapse to one dash");
+    }
+
+    #[test]
+    fn slugify_limits_length() {
+        let s = "a".repeat(100);
+        let slug = slugify(&s);
+        assert!(slug.len() <= 80, "slug must be at most 80 chars");
+    }
+
+    #[test]
+    fn generate_save_filename_has_correct_format() {
+        let name = generate_save_filename("my-server", &Some("root@10.0.0.5:22".into()));
+        assert!(
+            name.starts_with("root-10.0.0.5-22.") && name.ends_with(".md"),
+            "expected slug.date.time.md format, got: {name}"
+        );
+        assert!(!name.contains(' '), "filename must not contain spaces");
+    }
+
+    #[test]
+    fn messages_to_markdown_covers_all_block_types() {
+        let blocks = vec![
+            ChatBlock::User("hello".into()),
+            ChatBlock::Agent("hi".into()),
+            ChatBlock::Command {
+                command: "ls".into(),
+                explanation: "list".into(),
+                output: Some("f.txt".into()),
+                approved: true,
+            },
+            ChatBlock::Error("fail".into()),
+            ChatBlock::System("started".into()),
+        ];
+        let md = messages_to_markdown(&blocks, "test", &Some("u@h:22".into()));
+        assert!(md.contains("**You:** hello"), "must render User block");
+        assert!(md.contains("**Agent:** hi"), "must render Agent block");
+        assert!(md.contains("**$ ls**"), "must render Command block");
+        assert!(md.contains("f.txt"), "must render command output");
+        assert!(md.contains("**Error:** fail"), "must render Error block");
+        assert!(md.contains("*started*"), "must render System block");
+    }
+
+    #[test]
+    fn start_save_sets_overlay_without_tx() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.save_tx = None;
+        app.start_save();
+        assert!(app.save_overlay_visible, "start_save must open overlay");
+        assert_eq!(app.save_progress, 0, "save_progress must reset");
+        assert!(app.save_error.is_none(), "save_error must clear");
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -699,11 +699,17 @@ fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &O
                 md.push_str(&format!("**$ {command}**\n"));
                 if let Some(out) = output {
                     let max_ticks = out
-                        .split(|ch| ch != '`')
-                        .map(str::len)
-                        .max()
-                        .unwrap_or(0);
-                    let fence = "`".repeat((max_ticks + 1).max(3));
+                        .chars()
+                        .fold((0usize, 0usize), |(max, cur), ch| {
+                            if ch == '`' {
+                                let cur = cur + 1;
+                                (max.max(cur), cur)
+                            } else {
+                                (max, 0)
+                            }
+                        })
+                        .0;
+                    let fence = "`".repeat((max_ticks + 1).max(3_usize));
                     md.push_str(&fence);
                     md.push('\n');
                     md.push_str(out);
@@ -1044,6 +1050,10 @@ impl App {
 
     /// Called by the runner when a save completes (success or error).
     /// Resets the in-flight guard so a new save can be started.
+    ///
+    /// TODO(#235): runner must re-show the overlay (`save_overlay_visible = true`)
+    /// when Done/Error arrives, so the user sees the result even if they pressed
+    /// Esc while the task was still running.
     pub fn finish_save(&mut self) {
         self.save_in_flight = false;
     }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -647,12 +647,20 @@ fn generate_save_filename(session_name: &str, ssh_info: &Option<String>) -> Stri
     // Avoid overwriting: append -1, -2, … if file already exists.
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     if cwd.join(&name).exists() {
-        for n in 1u32.. {
+        for n in 1u32..1000 {
             let alt = format!("{slug}.{ts}-{n}.md");
             if !cwd.join(&alt).exists() {
                 name = alt;
                 break;
             }
+        }
+        // Extreme edge-case: all 999 suffixes taken → append nanos.
+        if cwd.join(&name).exists() {
+            let ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_nanos();
+            name = format!("{slug}.{ts}-{ns}.md");
         }
     }
     name
@@ -687,12 +695,17 @@ fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &O
             ChatBlock::Command { command, output, .. } => {
                 md.push_str(&format!("**$ {command}**\n"));
                 if let Some(out) = output {
-                    md.push_str("```\n");
+                    // Use a 4-backtick fence when the output itself contains ```.
+                    let contains_fence = out.contains("```");
+                    let fence = if contains_fence { "````" } else { "```" };
+                    md.push_str(fence);
+                    md.push('\n');
                     md.push_str(out);
                     if !out.ends_with('\n') {
                         md.push('\n');
                     }
-                    md.push_str("```\n");
+                    md.push_str(fence);
+                    md.push('\n');
                 }
                 md.push('\n');
             }
@@ -981,6 +994,11 @@ impl App {
     /// Spawns a background task that converts messages to Markdown and writes
     /// the file asynchronously. Progress is reported via `self.save_tx`.
     pub fn start_save(&mut self) {
+        // Guard against concurrent saves.
+        if self.save_overlay_visible {
+            return;
+        }
+
         self.save_overlay_visible = true;
         self.save_progress = 0;
         self.save_error = None;


### PR DESCRIPTION
Closes #234

## Summary

Ядро фичи Ctrl+S: конвертация сессии в Markdown, генерация имени файла и асинхронная запись на диск с передачей прогресса.

### Что сделано

1. **`SaveProgress` enum** (`app.rs`) — типы сообщений прогресса: `Started`, `Writing`, `Done(filename)`, `Error(msg)`

2. **`messages_to_markdown()`** — конвертация `Vec<ChatBlock>` в Markdown:
   - `User` → `**You:** text`
   - `Agent` → `**Agent:** text`
   - `Command` → `**$ command**` + код-блок с output
   - `Error` → `**Error:** text`
   - `System` → `*text*`
   - Заголовок с именем сессии, датой и таргетом

3. **`generate_save_filename()`** — формат `slug.YYYY-MM-DD.HHMMSS.md`:
   - `slugify()` — замена спецсимволов на `-`, ограничение 80 символов
   - Избегает перезаписи: добавляет `-N` суффикс если файл существует
   - `format_now_utc()` — UTC timestamp без внешних зависимостей (алгоритм из `core::session`)

4. **`App::start_save()`** — spawn tokio-задачи:
   - Устанавливает флаги оверлея (`save_overlay_visible`, сброс прогресса/ошибки)
   - Без `save_tx` (до #235) — только открывает оверлей
   - С `save_tx` — spawn задачи: конвертация → запись файла → прогресс через канал

5. **Поле `App::save_tx`** — слот для канала (wiring в #235)

### Тесты

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ — 470 тестов, 0 failed, 7 ignored (Docker)
- 6 новых unit-тестов: slugify (3), filename format, messages_to_markdown, start_save без tx

### Что НЕ вошло в скоуп

- Интеграция канала прогресса в runner — issue #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Session-to-Markdown export, including chat content and Markdown formatting.
  * Use **Ctrl+S** to save the active session asynchronously.
  * Saved files receive unique, slugified filenames with timestamps.
  * Added progress feedback while saving and clear error reporting if saving fails.
  * Prevented multiple simultaneous save operations.

* **Documentation**
  * Added documentation and changelog details for session export and save progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->