### PR TITLE
fix(transport,windows): use [Console]::OutputEncoding instead of chcp 65001 for UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Fixed visual artifact in Thinking mode where the mode badge yellow
   background would bleed into adjacent cells during spinner animation
   ([#245](https://github.com/devlawey/filar/issues/245)).
+- PowerShell output (including Russian error messages) on Windows now
+  encodes as UTF-8 via `[Console]::OutputEncoding`, replacing the
+  ineffective `chcp 65001` (which .NET ignores for piped output)
+  ([#253](https://github.com/devlawey/filar/issues/253)).
 
 ## [0.8.6] - 2026-08-02
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3931,7 +3931,7 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ## Текущая работа: 0.9.0 milestone
 
-**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (12 issue, 11 закрыто, #253 открыт).
+**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (12 issue, 12 закрыто — milestone завершён).
 
 **Сделано:**
 - #232: feat — инфраструктура оверлея сохранения сессии и Ctrl+S binding
@@ -3959,6 +3959,10 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - `LaunchConfig` получил `save_dir`, `profiles`, `ssh_targets` (передаются через `pending_launch.json`)
   - `main.rs`: `tui_config` собирается из `launch`, а не из устаревшего `config`
   - `save_config_toml()` больше НЕ пишет `llm_profiles`/`ssh_targets`/`save_dir` (но и НЕ чистит их — fallback для direct-TUI); первичная секция `[llm]` остаётся
+- #253: fix — UTF-8 вывод PowerShell через `[Console]::OutputEncoding`:
+  - `chcp 65001` (неэффективен для piped-вывода — .NET кеширует кодировку при старте) заменён на `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`
+  - `CREATE_NO_WINDOW` убран; `2>&1` из #243 остаётся
+  - Не трогает консольную кодовую страницу → нет смены шрифта/resize (#246)
 
 **Публичные контракты:** `LaunchConfig` — новые поля `save_dir`, `profiles`, `ssh_targets`.
 `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `save_dir`, `finish_save()`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3931,7 +3931,7 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ## Текущая работа: 0.9.0 milestone
 
-**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (12 issue, 12 закрыто — milestone завершён).
+**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (12/12 issue закрыты; Windows smoke-тест #253/#246 — ожидает ручной проверки).
 
 **Сделано:**
 - #232: feat — инфраструктура оверлея сохранения сессии и Ctrl+S binding
@@ -3968,7 +3968,15 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `save_dir`, `finish_save()`.
 `Config::save_dir`. Тип `SaveProgress`. Модуль `crates/tui/src/ui/save_overlay.rs`.
 
-**Engine:** не менялся (только tui). Тег engine НЕ ставится.
+**Затронутые крейты:** `tui` (#232–#247), `transport` (#243, #246, #253 — `local.rs`),
+`core` (#247 — `Config::save_dir`), `app` (#247, #255 — `main.rs`), `gui` (#247, #255 — `lib.rs`).
+`crates/core` менялся → по правилу `release.engine_tag` engine-тег ставится при релизе.
+
+**Тесты:** `cargo test --workspace` — 471 тест (469 unit + 2 doc), 0 failed, 7 ignored (Docker sshd).
+
+**Следующий шаг:** Windows smoke-тест (ручной) — проверить читаемость не-ASCII
+(PowerShell-ошибки) и отсутствие изменения размера окна после #253/#246. После него
+milestone можно закрыть финально.
 
 ---
 

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -59,19 +59,10 @@ impl crate::CommandExecutor for LocalExecutor {
         // Build the command based on platform.
         #[cfg(windows)]
         let mut cmd = {
-            use std::os::windows::process::CommandExt;
-
             let full = build_shell_command(command);
-            let mut c = std::process::Command::new("powershell");
+            let mut c = tokio::process::Command::new("powershell");
             c.args(["-NoProfile", "-NonInteractive", "-Command", &full]);
-            // CREATE_NO_WINDOW: run the child without a visible console window.
-            // On modern Windows this allocates a private (windowless) console,
-            // so `chcp 65001` inside the child does not touch the parent TUI's
-            // console code page (avoids font switch / resize events, #246).
-            // Verified behavior on the target Windows configuration is pending
-            // a smoke test — see #246.
-            c.creation_flags(0x0800_0000);
-            tokio::process::Command::from(c)
+            c
         };
         #[cfg(unix)]
         let mut cmd = {
@@ -141,16 +132,16 @@ impl crate::CommandExecutor for LocalExecutor {
 
 /// Build the shell command string for the current platform.
 ///
-/// On Windows, prepends `chcp 65001 > $null;` to set the console code page
-/// to UTF-8 and appends `2>&1` to redirect stderr through stdout so that
-/// PowerShell error messages are also decoded correctly by
-/// `String::from_utf8_lossy`. The child runs with `CREATE_NO_WINDOW` so
-/// `chcp` is intended to affect only the child's console — behaviour pending
-/// a Windows smoke test (#246).
+/// On Windows, sets `[Console]::OutputEncoding` to UTF-8 so PowerShell writes
+/// its own output (cmdlet output, error messages) as UTF-8 bytes, and appends
+/// `2>&1` to redirect stderr through stdout. Unlike `chcp 65001`, this does
+/// not change the console active code page (`SetConsoleOutputCP`), which .NET
+/// caches at startup and ignores later — and which could trigger font switch /
+/// resize events on the parent console (#246).
 fn build_shell_command(command: &str) -> String {
     #[cfg(windows)]
     {
-        format!("chcp 65001 > $null; {command} 2>&1")
+        format!("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); {command} 2>&1")
     }
     #[cfg(not(windows))]
     {
@@ -170,11 +161,11 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    fn build_shell_command_windows_has_chcp() {
+    fn build_shell_command_windows_has_output_encoding() {
         let result = build_shell_command("dir");
         assert!(
-            result.starts_with("chcp 65001 > $null; "),
-            "Windows command must start with chcp 65001 prefix, got: {result}"
+            result.starts_with("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); "),
+            "Windows command must start with OutputEncoding prefix, got: {result}"
         );
     }
 
@@ -183,16 +174,17 @@ mod tests {
     fn build_shell_command_windows_has_stderr_redirect() {
         let result = build_shell_command("dir");
         assert!(
-            result.starts_with("chcp 65001 > $null; ") && result.ends_with(" 2>&1"),
-            "Windows command must have chcp prefix and 2>&1 suffix, got: {result}"
+            result.starts_with("[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); ")
+                && result.ends_with(" 2>&1"),
+            "Windows command must have OutputEncoding prefix and 2>&1 suffix, got: {result}"
         );
     }
 
     #[test]
     #[cfg(not(windows))]
-    fn build_shell_command_unix_no_chcp() {
+    fn build_shell_command_unix_no_prefix() {
         let result = build_shell_command("ls");
         assert_eq!(result, "ls");
-        assert!(!result.contains("chcp"));
+        assert!(!result.contains("OutputEncoding"));
     }
 }

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -54,20 +54,22 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 
 | Platform | Default console code page | filar behaviour |
 |----------|--------------------------|-----------------|
-| Windows  | CP866 or CP1251 (locale-dependent) | `[Console]::OutputEncoding = UTF8` prepended + `2>&1` stderr redirect |
+| Windows  | OEM console CP (e.g. CP866, CP437/CP850) or ANSI CP (CP1251/CP1252), host-config-dependent | `[Console]::OutputEncoding = UTF8` prepended + `2>&1` stderr redirect |
 | Unix     | UTF-8                    | No conversion needed |
 
-> PowerShell on Windows uses the system locale code page (CP866 for Russian,
-> CP1252 for Western) for console output by default. `chcp 65001` (via
-> `SetConsoleOutputCP`) is **ineffective for piped output**: .NET caches the
-> console encoding at startup and ignores later `chcp` calls. Instead, filar
-> sets `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`, which
-> directly changes the .NET property PowerShell uses to encode its own output
-> (cmdlet output, error messages) to UTF-8. This does **not** touch the console
-> active code page, so it avoids font-switch/resize events on the parent
-> console (#246). `2>&1` redirects stderr through stdout so PowerShell error
-> messages are also decoded correctly (#243). `String::from_utf8_lossy` then
-> decodes the bytes (#228).
+> PowerShell on Windows encodes its own console output using the active code
+> page: OEM pages (CP866 for Russian locales, CP437/CP850 for Western) for
+> legacy 8-bit console APIs, or ANSI pages (CP1251/CP1252) for the .NET text
+> layer — which one applies depends on host configuration and locale.
+> `chcp 65001` (via `SetConsoleOutputCP`) is **ineffective for piped output**:
+> .NET caches the console encoding at startup and ignores later `chcp` calls.
+> Instead, filar sets `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`,
+> which directly changes the .NET property PowerShell uses to encode its own
+> output (cmdlet output, error messages) to UTF-8. This does **not** touch the
+> console active code page, so it avoids font-switch/resize events on the
+> parent console (#246). `2>&1` redirects stderr through stdout so PowerShell
+> error messages are also decoded correctly (#243). `String::from_utf8_lossy`
+> then decodes the bytes (#228).
 >
 > **Note:** this covers PowerShell's *own* output. Native programs writing raw
 > bytes to the pipe in the OEM code page may still be mis-decoded; that is a

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -54,22 +54,23 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 
 | Platform | Default console code page | filar behaviour |
 |----------|--------------------------|-----------------|
-| Windows  | CP866 or CP1251 (locale-dependent) | `chcp 65001` prepended + child spawned with `CREATE_NO_WINDOW` |
+| Windows  | CP866 or CP1251 (locale-dependent) | `[Console]::OutputEncoding = UTF8` prepended + `2>&1` stderr redirect |
 | Unix     | UTF-8                    | No conversion needed |
 
 > PowerShell on Windows uses the system locale code page (CP866 for Russian,
-> CP1252 for Western) for console output by default. `chcp 65001` changes the
-> **console active code page** to UTF-8, which affects how child processes
-> encode their stdout/stderr. The child PowerShell process is spawned with the
-> `CREATE_NO_WINDOW` flag, which runs it without a visible console window; the
-> intent is that `chcp 65001` then does **not** touch the parent TUI's console
-> (avoiding font switches and resize events on some Windows configurations,
-> #246). `2>&1` appends to redirect stderr through stdout so PowerShell error
+> CP1252 for Western) for console output by default. `chcp 65001` (via
+> `SetConsoleOutputCP`) is **ineffective for piped output**: .NET caches the
+> console encoding at startup and ignores later `chcp` calls. Instead, filar
+> sets `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`, which
+> directly changes the .NET property PowerShell uses to encode its own output
+> (cmdlet output, error messages) to UTF-8. This does **not** touch the console
+> active code page, so it avoids font-switch/resize events on the parent
+> console (#246). `2>&1` redirects stderr through stdout so PowerShell error
 > messages are also decoded correctly (#243). `String::from_utf8_lossy` then
 > decodes the bytes (#228).
 >
-> **Note:** exact behaviour of `CREATE_NO_WINDOW` (private windowless console
-> vs. inheritance) depends on the Windows version; final verification of
-> non-ASCII native stdout/stderr is pending a Windows smoke test (#246).
+> **Note:** this covers PowerShell's *own* output. Native programs writing raw
+> bytes to the pipe in the OEM code page may still be mis-decoded; that is a
+> separate, harder problem and is not handled here.
 
 


### PR DESCRIPTION
Closes #253

## Summary

`chcp 65001` заменён на `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`. `chcp` меняет консольную кодовую страницу (`SetConsoleOutputCP`), но .NET кеширует кодировку консоли при старте и игнорирует последующие `chcp` — для piped-вывода это не даёт UTF-8. `[Console]::OutputEncoding` напрямую меняет .NET-свойство, которым PowerShell кодирует собственный вывод (cmdlet'ы, ошибки).

### Что сделано

1. `build_shell_command` (crates/transport/src/local.rs): `chcp 65001 > $null;` → `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new();`
2. Убран `CREATE_NO_WINDOW` (больше не нужен — нет влияния на консольную кодовую страницу)
3. `2>&1` остаётся (stderr → UTF-8 stdout)
4. Обновлены тесты и `docs/PLATFORM_NOTES.md`

### Тесты

- `cargo build --workspace` ✅
- `cargo test -p filar-transport --lib` ✅ — 27 passed, 7 ignored (Docker)

### Ручная проверка (DoD)

Требуется запуск на Windows: `echo "тест" && ping -n 2 8.8.8.8` через агента — русские ошибки PowerShell должны быть читаемы. В окружении агента TUI не запускается; прогон выполнит пользователь.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows PowerShell command output encoding for more reliable UTF-8 text.
  * Standardized command output so error messages continue appearing alongside regular output.
  * Avoided changing the parent console’s code page during command execution.

* **Documentation**
  * Updated platform notes and the unreleased changelog with the revised Windows output behavior and its limitations for some native programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->