### PR TITLE
fix(transport,windows): replace chcp 65001 with Console.OutputEncoding to prevent window resize

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3947,9 +3947,10 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - `bars.rs`: `Clear` перед `render_status_bar` и `render_separator`
   - `input.rs`: `Clear` перед `render_thinking`
   - Убирает жёлтый артефакт от mode-бейджа Thinking
-- #246: fix — замена `chcp 65001` на `[Console]::OutputEncoding`:
-  - Не вызывает `SetConsoleOutputCP` → нет смены шрифта консоли → нет resize
-  - UTF-8 сохраняется для stdout/stderr; `2>&1` из #243 остаётся
+- #246: fix — изоляция `chcp 65001` через `CREATE_NO_WINDOW`:
+  - PowerShell spawn'ится с `CREATE_NO_WINDOW` (0x08000000) → своя скрытая консоль
+  - `chcp 65001` не трогает консоль родительского TUI → нет смены шрифта/resize
+  - UTF-8 сохраняется; `2>&1` из #243 остаётся
 
 **Публичные контракты:** `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `finish_save()`.
 Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3947,6 +3947,9 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - `bars.rs`: `Clear` перед `render_status_bar` и `render_separator`
   - `input.rs`: `Clear` перед `render_thinking`
   - Убирает жёлтый артефакт от mode-бейджа Thinking
+- #246: fix — замена `chcp 65001` на `[Console]::OutputEncoding`:
+  - Не вызывает `SetConsoleOutputCP` → нет смены шрифта консоли → нет resize
+  - UTF-8 сохраняется для stdout/stderr; `2>&1` из #243 остаётся
 
 **Публичные контракты:** `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `finish_save()`.
 Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3948,9 +3948,9 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - `input.rs`: `Clear` перед `render_thinking`
   - Убирает жёлтый артефакт от mode-бейджа Thinking
 - #246: fix — изоляция `chcp 65001` через `CREATE_NO_WINDOW`:
-  - PowerShell spawn'ится с `CREATE_NO_WINDOW` (0x08000000) → своя скрытая консоль
-  - `chcp 65001` не трогает консоль родительского TUI → нет смены шрифта/resize
+  - PowerShell spawn'ится с `CREATE_NO_WINDOW` (0x08000000) — не трогает консоль TUI
   - UTF-8 сохраняется; `2>&1` из #243 остаётся
+  - ⚠️ Требует Windows smoke-теста (не-ASCII stdout/stderr)
 
 **Публичные контракты:** `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `finish_save()`.
 Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -64,9 +64,12 @@ impl crate::CommandExecutor for LocalExecutor {
             let full = build_shell_command(command);
             let mut c = std::process::Command::new("powershell");
             c.args(["-NoProfile", "-NonInteractive", "-Command", &full]);
-            // CREATE_NO_WINDOW: give the child its own hidden console so that
-            // `chcp 65001` does not change the parent TUI's console code page
-            // (which could trigger font switch / resize events).
+            // CREATE_NO_WINDOW: run the child without a visible console window.
+            // On modern Windows this allocates a private (windowless) console,
+            // so `chcp 65001` inside the child does not touch the parent TUI's
+            // console code page (avoids font switch / resize events, #246).
+            // Verified behavior on the target Windows configuration is pending
+            // a smoke test — see #246.
             c.creation_flags(0x0800_0000);
             tokio::process::Command::from(c)
         };
@@ -141,8 +144,9 @@ impl crate::CommandExecutor for LocalExecutor {
 /// On Windows, prepends `chcp 65001 > $null;` to set the console code page
 /// to UTF-8 and appends `2>&1` to redirect stderr through stdout so that
 /// PowerShell error messages are also decoded correctly by
-/// `String::from_utf8_lossy`. The child process runs with `CREATE_NO_WINDOW`
-/// so `chcp` affects only its own hidden console, not the parent TUI console.
+/// `String::from_utf8_lossy`. The child runs with `CREATE_NO_WINDOW` so
+/// `chcp` is intended to affect only the child's console — behaviour pending
+/// a Windows smoke test (#246).
 fn build_shell_command(command: &str) -> String {
     #[cfg(windows)]
     {

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -132,14 +132,15 @@ impl crate::CommandExecutor for LocalExecutor {
 
 /// Build the shell command string for the current platform.
 ///
-/// On Windows, prepends `chcp 65001 > $null;` to set the console code page
-/// to UTF-8 and appends `2>&1` to redirect stderr through stdout so that
-/// PowerShell error messages are also decoded correctly by
-/// `String::from_utf8_lossy`.
+/// On Windows, uses `[Console]::OutputEncoding` to set the output stream
+/// encoding to UTF-8 (without calling `SetConsoleOutputCP`, which can trigger
+/// console font switches and resize events on some Windows configurations).
+/// Appends `2>&1` to redirect stderr through stdout so that PowerShell error
+/// messages are also decoded correctly by `String::from_utf8_lossy`.
 fn build_shell_command(command: &str) -> String {
     #[cfg(windows)]
     {
-        format!("chcp 65001 > $null; {command} 2>&1")
+        format!("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); {command} 2>&1")
     }
     #[cfg(not(windows))]
     {
@@ -159,11 +160,11 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    fn build_shell_command_windows_has_chcp() {
+    fn build_shell_command_windows_has_output_encoding() {
         let result = build_shell_command("dir");
         assert!(
-            result.starts_with("chcp 65001 > $null; "),
-            "Windows command must start with chcp 65001 prefix, got: {result}"
+            result.starts_with("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); "),
+            "Windows command must start with OutputEncoding prefix, got: {result}"
         );
     }
 
@@ -172,16 +173,17 @@ mod tests {
     fn build_shell_command_windows_has_stderr_redirect() {
         let result = build_shell_command("dir");
         assert!(
-            result.starts_with("chcp 65001 > $null; ") && result.ends_with(" 2>&1"),
-            "Windows command must have chcp prefix and 2>&1 suffix, got: {result}"
+            result.starts_with("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); ")
+                && result.ends_with(" 2>&1"),
+            "Windows command must have OutputEncoding prefix and 2>&1 suffix, got: {result}"
         );
     }
 
     #[test]
     #[cfg(not(windows))]
-    fn build_shell_command_unix_no_chcp() {
+    fn build_shell_command_unix_no_prefix() {
         let result = build_shell_command("ls");
         assert_eq!(result, "ls");
-        assert!(!result.contains("chcp"));
+        assert!(!result.contains("OutputEncoding"));
     }
 }

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -59,10 +59,16 @@ impl crate::CommandExecutor for LocalExecutor {
         // Build the command based on platform.
         #[cfg(windows)]
         let mut cmd = {
+            use std::os::windows::process::CommandExt;
+
             let full = build_shell_command(command);
-            let mut c = tokio::process::Command::new("powershell");
+            let mut c = std::process::Command::new("powershell");
             c.args(["-NoProfile", "-NonInteractive", "-Command", &full]);
-            c
+            // CREATE_NO_WINDOW: give the child its own hidden console so that
+            // `chcp 65001` does not change the parent TUI's console code page
+            // (which could trigger font switch / resize events).
+            c.creation_flags(0x0800_0000);
+            tokio::process::Command::from(c)
         };
         #[cfg(unix)]
         let mut cmd = {
@@ -132,15 +138,15 @@ impl crate::CommandExecutor for LocalExecutor {
 
 /// Build the shell command string for the current platform.
 ///
-/// On Windows, uses `[Console]::OutputEncoding` to set the output stream
-/// encoding to UTF-8 (without calling `SetConsoleOutputCP`, which can trigger
-/// console font switches and resize events on some Windows configurations).
-/// Appends `2>&1` to redirect stderr through stdout so that PowerShell error
-/// messages are also decoded correctly by `String::from_utf8_lossy`.
+/// On Windows, prepends `chcp 65001 > $null;` to set the console code page
+/// to UTF-8 and appends `2>&1` to redirect stderr through stdout so that
+/// PowerShell error messages are also decoded correctly by
+/// `String::from_utf8_lossy`. The child process runs with `CREATE_NO_WINDOW`
+/// so `chcp` affects only its own hidden console, not the parent TUI console.
 fn build_shell_command(command: &str) -> String {
     #[cfg(windows)]
     {
-        format!("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); {command} 2>&1")
+        format!("chcp 65001 > $null; {command} 2>&1")
     }
     #[cfg(not(windows))]
     {
@@ -160,11 +166,11 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    fn build_shell_command_windows_has_output_encoding() {
+    fn build_shell_command_windows_has_chcp() {
         let result = build_shell_command("dir");
         assert!(
-            result.starts_with("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); "),
-            "Windows command must start with OutputEncoding prefix, got: {result}"
+            result.starts_with("chcp 65001 > $null; "),
+            "Windows command must start with chcp 65001 prefix, got: {result}"
         );
     }
 
@@ -173,17 +179,16 @@ mod tests {
     fn build_shell_command_windows_has_stderr_redirect() {
         let result = build_shell_command("dir");
         assert!(
-            result.starts_with("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); ")
-                && result.ends_with(" 2>&1"),
-            "Windows command must have OutputEncoding prefix and 2>&1 suffix, got: {result}"
+            result.starts_with("chcp 65001 > $null; ") && result.ends_with(" 2>&1"),
+            "Windows command must have chcp prefix and 2>&1 suffix, got: {result}"
         );
     }
 
     #[test]
     #[cfg(not(windows))]
-    fn build_shell_command_unix_no_prefix() {
+    fn build_shell_command_unix_no_chcp() {
         let result = build_shell_command("ls");
         assert_eq!(result, "ls");
-        assert!(!result.contains("OutputEncoding"));
+        assert!(!result.contains("chcp"));
     }
 }

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -54,16 +54,17 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 
 | Platform | Default console code page | filar behaviour |
 |----------|--------------------------|-----------------|
-| Windows  | CP866 or CP1251 (locale-dependent) | `[Console]::OutputEncoding = UTF8` + `2>&1` stderr redirect |
+| Windows  | CP866 or CP1251 (locale-dependent) | `chcp 65001` prepended + child spawned with `CREATE_NO_WINDOW` |
 | Unix     | UTF-8                    | No conversion needed |
 
 > PowerShell on Windows uses the system locale code page (CP866 for Russian,
-> CP1252 for Western) for console output by default. `[Console]::OutputEncoding`
-> changes the output stream encoding (stdout/stderr) to UTF-8 **without**
-> touching the console active code page (`SetConsoleOutputCP`). This avoids
-> triggering console font switches and resize events on some Windows
-> configurations (#246). `2>&1` appends to redirect stderr through stdout
-> so that PowerShell error messages are also decoded correctly (#243).
-> `String::from_utf8_lossy` then decodes the bytes correctly (#228).
+> CP1252 for Western) for console output by default. `chcp 65001` changes the
+> **console active code page** to UTF-8, which affects how child processes
+> encode their stdout/stderr. The child PowerShell process is spawned with the
+> `CREATE_NO_WINDOW` flag so `chcp 65001` affects only its own hidden console,
+> **not** the parent TUI's console — this avoids font switches and resize
+> events on some Windows configurations (#246). `2>&1` appends to redirect
+> stderr through stdout so PowerShell error messages are also decoded
+> correctly (#243). `String::from_utf8_lossy` then decodes the bytes (#228).
 
 

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -54,16 +54,16 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 
 | Platform | Default console code page | filar behaviour |
 |----------|--------------------------|-----------------|
-| Windows  | CP866 or CP1251 (locale-dependent) | `chcp 65001` prepended to every PowerShell command |
+| Windows  | CP866 or CP1251 (locale-dependent) | `[Console]::OutputEncoding = UTF8` + `2>&1` stderr redirect |
 | Unix     | UTF-8                    | No conversion needed |
 
 > PowerShell on Windows uses the system locale code page (CP866 for Russian,
-> CP1252 for Western) for console output by default. `chcp 65001` changes the
-> **console active code page** to UTF-8, which affects how child processes
-> encode their stdout/stderr. This does not change PowerShell's internal
-> `[Console]::OutputEncoding` or `$OutputEncoding` settings — but since
-> `LocalExecutor` reads raw stdout bytes via `tokio::process::Command` (not
-> through the PowerShell pipeline), the console code page is what matters.
+> CP1252 for Western) for console output by default. `[Console]::OutputEncoding`
+> changes the output stream encoding (stdout/stderr) to UTF-8 **without**
+> touching the console active code page (`SetConsoleOutputCP`). This avoids
+> triggering console font switches and resize events on some Windows
+> configurations (#246). `2>&1` appends to redirect stderr through stdout
+> so that PowerShell error messages are also decoded correctly (#243).
 > `String::from_utf8_lossy` then decodes the bytes correctly (#228).
 
 

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -61,10 +61,15 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 > CP1252 for Western) for console output by default. `chcp 65001` changes the
 > **console active code page** to UTF-8, which affects how child processes
 > encode their stdout/stderr. The child PowerShell process is spawned with the
-> `CREATE_NO_WINDOW` flag so `chcp 65001` affects only its own hidden console,
-> **not** the parent TUI's console — this avoids font switches and resize
-> events on some Windows configurations (#246). `2>&1` appends to redirect
-> stderr through stdout so PowerShell error messages are also decoded
-> correctly (#243). `String::from_utf8_lossy` then decodes the bytes (#228).
+> `CREATE_NO_WINDOW` flag, which runs it without a visible console window; the
+> intent is that `chcp 65001` then does **not** touch the parent TUI's console
+> (avoiding font switches and resize events on some Windows configurations,
+> #246). `2>&1` appends to redirect stderr through stdout so PowerShell error
+> messages are also decoded correctly (#243). `String::from_utf8_lossy` then
+> decodes the bytes (#228).
+>
+> **Note:** exact behaviour of `CREATE_NO_WINDOW` (private windowless console
+> vs. inheritance) depends on the Windows version; final verification of
+> non-ASCII native stdout/stderr is pending a Windows smoke test (#246).
 
 


### PR DESCRIPTION
Closes #246

`chcp 65001` заменён на `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()` в `build_shell_command`. 

`[Console]::OutputEncoding` меняет кодировку stdout/stderr **не трогая** консольную кодовую страницу (`SetConsoleOutputCP` не вызывается) — консоль не переключает шрифт, окно не меняет размер. UTF-8 вывод сохраняется. `2>&1` (из #243) остаётся для stderr.

Обновлены тесты, `PROGRESS.md`, `docs/PLATFORM_NOTES.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows command execution to prevent PowerShell from affecting the parent terminal’s console settings.
  - Preserved UTF-8 command output and existing stderr handling.
  - Windows command processes now run without opening a visible console window.

- **Documentation**
  - Updated platform and shell-command documentation to describe the improved Windows behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->