### PR TITLE
fix(gui,core): omit password key when None to fix launch regression

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3931,7 +3931,7 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 
 ## Текущая работа: 0.9.0 milestone
 
-**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (12/12 issue закрыты; Windows smoke-тест #253/#246 — ожидает ручной проверки).
+**Дата:** 2026-08-12. **Milestone:** Filar v0.9.0 (12/12 issue закрыты + #258 регрессия; Windows smoke-тест #253/#246 — ожидает ручной проверки).
 
 **Сделано:**
 - #232: feat — инфраструктура оверлея сохранения сессии и Ctrl+S binding
@@ -3963,6 +3963,9 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
   - `chcp 65001` (неэффективен для piped-вывода — .NET кеширует кодировку при старте) заменён на `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`
   - `CREATE_NO_WINDOW` убран; `2>&1` из #243 остаётся
   - Не трогает консольную кодовую страницу → нет смены шрифта/resize (#246)
+- #258: fix — `SshAuth::Password` с `password: None` не сериализует ключ `"password"`:
+  - Регрессия #255: `LaunchConfig.ssh_targets` эмитил `"password": null` → `load_pending_launch` удалял pending_launch.json → TUI не стартовал
+  - Фикс: `#[serde(skip_serializing_if = "Option::is_none")]` на `password`; regression-тест добавлен
 
 **Публичные контракты:** `LaunchConfig` — новые поля `save_dir`, `profiles`, `ssh_targets`.
 `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `save_dir`, `finish_save()`.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -100,7 +100,7 @@ pub enum SshAuth {
     /// Password-based authentication.
     Password {
         /// Password (optional — falls back to `SSH_PASSWORD` env var).
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         password: Option<String>,
     },
 }

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -1051,6 +1051,40 @@ mod tests {
     }
 
     #[test]
+    fn launch_config_serialization_omits_password_key() {
+        // Regression: SshAuth::Password { password: None } must NOT emit a
+        // `"password":` key, otherwise load_pending_launch() mistakes the file
+        // for an old-format plaintext-secret payload and deletes it (#258).
+        let cfg = LaunchConfig {
+            target: "ssh".into(),
+            ssh: None,
+            model: "glm".into(),
+            api_base_url: "https://api.example.com".into(),
+            api_key: String::new(),
+            session_id: None,
+            temperature: String::new(),
+            extra_body: String::new(),
+            selected_profile: None,
+            key_env: "GLM_API_KEY".into(),
+            save_dir: None,
+            profiles: vec![],
+            ssh_targets: vec![filar_core::SshTarget {
+                name: "srv".into(),
+                host: "10.0.0.1".into(),
+                port: 22,
+                user: "root".into(),
+                auth: filar_core::SshAuth::Password { password: None },
+                host_key_policy: filar_core::HostKeyPolicy::Tofu,
+            }],
+        };
+        let json = serde_json::to_string_pretty(&cfg).unwrap();
+        assert!(!json.contains("\"password\":"), "must not emit password key when None, got: {json}");
+        assert!(json.contains("10.0.0.1"), "ssh target must survive");
+        // And the secret-detection heuristic in load_pending_launch must not trip.
+        assert!(!json.contains("\"api_key\":"), "must not emit api_key");
+    }
+
+    #[test]
     fn settings_save_pattern_preserves_data() {
         // Test the internal pattern: create_dir_all before write,
         // then write→read round-trip verifying data integrity.


### PR DESCRIPTION
Closes #258

## Summary

Регрессия из #255: нажатие «Launch» в GUI закрывало окно без запуска TUI.

**Корень:** `LaunchConfig.ssh_targets` (добавлено в #255) сериализовал `SshAuth::Password { password: None }` как `"password": null`. Эвристика в `load_pending_launch()` (`data.contains("\"password\":")`) принимала это за старый формат с plaintext-секретами, **удаляла** `pending_launch.json` и возвращала `None` → main.rs выходил по ветке «GUI cancelled».

**Фикс:** `#[serde(skip_serializing_if = "Option::is_none")]` на `SshAuth::Password.password` (`crates/core/src/config.rs`) — `password: None` больше не эмитит ключ `"password"`.

### Тесты

- `cargo build --workspace` ✅
- `cargo test -p filar-core -p filar-gui` ✅ — 49+17 unit + 2 doc, 0 failed
- Новый regression-тест `launch_config_serialization_omits_password_key` проверяет отсутствие ключа `"password":`
