### PR TITLE
fix(tui): add Clear widget before status bar, separators and thinking input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - PowerShell error output (stderr) on Windows now displays correctly in
   UTF-8 — redirected to stdout via `2>&1` (local Windows executor only)
   ([#243](https://github.com/devlawey/filar/issues/243)).
+- Fixed visual artifact in Thinking mode where the mode badge yellow
+  background would bleed into adjacent cells during spinner animation
+  ([#245](https://github.com/devlawey/filar/issues/245)).
 
 ## [0.8.6] - 2026-08-02
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3943,6 +3943,10 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 - #243: fix — PowerShell error stream encoding:
   - `2>&1` в `build_shell_command` (crates/transport/src/local.rs)
   - stderr PowerShell (ошибки на русском) проходит через UTF-8 stdout
+- #245: fix — Clear widget before status bar / separator / thinking input:
+  - `bars.rs`: `Clear` перед `render_status_bar` и `render_separator`
+  - `input.rs`: `Clear` перед `render_thinking`
+  - Убирает жёлтый артефакт от mode-бейджа Thinking
 
 **Публичные контракты:** `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `finish_save()`.
 Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -5,7 +5,7 @@
 
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::Paragraph;
+use ratatui::widgets::{Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{App, AppMode, HelpAction};
@@ -185,6 +185,7 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
 
     let line = Line::from(spans);
     let paragraph = Paragraph::new(line);
+    f.render_widget(Clear, area);
     f.render_widget(paragraph, area);
 }
 
@@ -193,6 +194,7 @@ pub(crate) fn render_separator(f: &mut Frame, app: &App, area: Rect) {
     let glyphs = app.theme.glyphs();
     let sep: String = std::iter::repeat_n(glyphs.separator, area.width as usize).collect();
     let paragraph = Paragraph::new(sep).style(app.theme.muted());
+    f.render_widget(Clear, area);
     f.render_widget(paragraph, area);
 }
 

--- a/crates/tui/src/ui/input.rs
+++ b/crates/tui/src/ui/input.rs
@@ -2,7 +2,7 @@
 
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::Paragraph;
+use ratatui::widgets::{Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{App, AppMode};
@@ -103,6 +103,7 @@ fn render_thinking(f: &mut Frame, app: &App, area: Rect) {
         Span::raw("  "),
         Span::styled("(ctrl+c to cancel)", app.theme.muted()),
     ]);
+    f.render_widget(Clear, area);
     f.render_widget(Paragraph::new(line), area);
 }
 


### PR DESCRIPTION
Closes #245

Добавлен `f.render_widget(Clear, area)` в трёх точках, где рендеринг шёл без очистки области:

- `bars.rs:render_status_bar` — статус-бар (желтый фон Thinking бейджа)
- `bars.rs:render_separator` — горизонтальная линия-разделитель
- `input.rs:render_thinking` — спиннер в Thinking режиме

По аналогии с уже работающим `Clear` в `chat.rs:78`. Убирает визуальный артефакт — жёлтый фон от mode-бейджа, который «перетекал» на соседние ячейки при смене спиннер-символов.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual artifacts in Thinking mode where the yellow mode badge background could bleed into adjacent areas during spinner animations.
  * Cleared status bars, separators, and input areas before rendering to prevent stale terminal content from remaining visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->