### PR TITLE
fix(agent): truncate output by chars to avoid multibyte panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   encodes as UTF-8 via `[Console]::OutputEncoding`, replacing the
   ineffective `chcp 65001` (which .NET ignores for piped output)
   ([#253](https://github.com/devlawey/filar/issues/253)).
+- Fixed panic when agent output was truncated in the middle of a multibyte
+  (e.g. Cyrillic) character — truncation is now by characters, not bytes
+  ([#260](https://github.com/devlawey/filar/issues/260)).
 
 ## [0.8.6] - 2026-08-02
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3966,6 +3966,9 @@ SSH-коннектор использует `~/.ssh/id_rsa` по умолчан�
 - #258: fix — `SshAuth::Password` с `password: None` не сериализует ключ `"password"`:
   - Регрессия #255: `LaunchConfig.ssh_targets` эмитил `"password": null` → `load_pending_launch` удалял pending_launch.json → TUI не стартовал
   - Фикс: `#[serde(skip_serializing_if = "Option::is_none")]` на `password`; regression-тест добавлен
+- #260: fix — `truncate_output` паниковал на многобайтовой границе:
+  - `&output[..max_output_chars]` резал по байтам → паника на кириллице (10 000-й байт в середине символа)
+  - Фикс: обрезка по символам (`chars().take()`); regression-тест с кириллицей
 
 **Публичные контракты:** `LaunchConfig` — новые поля `save_dir`, `profiles`, `ssh_targets`.
 `App` — поля `save_overlay_visible`, `save_progress`, `save_error`, `save_in_flight`, `save_tx`, `save_dir`, `finish_save()`.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -619,15 +619,18 @@ impl Agent {
 
     /// Truncate output to `max_output_chars`, appending a notice if truncated.
     fn truncate_output(&self, output: &str) -> String {
-        if output.len() <= self.max_output_chars {
+        let total_chars = output.chars().count();
+        if total_chars <= self.max_output_chars {
             return output.to_string();
         }
 
-        let truncated = &output[..self.max_output_chars];
+        // Truncate by characters, not bytes — slicing at `max_output_chars`
+        // bytes could land mid-UTF-8-char and panic (#260).
+        let truncated: String = output.chars().take(self.max_output_chars).collect();
         format!(
             "{truncated}\n\n[... output truncated: showed {shown} of {total} characters ...]",
             shown = self.max_output_chars,
-            total = output.len()
+            total = total_chars
         )
     }
 }
@@ -930,6 +933,30 @@ mod tests {
         assert!(truncated.starts_with("0123456789"));
         assert!(truncated.contains("truncated"));
         assert!(truncated.contains("16"));
+    }
+
+    #[test]
+    fn truncate_output_multibyte_no_panic() {
+        let agent = Agent::builder()
+            .llm(Arc::new(MockLlm::new(vec![])))
+            .executor(Arc::new(MockExecutor {
+                last_command: std::sync::Mutex::new(String::new()),
+            }))
+            .confirmer(Arc::new(MockConfirmer { approve: true }))
+            .max_output_chars(10)
+            .build()
+            .unwrap();
+
+        // Cyrillic: 2 bytes per char. Byte 10 lands inside a char,
+        // which previously panicked at `&output[..10]`.
+        let output = "абвгдеёжзийк"; // 12 chars, 24 bytes
+        let truncated = agent.truncate_output(output);
+        assert!(
+            truncated.starts_with("абвгдеёжзи"),
+            "must keep first 10 chars, got: {truncated}"
+        );
+        assert!(truncated.contains("truncated"));
+        assert!(truncated.contains("12"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #260

## Summary

Panic при запросе «состав папки Документы» — `Agent::truncate_output` резал строку по байтам (`&output[..max_output_chars]`), попадая в середину UTF-8 символа (кириллица).

### Что сделано

- `truncate_output` теперь обрезает по символам (`output.chars().take(...)`), а notice показывает реальное число символов
- Regression-тест `truncate_output_multibyte_no_panic` с кириллическим выводом

### Тесты

- `cargo test -p filar-agent` ✅ — 68 passed, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed agent output truncation for text containing multibyte characters, such as Cyrillic.
  - Prevented errors caused by cutting text in the middle of a character.
  - Updated truncation notices to report character counts accurately.

- **Tests**
  - Added regression coverage for Unicode output truncation.

- **Documentation**
  - Added an Unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->