### PR TITLE
fix(transport,windows): redirect stderr to stdout via 2>&1 for UTF-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   instead of jumping instantly to completion.
   ([#240](https://github.com/devlawey/filar/issues/240)).
 
+### Fixed
+
+- PowerShell error output (stderr) on Windows now displays correctly in
+  UTF-8 — redirected to stdout via `2>&1`
+  ([#243](https://github.com/devlawey/filar/issues/243)).
+
 ## [0.8.6] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 ### Fixed
 
 - PowerShell error output (stderr) on Windows now displays correctly in
-  UTF-8 — redirected to stdout via `2>&1`
+  UTF-8 — redirected to stdout via `2>&1` (local Windows executor only)
   ([#243](https://github.com/devlawey/filar/issues/243)).
 
 ## [0.8.6] - 2026-08-02

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3940,6 +3940,9 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 - #235: feat — интеграция канала сохранения в runner
 - #240: feat — плавная анимация прогресса сохранения
 - #242: feat — `^S` в F1 help overlay (Normal mode)
+- #243: fix — PowerShell error stream encoding:
+  - `2>&1` в `build_shell_command` (crates/transport/src/local.rs)
+  - stderr PowerShell (ошибки на русском) проходит через UTF-8 stdout
 
 **Публичные контракты:** `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `finish_save()`.
 Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -133,12 +133,13 @@ impl crate::CommandExecutor for LocalExecutor {
 /// Build the shell command string for the current platform.
 ///
 /// On Windows, prepends `chcp 65001 > $null;` to set the console code page
-/// to UTF-8 so that non-ASCII output (filenames, text) is decoded correctly
-/// by `String::from_utf8_lossy`.
+/// to UTF-8 and appends `2>&1` to redirect stderr through stdout so that
+/// PowerShell error messages are also decoded correctly by
+/// `String::from_utf8_lossy`.
 fn build_shell_command(command: &str) -> String {
     #[cfg(windows)]
     {
-        format!("chcp 65001 > $null; {command}")
+        format!("chcp 65001 > $null; {command} 2>&1")
     }
     #[cfg(not(windows))]
     {

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -168,6 +168,16 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
+    fn build_shell_command_windows_has_stderr_redirect() {
+        let result = build_shell_command("dir");
+        assert!(
+            result.ends_with(" 2>&1"),
+            "Windows command must redirect stderr to stdout for UTF-8 encoding, got: {result}"
+        );
+    }
+
+    #[test]
     #[cfg(not(windows))]
     fn build_shell_command_unix_no_chcp() {
         let result = build_shell_command("ls");

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -172,8 +172,8 @@ mod tests {
     fn build_shell_command_windows_has_stderr_redirect() {
         let result = build_shell_command("dir");
         assert!(
-            result.ends_with(" 2>&1"),
-            "Windows command must redirect stderr to stdout for UTF-8 encoding, got: {result}"
+            result.starts_with("chcp 65001 > $null; ") && result.ends_with(" 2>&1"),
+            "Windows command must have chcp prefix and 2>&1 suffix, got: {result}"
         );
     }
 


### PR DESCRIPTION
Closes #243

В `build_shell_command` (crates/transport/src/local.rs) добавлен `2>&1` — stderr PowerShell теперь редиректится в stdout, который уже в UTF-8 благодаря `chcp 65001`. Ошибки PowerShell на русском больше не кракозябры.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed PowerShell error messages in Russian and other non-ASCII languages appearing with incorrect encoding on Windows.
  - Error output now consistently passes through the UTF-8 output path for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->