### PR TITLE
feat(config,gui): configurable save directory with GUI folder picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   shows intermediate states (0% → 50% → 100%) with brief pauses,
   instead of jumping instantly to completion.
   ([#240](https://github.com/devlawey/filar/issues/240)).
+- Configurable save directory for session exports: `save_dir` in
+  `config.toml` sets where Ctrl+S writes `.md` files (default: working
+  directory). The GUI launcher gained a "Save directory" field with a
+  Browse folder picker.
+  ([#247](https://github.com/devlawey/filar/issues/247)).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,170 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,7 +370,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -326,6 +490,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,7 +544,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -796,7 +982,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -819,7 +1005,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -830,7 +1016,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -868,7 +1054,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -922,6 +1108,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -933,7 +1121,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1142,6 +1330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,7 +1344,28 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1197,6 +1412,26 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1290,6 +1525,7 @@ dependencies = [
  "filar-core",
  "image",
  "keyring",
+ "rfd",
  "serde",
  "serde_json",
  "toml 0.8.23",
@@ -1383,7 +1619,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1456,6 +1692,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,7 +1712,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2051,7 +2300,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2123,7 +2372,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2151,7 +2400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2551,7 +2800,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2595,7 +2844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -2611,6 +2860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2624,7 +2874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2636,7 +2886,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2648,7 +2898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2683,7 +2933,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2695,7 +2945,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -2714,7 +2964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -2748,7 +2998,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2761,7 +3011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2773,7 +3023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2796,7 +3046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -2816,7 +3066,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2828,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2848,6 +3098,16 @@ checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2919,6 +3179,12 @@ dependencies = [
  "windows",
  "windows-strings",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3010,7 +3276,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3112,6 +3378,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "poly1305"
@@ -3488,6 +3760,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,7 +4137,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3855,6 +4151,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4277,7 +4584,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4304,6 +4611,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,7 +4638,20 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4358,7 +4689,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4369,7 +4700,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4477,7 +4808,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4661,7 +4992,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4735,6 +5066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,7 +5143,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -4817,6 +5166,7 @@ checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4922,7 +5272,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -5218,7 +5568,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5229,7 +5579,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5450,7 +5800,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
  "cfg_aliases",
@@ -5621,8 +5971,78 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5642,7 +6062,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5662,7 +6082,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5683,7 +6103,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5716,7 +6136,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5738,4 +6158,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 1.0.3",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ alacritty_terminal = "0.26"
 
 # GUI launcher
 eframe = { version = "0.29", default-features = false, features = ["glow", "default_fonts"] }
+rfd = "0.15"
 
 # OS credential storage (Windows Credential Manager, macOS Keychain, Linux Secret Service)
 keyring = { version = "3", default-features = false, features = ["apple-native", "windows-native", "sync-secret-service"] }

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3931,7 +3931,7 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ## Текущая работа: 0.9.0 milestone
 
-**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (10 issue, 5 закрыто, #242 в работе).
+**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (10 issue, 9 закрыто, #247 в работе).
 
 **Сделано:**
 - #232: feat — инфраструктура оверлея сохранения сессии и Ctrl+S binding
@@ -3951,9 +3951,13 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - PowerShell spawn'ится с `CREATE_NO_WINDOW` (0x08000000) — не трогает консоль TUI
   - UTF-8 сохраняется; `2>&1` из #243 остаётся
   - ⚠️ Требует Windows smoke-теста (не-ASCII stdout/stderr)
+- #247: feat — настраиваемая папка сохранения `save_dir`:
+  - `Config::save_dir: Option<PathBuf>` (core) → `TuiConfig` → `App`
+  - `start_save()`/`generate_save_filename()` пишут в `save_dir`, иначе CWD
+  - GUI-лаунчер: поле "Save directory" + Browse (rfd) + Reset
 
-**Публичные контракты:** `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `finish_save()`.
-Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.
+**Публичные контракты:** `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `save_dir`, `finish_save()`.
+`Config::save_dir`. Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.
 
 **Engine:** не менялся (только tui). Тег engine НЕ ставится.
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -543,6 +543,7 @@ async fn run() -> anyhow::Result<()> {
             }
         }),
         ssh_targets: config.ssh_targets.clone(),
+        save_dir: config.save_dir.clone(),
     };
 
     info!("launching TUI");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -36,6 +36,11 @@ pub struct Config {
     /// Command confirmation policy.
     #[serde(default)]
     pub confirm_mode: CommandConfirmMode,
+
+    /// Directory where Ctrl+S session exports (`.md`) are written.
+    /// `None` means the process working directory at startup.
+    #[serde(default)]
+    pub save_dir: Option<PathBuf>,
 }
 
 impl Default for Config {
@@ -46,6 +51,7 @@ impl Default for Config {
             llm_profiles: Vec::new(),
             timeouts: TimeoutConfig::default(),
             confirm_mode: CommandConfirmMode::Allowlist,
+            save_dir: None,
         }
     }
 }

--- a/crates/gui/Cargo.toml
+++ b/crates/gui/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 filar-core = { workspace = true }
 eframe = { workspace = true }
+rfd = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -266,6 +266,9 @@ struct Settings {
     /// Index of the default (last-selected) profile.
     #[serde(default)]
     selected_profile: usize,
+    /// Directory for Ctrl+S session exports (`None` = CWD).
+    #[serde(default)]
+    save_dir: Option<std::path::PathBuf>,
 }
 
 impl Settings {
@@ -401,6 +404,9 @@ fn save_config_toml(settings: &Settings) {
     // Sync launcher SSH profiles to [[ssh_targets]].
     config.ssh_targets = build_ssh_targets_from_profiles(&settings.ssh_profiles);
 
+    // Save directory for Ctrl+S session exports.
+    config.save_dir = settings.save_dir.clone();
+
     if let Err(e) = std::fs::create_dir_all(&app_dir) {
         tracing::warn!(path = %app_dir.display(), error = %e, "failed to create config directory");
         return;
@@ -472,6 +478,8 @@ struct LauncherApp {
     /// Currently selected profile index.
     selected_profile: usize,
     validation_error: String,
+    /// Directory for Ctrl+S session exports (`None` = CWD).
+    save_dir: Option<std::path::PathBuf>,
 }
 
 /// Local copy of an LLM profile for GUI editing.
@@ -659,6 +667,30 @@ impl LauncherApp {
             .desired_rows(2).desired_width(f32::INFINITY));
     }
 
+    /// Folder picker for the Ctrl+S session export directory.
+    fn render_save_dir_field(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.label("Save directory:");
+            let mut display = match &self.save_dir {
+                Some(p) => p.display().to_string(),
+                None => "CWD (where filar was launched)".to_string(),
+            };
+            ui.add(
+                egui::TextEdit::singleline(&mut display)
+                    .desired_width(240.0)
+                    .interactive(false),
+            );
+            if ui.button("Browse…").clicked() {
+                if let Some(dir) = rfd::FileDialog::new().pick_folder() {
+                    self.save_dir = Some(dir);
+                }
+            }
+            if self.save_dir.is_some() && ui.button("Reset").clicked() {
+                self.save_dir = None;
+            }
+        });
+    }
+
     fn save_profiles(&mut self) {
         let p = self.profiles.get(self.selected_profile);
         Settings {
@@ -675,6 +707,7 @@ impl LauncherApp {
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
             }).collect(),
             selected_profile: self.selected_profile,
+            save_dir: self.save_dir.clone(),
         }.save();
     }
 
@@ -727,6 +760,7 @@ impl LauncherApp {
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
             }).collect(),
             selected_profile: self.selected_profile,
+            save_dir: self.save_dir.clone(),
         };
         settings.save();
         save_config_toml(&settings);
@@ -787,6 +821,8 @@ impl eframe::App for LauncherApp {
                 self.render_ssh_fields(ui);
                 ui.separator();
                 self.render_llm_settings(ui);
+                ui.separator();
+                self.render_save_dir_field(ui);
             });
         });
     }
@@ -872,6 +908,7 @@ pub fn run_launcher(config: &Config) {
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
             }).collect(),
             selected_profile: settings.selected_profile.min(profiles.len().saturating_sub(1)),
+            save_dir: settings.save_dir.clone(),
         }.save();
         tracing::info!("persisted deduplicated profile config on startup");
     }
@@ -890,6 +927,7 @@ pub fn run_launcher(config: &Config) {
         profiles,
         selected_profile,
         validation_error: String::new(),
+        save_dir: settings.save_dir.clone(),
     };
 
     let options = eframe::NativeOptions {
@@ -1009,6 +1047,7 @@ mod tests {
             extra_body: String::new(),
             profiles: vec![],
             selected_profile: 0,
+            save_dir: None,
         };
         std::fs::write(&file, serde_json::to_string_pretty(&s).unwrap()).unwrap();
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -228,6 +228,8 @@ pub struct App {
     pub save_in_flight: bool,
     /// Channel sender for save progress events. Set by the runner (#235).
     pub save_tx: Option<tokio::sync::mpsc::UnboundedSender<SaveProgress>>,
+    /// Directory where Ctrl+S session exports are written (`None` = CWD).
+    pub save_dir: Option<std::path::PathBuf>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -403,6 +405,7 @@ impl App {
             save_error: None,
             save_in_flight: false,
             save_tx: None,
+            save_dir: None,
         }
     }
 
@@ -641,24 +644,28 @@ fn slugify(s: &str) -> String {
     result.trim_matches('-').chars().take(80).collect()
 }
 
-/// Generate a save filename: `{slug}.{date}.{time}.md`
-fn generate_save_filename(session_name: &str, ssh_info: &Option<String>) -> String {
+/// Generate a save filename: `{slug}.{date}.{time}.md`, avoiding collisions
+/// within `base_dir`.
+fn generate_save_filename(
+    session_name: &str,
+    ssh_info: &Option<String>,
+    base_dir: &std::path::Path,
+) -> String {
     let base = ssh_info.as_deref().unwrap_or(session_name);
     let slug = slugify(base);
     let ts = format_now_utc();
     let mut name = format!("{slug}.{ts}.md");
     // Avoid overwriting: append -1, -2, … if file already exists.
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    if cwd.join(&name).exists() {
+    if base_dir.join(&name).exists() {
         for n in 1u32..1000 {
             let alt = format!("{slug}.{ts}-{n}.md");
-            if !cwd.join(&alt).exists() {
+            if !base_dir.join(&alt).exists() {
                 name = alt;
                 break;
             }
         }
         // Extreme edge-case: all 999 suffixes taken → append nanos.
-        if cwd.join(&name).exists() {
+        if base_dir.join(&name).exists() {
             let ns = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -1025,6 +1032,11 @@ impl App {
         let ssh_info = self.sessions[self.active].ssh_info.clone();
         let messages = self.sessions[self.active].messages.clone();
         let tx = tx.clone();
+        // Resolve the export directory: configured `save_dir`, else CWD.
+        let base_dir = self
+            .save_dir
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")));
 
         tokio::spawn(async move {
             tx.send(SaveProgress::Started).ok();
@@ -1032,7 +1044,7 @@ impl App {
             // Small delay so the overlay has time to render the 0% state.
             tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
-            let filename = generate_save_filename(&session_name, &ssh_info);
+            let filename = generate_save_filename(&session_name, &ssh_info, &base_dir);
             let md_content = messages_to_markdown(&messages, &session_name, &ssh_info);
 
             tx.send(SaveProgress::Writing).ok();
@@ -1040,8 +1052,7 @@ impl App {
             // Let the progress bar sit at 50% before jumping to 100%.
             tokio::time::sleep(std::time::Duration::from_millis(400)).await;
 
-            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-            let filepath = cwd.join(&filename);
+            let filepath = base_dir.join(&filename);
 
             match tokio::fs::write(&filepath, &md_content).await {
                 Ok(_) => {
@@ -6125,7 +6136,11 @@ mod tests {
 
     #[test]
     fn generate_save_filename_has_correct_format() {
-        let name = generate_save_filename("my-server", &Some("root@10.0.0.5:22".into()));
+        let name = generate_save_filename(
+            "my-server",
+            &Some("root@10.0.0.5:22".into()),
+            std::path::Path::new("."),
+        );
         assert!(
             name.starts_with("root-10.0.0.5-22.") && name.ends_with(".md"),
             "expected slug.date.time.md format, got: {name}"

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -645,8 +645,8 @@ fn slugify(s: &str) -> String {
 }
 
 /// Generate a save filename: `{slug}.{date}.{time}.md`, avoiding collisions
-/// within `base_dir`.
-fn generate_save_filename(
+/// within `base_dir`. Async because existence checks are non-blocking I/O.
+async fn generate_save_filename(
     session_name: &str,
     ssh_info: &Option<String>,
     base_dir: &std::path::Path,
@@ -656,16 +656,16 @@ fn generate_save_filename(
     let ts = format_now_utc();
     let mut name = format!("{slug}.{ts}.md");
     // Avoid overwriting: append -1, -2, … if file already exists.
-    if base_dir.join(&name).exists() {
+    if tokio::fs::try_exists(base_dir.join(&name)).await.unwrap_or(false) {
         for n in 1u32..1000 {
             let alt = format!("{slug}.{ts}-{n}.md");
-            if !base_dir.join(&alt).exists() {
+            if !tokio::fs::try_exists(base_dir.join(&alt)).await.unwrap_or(false) {
                 name = alt;
                 break;
             }
         }
         // Extreme edge-case: all 999 suffixes taken → append nanos.
-        if base_dir.join(&name).exists() {
+        if tokio::fs::try_exists(base_dir.join(&name)).await.unwrap_or(false) {
             let ns = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -1044,7 +1044,7 @@ impl App {
             // Small delay so the overlay has time to render the 0% state.
             tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
-            let filename = generate_save_filename(&session_name, &ssh_info, &base_dir);
+            let filename = generate_save_filename(&session_name, &ssh_info, &base_dir).await;
             let md_content = messages_to_markdown(&messages, &session_name, &ssh_info);
 
             tx.send(SaveProgress::Writing).ok();
@@ -6134,13 +6134,14 @@ mod tests {
         assert!(slug.len() <= 80, "slug must be at most 80 chars");
     }
 
-    #[test]
-    fn generate_save_filename_has_correct_format() {
+    #[tokio::test]
+    async fn generate_save_filename_has_correct_format() {
         let name = generate_save_filename(
             "my-server",
             &Some("root@10.0.0.5:22".into()),
             std::path::Path::new("."),
-        );
+        )
+        .await;
         assert!(
             name.starts_with("root-10.0.0.5-22.") && name.ends_with(".md"),
             "expected slug.date.time.md format, got: {name}"

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -233,6 +233,8 @@ pub struct TuiConfig {
     /// `System` block, so important logs surface in the chat instead of being
     /// painted over the interface. `None` disables the feature (e.g. in tests).
     pub log_rx: Option<mpsc::UnboundedReceiver<String>>,
+    /// Directory where Ctrl+S session exports are written (`None` = CWD).
+    pub save_dir: Option<std::path::PathBuf>,
 }
 
 /// Run the TUI with the given LLM client, executor, and configuration.
@@ -315,12 +317,14 @@ async fn run_app(
         a.profiles = profiles_for_restore;
         a.default_profile_name = default_for_restore;
         a.ssh_targets = config.ssh_targets.clone();
+        a.save_dir = config.save_dir.clone();
         a
     } else {
         let mut a = App::new(config.target_name.clone(), config.confirm_mode);
         a.profiles = profiles_for_restore;
         a.default_profile_name = default_for_restore;
         a.ssh_targets = config.ssh_targets.clone();
+        a.save_dir = config.save_dir.clone();
         if let Some(s) = a.sessions.first_mut() {
             s.llm_profile = Some(config.llm_profile.clone());
         }


### PR DESCRIPTION
Closes #247

## Summary

Настраиваемая папка сохранения сессий Ctrl+S с GUI-пикером.

### Что сделано

1. **`Config::save_dir: Option<PathBuf>`** (`crates/core/src/config.rs`) — `#[serde(default)]`, `None` по умолчанию
2. **Проброс через `TuiConfig`** (`crates/app/src/main.rs`, `crates/tui/src/runner.rs`) → `App::save_dir`
3. **`start_save()` + `generate_save_filename()`** (`crates/tui/src/app.rs`) — пишут в `save_dir`, иначе `current_dir()` (старое поведение)
4. **GUI-лаунчер** (`crates/gui/src/lib.rs`):
   - поле "Save directory" с нередактируемым отображением пути
   - кнопка "Browse…" — `rfd::FileDialog::pick_folder()`
   - кнопка "Reset" — вернуть к CWD
   - `save_dir` пишется в `config.toml` через `save_config_toml()`

### Зависимости

Добавлен `rfd = "0.15"` в workspace (native file dialog; на Windows — IFileDialog).

### Тесты

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ — 471 тест (469 unit + 2 doc), 0 failed, 7 ignored (Docker)

### Что НЕ вошло в скоуп

- TUI-оверлей выбора папки (только GUI) — Ctrl+S в TUI читает `save_dir` из конфига


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable session-export destinations through `save_dir` in `config.toml`.
  - Added a GUI Save directory field with folder browsing and reset controls.
  - Saved sessions now use the selected directory, or the working directory by default.
  - Configured save locations are restored when the application starts.

- **Documentation**
  - Updated the unreleased changelog with session-export directory configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->