### PR TITLE
feat(agent,core): explain mode core — schema, prompt, validation, rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   directory). The GUI launcher gained a "Save directory" field with a
   Browse folder picker.
   ([#247](https://github.com/devlawey/filar/issues/247)).
+- Explain (safe mode) confirm mode: `CommandConfirmMode::Explain` requires
+  every command to have a mandatory `explanation` from the model. In this
+  mode, `explanation` is added to the `required` array in all tool schemas,
+  a SAFE MODE block is appended to the system prompt, and all commands
+  (including read-only) require confirmation. Missing explanations are
+  rejected with a retry limit of 2.
+  ([#262](https://github.com/devlawey/filar/issues/262)).
 
 ### Changed
 
@@ -38,6 +45,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   writes these launch-specific sections to `config.toml`; they remain only
   as a fallback for direct (non-GUI) TUI launches.
   ([#255](https://github.com/devlawey/filar/issues/255)).
+- `tool_definitions()` now takes a `CommandConfirmMode` argument to produce
+  mode-aware tool schemas. External engine consumers must update calls.
+  ([#262](https://github.com/devlawey/filar/issues/262)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -339,8 +339,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 ## 8. Тесты
 
-- **490 unit-тестов** проходят (включая doc-тесты):
-  - filar-agent: 83 теста
+- **491 unit-тестов** проходят (включая doc-тесты):
+  - filar-agent: 87 тестов
   - filar-app: 14 тестов
   - filar-core: 50 тестов + 2 doc-теста
   - filar-gui: 16 тестов

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -339,10 +339,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 ## 8. Тесты
 
-- **470 unit-тестов** проходят (включая doc-тесты):
-  - filar-agent: 67 тестов
+- **490 unit-тестов** проходят (включая doc-тесты):
+  - filar-agent: 83 теста
   - filar-app: 14 тестов
-  - filar-core: 49 тестов + 2 doc-теста
+  - filar-core: 50 тестов + 2 doc-теста
   - filar-gui: 16 тестов
   - filar-transport: 26 тестов (7 ignored — требуют Docker sshd)
   - filar-tui: 296 тестов
@@ -4135,3 +4135,40 @@ agent (session_id). Тег `engine-v0.6.1` ставится.
 ## Issue #190: feat(agent,tui) — стоимость запросов из OpenRouter, токены по профилям, фактическая модель
 
 **Milestone:** Filar v0.7.2. **Ветка:** `feat/190-openrouter-cost-per-profile`.
+
+---
+
+## Issue #262: feat(agent,core) — Explain mode: ядро режима (схема, промпт, валидация, отказ)
+
+**Milestone:** 0.9.0. **Ветка:** `feat/262-explain-mode-core`.
+
+**Что сделано:**
+- Добавлен `CommandConfirmMode::Explain` в `crates/core/src/config.rs` — четвёртый
+  режим подтверждения. Парсится из `"explain"` в `config.toml`.
+- `tool_definitions(mode)` в `crates/agent/src/tools.rs` стала режим-зависимой: в
+  `Explain` поле `explanation` добавляется в `required` для всех инструментов
+  (`run_command`, `read_file`, `list_dir`). В остальных режимах — без изменений.
+- `ReadFileParams` и `ListDirParams` получили поле `explanation` (`#[serde(default)]`).
+  Если модель не прислала explanation — `parse_tool_call` использует автогенерацию
+  (`"Read file: {path}"`) для обратной совместимости.
+- `check_explanation()` в `tools.rs` — проверяет наличие непустого explanation для
+  каждого инструмента. Возвращает `Some(error_msg)` если пусто.
+- В `agent.rs::run_loop()` валидация: в Explain режиме каждый tool call проверяется
+  через `check_explanation()`. При пустом explanation — ошибка возвращается модели
+  для повторной попытки. Лимит повторов — `MAX_MISSING_EXPLANATION_RETRIES = 2`,
+  после исчерпания — остановка с сообщением пользователю.
+- `SAFE_MODE_PROMPT` — блок системного промпта с правилами для объяснений.
+  Добавляется к `system_prompt` в `AgentBuilder::build()` при `confirm_mode == Explain`.
+- `security::check_command()` и `tool_needs_confirmation()` — `Explain` ведёт себя
+  как `Always`: все команды (включая read-only) требуют подтверждения.
+- Отказ пользователя (пункт 8): текущий механизм уже возвращает модели
+  `"Command denied by user. Try a different approach."` — работает корректно.
+
+**Публичный API:** `tool_definitions()` изменила сигнатуру — теперь принимает
+`CommandConfirmMode`. External consumers (engine) должны обновить вызовы.
+`CommandConfirmMode` получил новый вариант `Explain`.
+
+**Тесты:** 16 новых (tools: 12, security: 3, config: 1). Все 133 теста
+core+agent проходят. Тесты падают на старом коде (новые behaviour не существует).
+
+**Не вошло (вынесено в #263–#265):** F2 toggle, авто-расшифровка, подсказки/документация.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -33,6 +33,38 @@ const DEFAULT_MAX_ITERATIONS: usize = 50;
 /// Default maximum output length (in characters) before truncation.
 const DEFAULT_MAX_OUTPUT_CHARS: usize = 10_000;
 
+/// Maximum number of retries for missing explanation in Explain mode.
+const MAX_MISSING_EXPLANATION_RETRIES: u32 = 2;
+
+/// System prompt block appended when `CommandConfirmMode::Explain` is active.
+const SAFE_MODE_PROMPT: &str = r#"
+
+SAFE MODE IS ACTIVE.
+
+Every command you propose must include an `explanation` that lets the user decide
+whether to approve it, without having to reconstruct your reasoning. In 1–3 sentences,
+each explanation must cover:
+
+1. What the command does — in plain language, not a restatement of its flags.
+2. Why it is needed right now — the link to the user's task or to what you just
+   observed. This is the most important part.
+3. What it changes — say that it only reads state, or name exactly what it creates,
+   modifies, restarts, or deletes.
+
+For anything that modifies state, also state the blast radius and how to undo it — or
+say plainly that it cannot be undone.
+
+Rules:
+- Never write an explanation that merely restates the command ("runs df -h to show
+  disk usage"). If it would not help someone decide, it is not good enough.
+- Distinguish what you know from what you assume. Say "assuming this service is managed
+  by systemd" rather than asserting it.
+- Prefer several small commands, each separately explainable, over one compound command
+  whose combined effect is hard to describe.
+- If the user rejects a command, do not resubmit the same command with a reworded
+  explanation. Propose a different approach or ask a clarifying question.
+"#;
+
 /// Build the system prompt based on execution context.
 ///
 /// - `is_local`: true when executing commands on the local machine.
@@ -286,6 +318,13 @@ impl AgentBuilder {
             Some(provider) => Arc::new(SecretSubstitutingExecutor::new(executor, provider.clone())),
             None => executor,
         };
+        let mut system_prompt = self.system_prompt.unwrap_or_else(||
+            build_system_prompt(false, None, cfg!(windows))
+        );
+        // Append SAFE MODE block in Explain mode.
+        if self.confirm_mode == CommandConfirmMode::Explain {
+            system_prompt.push_str(SAFE_MODE_PROMPT);
+        }
         Ok(Agent {
             llm: self.llm.ok_or_else(|| CoreError::Other("LLM client not set".into()))?,
             executor,
@@ -293,9 +332,7 @@ impl AgentBuilder {
             confirm_mode: self.confirm_mode,
             max_iterations: self.max_iterations,
             max_output_chars: self.max_output_chars,
-            system_prompt: self.system_prompt.unwrap_or_else(||
-                build_system_prompt(false, None, cfg!(windows))
-            ),
+            system_prompt,
             on_text_delta: self.on_text_delta,
             event_sink: self.event_sink,
             cancellation: self.cancellation,
@@ -390,9 +427,11 @@ impl Agent {
         messages.extend_from_slice(history);
         messages.push(ChatMessage::user(user_prompt));
 
-        let tool_defs = tools::tool_definitions();
+        let tool_defs = tools::tool_definitions(self.confirm_mode);
 
         info!(prompt = %user_prompt, "agent loop started");
+
+        let mut missing_explanation_count: u32 = 0;
 
         for iteration in 0..self.max_iterations {
             info!(iteration, "sending request to LLM");
@@ -443,6 +482,21 @@ impl Agent {
 
                 // Process each tool call.
                 for tc in &tool_calls {
+                    // In Explain mode, validate explanation before processing.
+                    if self.confirm_mode == CommandConfirmMode::Explain {
+                        if let Some(err) = tools::check_explanation(&tc.name, &tc.arguments) {
+                            missing_explanation_count += 1;
+                            if missing_explanation_count > MAX_MISSING_EXPLANATION_RETRIES {
+                                warn!(count = missing_explanation_count, "explanation retries exhausted");
+                                return Err(CoreError::Other(
+                                    "Agent repeatedly proposed commands without the required explanation. Stopping.".into()
+                                ));
+                            }
+                            warn!(tool = %tc.name, "missing explanation in safe mode");
+                            messages.push(ChatMessage::tool(&tc.id, err));
+                            continue;
+                        }
+                    }
                     let result = self.process_tool_call(tc).await?;
                     messages.push(result);
                 }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -323,6 +323,7 @@ impl AgentBuilder {
         );
         // Append SAFE MODE block in Explain mode.
         if self.confirm_mode == CommandConfirmMode::Explain {
+            system_prompt.push('\n');
             system_prompt.push_str(SAFE_MODE_PROMPT);
         }
         Ok(Agent {
@@ -480,23 +481,37 @@ impl Agent {
                 );
                 messages.push(assistant_msg);
 
-                // Process each tool call.
-                for tc in &tool_calls {
-                    // In Explain mode, validate explanation before processing.
-                    if self.confirm_mode == CommandConfirmMode::Explain {
+                // In Explain mode, validate ALL explanations before executing any.
+                // If any tool call lacks an explanation, reject the entire batch
+                // and let the model retry — no partial execution in safe mode.
+                if self.confirm_mode == CommandConfirmMode::Explain {
+                    let mut errors: Vec<(&str, String)> = Vec::new();
+                    for tc in &tool_calls {
                         if let Some(err) = tools::check_explanation(&tc.name, &tc.arguments) {
-                            missing_explanation_count += 1;
-                            if missing_explanation_count > MAX_MISSING_EXPLANATION_RETRIES {
-                                warn!(count = missing_explanation_count, "explanation retries exhausted");
-                                return Err(CoreError::Other(
-                                    "Agent repeatedly proposed commands without the required explanation. Stopping.".into()
-                                ));
-                            }
-                            warn!(tool = %tc.name, "missing explanation in safe mode");
-                            messages.push(ChatMessage::tool(&tc.id, err));
-                            continue;
+                            errors.push((&tc.id, err));
                         }
                     }
+                    if !errors.is_empty() {
+                        missing_explanation_count += 1;
+                        if missing_explanation_count > MAX_MISSING_EXPLANATION_RETRIES {
+                            warn!(count = missing_explanation_count, "explanation retries exhausted");
+                            return Err(CoreError::Other(
+                                "Agent repeatedly proposed commands without the required explanation. Stopping.".into()
+                            ));
+                        }
+                        for (id, err) in errors {
+                            warn!(tool = %id, "missing explanation in safe mode");
+                            messages.push(ChatMessage::tool(id, err));
+                        }
+                        // Skip execution for this entire batch — let the model retry.
+                        continue;
+                    }
+                    // All tool calls have valid explanations — reset the counter.
+                    missing_explanation_count = 0;
+                }
+
+                // Process each tool call.
+                for tc in &tool_calls {
                     let result = self.process_tool_call(tc).await?;
                     messages.push(result);
                 }
@@ -1432,6 +1447,123 @@ mod tests {
             snapshot.trim_end(),
             expected.trim_end(),
             "eval/prompts/agent-system.txt is out of sync with build_system_prompt(false, None, false)"
+        );
+    }
+
+    // ── Explain mode agent-level tests ─────────────────────────────────
+
+    #[test]
+    fn build_explain_mode_appends_safe_mode_prompt() {
+        let agent = Agent::builder()
+            .llm(Arc::new(MockLlm::new(vec![])))
+            .executor(Arc::new(MockExecutor {
+                last_command: std::sync::Mutex::new(String::new()),
+            }))
+            .confirmer(Arc::new(MockConfirmer { approve: true }))
+            .confirm_mode(CommandConfirmMode::Explain)
+            .build()
+            .unwrap();
+
+        assert!(
+            agent.system_prompt.contains("SAFE MODE IS ACTIVE"),
+            "system prompt must contain SAFE MODE block in Explain mode"
+        );
+    }
+
+    #[test]
+    fn build_non_explain_mode_no_safe_mode_prompt() {
+        for mode in [
+            CommandConfirmMode::Always,
+            CommandConfirmMode::Allowlist,
+            CommandConfirmMode::Never,
+        ] {
+            let agent = Agent::builder()
+                .llm(Arc::new(MockLlm::new(vec![])))
+                .executor(Arc::new(MockExecutor {
+                    last_command: std::sync::Mutex::new(String::new()),
+                }))
+                .confirmer(Arc::new(MockConfirmer { approve: true }))
+                .confirm_mode(mode)
+                .build()
+                .unwrap();
+
+            assert!(
+                !agent.system_prompt.contains("SAFE MODE IS ACTIVE"),
+                "system prompt must NOT contain SAFE MODE block in {:?} mode",
+                mode
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn explain_mode_rejects_missing_explanation() {
+        // Tool call without explanation — should be rejected, executor not called.
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
+            id: "call_1".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({"command": "ls"}),
+        }]);
+
+        let llm = Arc::new(MockLlm::new(vec![
+            tool_call,
+            ChatResponse::text("OK, let me explain first."),
+        ]));
+
+        let executor = Arc::new(MockExecutor {
+            last_command: std::sync::Mutex::new(String::new()),
+        });
+
+        let agent = Agent::builder()
+            .llm(llm)
+            .executor(executor.clone())
+            .confirmer(Arc::new(MockConfirmer { approve: true }))
+            .confirm_mode(CommandConfirmMode::Explain)
+            .build()
+            .unwrap();
+
+        let result = agent.run("list files", &[]).await.unwrap();
+        assert!(result.contains("explain"));
+        // Executor must NOT have been called — no command was executed.
+        assert!(
+            executor.last_command.lock().unwrap().is_empty(),
+            "executor must not be called when explanation is missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn explain_mode_stops_after_retry_limit() {
+        // Repeatedly send tool calls without explanation.
+        let tool_call = ChatResponse::tool_calls("", vec![ToolCall {
+            id: "call_1".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({"command": "ls"}),
+        }]);
+
+        let llm = Arc::new(MockLlm::new(vec![
+            tool_call.clone(),
+            tool_call.clone(),
+            tool_call,
+        ]));
+
+        let executor = Arc::new(MockExecutor {
+            last_command: std::sync::Mutex::new(String::new()),
+        });
+
+        let agent = Agent::builder()
+            .llm(llm)
+            .executor(executor)
+            .confirmer(Arc::new(MockConfirmer { approve: true }))
+            .confirm_mode(CommandConfirmMode::Explain)
+            .max_iterations(10)
+            .build()
+            .unwrap();
+
+        let result = agent.run("list files", &[]).await;
+        assert!(result.is_err(), "agent should stop after retry limit");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("explanation"),
+            "error should mention missing explanation, got: {err}"
         );
     }
 }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -485,10 +485,10 @@ impl Agent {
                 // If any tool call lacks an explanation, reject the entire batch
                 // and let the model retry — no partial execution in safe mode.
                 if self.confirm_mode == CommandConfirmMode::Explain {
-                    let mut errors: Vec<(&str, String)> = Vec::new();
+                    let mut errors: Vec<(String, String)> = Vec::new();
                     for tc in &tool_calls {
                         if let Some(err) = tools::check_explanation(&tc.name, &tc.arguments) {
-                            errors.push((&tc.id, err));
+                            errors.push((tc.id.clone(), err));
                         }
                     }
                     if !errors.is_empty() {

--- a/crates/agent/src/security.rs
+++ b/crates/agent/src/security.rs
@@ -253,6 +253,8 @@ pub enum ConfirmDecision {
 /// - `Never` → always auto-approve (dangerous).
 /// - `Allowlist` → auto-approve read-only commands, confirm everything else.
 /// - `Always` → confirm everything.
+/// - `Explain` → confirm everything (same as `Always`), plus the agent
+///   requires a mandatory `explanation` field on every tool call.
 ///
 /// Destructive commands always require confirmation (even in `Never` mode they
 /// get a warning, but are still auto-approved — the user chose `Never`).
@@ -275,7 +277,9 @@ pub fn check_command(command: &str, mode: CommandConfirmMode) -> ConfirmDecision
                 ConfirmDecision::NeedsConfirmation
             }
         }
-        CommandConfirmMode::Always => ConfirmDecision::NeedsConfirmation,
+        CommandConfirmMode::Always | CommandConfirmMode::Explain => {
+            ConfirmDecision::NeedsConfirmation
+        }
     }
 }
 
@@ -290,7 +294,9 @@ pub fn tool_needs_confirmation(kind: ToolKind, command: &str, mode: CommandConfi
                 match mode {
                     CommandConfirmMode::Never => ConfirmDecision::AutoApproved,
                     CommandConfirmMode::Allowlist => ConfirmDecision::AutoApproved,
-                    CommandConfirmMode::Always => ConfirmDecision::NeedsConfirmation,
+                    CommandConfirmMode::Always | CommandConfirmMode::Explain => {
+                        ConfirmDecision::NeedsConfirmation
+                    }
                 }
             } else {
                 check_command(command, mode)
@@ -503,6 +509,46 @@ mod tests {
             ToolKind::ReadFile,
             "cat /etc/hostname",
             CommandConfirmMode::Always,
+        );
+        assert_eq!(decision, ConfirmDecision::NeedsConfirmation);
+    }
+
+    #[test]
+    fn check_explain_mode() {
+        // Read-only commands also need confirmation in Explain mode.
+        assert_eq!(
+            check_command("ls", CommandConfirmMode::Explain),
+            ConfirmDecision::NeedsConfirmation
+        );
+        assert_eq!(
+            check_command("cat /etc/hostname", CommandConfirmMode::Explain),
+            ConfirmDecision::NeedsConfirmation
+        );
+        // Destructive commands also need confirmation.
+        assert_eq!(
+            check_command("rm -rf /", CommandConfirmMode::Explain),
+            ConfirmDecision::NeedsConfirmation
+        );
+    }
+
+    #[test]
+    fn tool_needs_confirmation_explain_read_file() {
+        // read_file generates "cat <path>" — read-only, but Explain requires confirmation.
+        let decision = tool_needs_confirmation(
+            ToolKind::ReadFile,
+            "cat /etc/hostname",
+            CommandConfirmMode::Explain,
+        );
+        assert_eq!(decision, ConfirmDecision::NeedsConfirmation);
+    }
+
+    #[test]
+    fn tool_needs_confirmation_explain_list_dir() {
+        // list_dir generates "ls -la <path>" — read-only, but Explain requires confirmation.
+        let decision = tool_needs_confirmation(
+            ToolKind::ListDir,
+            "ls -la /var/log",
+            CommandConfirmMode::Explain,
         );
         assert_eq!(decision, ConfirmDecision::NeedsConfirmation);
     }

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -11,7 +11,7 @@
 use serde::Deserialize;
 use tracing::{debug, info};
 
-use filar_core::{CoreError, Result};
+use filar_core::{CommandConfirmMode, CoreError, Result};
 use filar_transport::CommandExecutor;
 
 use crate::ToolDef;
@@ -43,6 +43,9 @@ pub struct RunCommandParams {
 pub struct ReadFileParams {
     /// Path to the file to read.
     pub path: String,
+    /// Human-readable explanation (required in Explain mode).
+    #[serde(default)]
+    pub explanation: String,
 }
 
 /// Parameters for the `list_dir` tool.
@@ -50,6 +53,9 @@ pub struct ReadFileParams {
 pub struct ListDirParams {
     /// Path to the directory to list.
     pub path: String,
+    /// Human-readable explanation (required in Explain mode).
+    #[serde(default)]
+    pub explanation: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -57,7 +63,26 @@ pub struct ListDirParams {
 // ---------------------------------------------------------------------------
 
 /// Return the list of tool definitions available to the LLM.
-pub fn tool_definitions() -> Vec<ToolDef> {
+///
+/// In `Explain` mode, the `explanation` field is added to `required` for all
+/// tools, forcing the model to provide a justification for each command.
+pub fn tool_definitions(mode: CommandConfirmMode) -> Vec<ToolDef> {
+    let require_explanation = mode == CommandConfirmMode::Explain;
+    let required_cmd = if require_explanation {
+        serde_json::json!(["command", "explanation"])
+    } else {
+        serde_json::json!(["command"])
+    };
+    let required_path = if require_explanation {
+        serde_json::json!(["path", "explanation"])
+    } else {
+        serde_json::json!(["path"])
+    };
+    let explanation_prop = || serde_json::json!({
+        "type": "string",
+        "description": "A brief explanation of what this command does and why."
+    });
+
     vec![
         ToolDef {
             name: TOOL_RUN_COMMAND.into(),
@@ -72,12 +97,9 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                         "type": "string",
                         "description": "The shell command to execute."
                     },
-                    "explanation": {
-                        "type": "string",
-                        "description": "A brief explanation of what this command does and why."
-                    }
+                    "explanation": explanation_prop()
                 },
-                "required": ["command"]
+                "required": required_cmd
             }),
         },
         ToolDef {
@@ -91,9 +113,10 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                     "path": {
                         "type": "string",
                         "description": "Absolute or relative path to the file."
-                    }
+                    },
+                    "explanation": explanation_prop()
                 },
-                "required": ["path"]
+                "required": required_path
             }),
         },
         ToolDef {
@@ -107,9 +130,10 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                     "path": {
                         "type": "string",
                         "description": "Absolute or relative path to the directory."
-                    }
+                    },
+                    "explanation": explanation_prop()
                 },
-                "required": ["path"]
+                "required": required_path
             }),
         },
     ]
@@ -166,7 +190,11 @@ pub fn parse_tool_call(id: &str, name: &str, arguments: &serde_json::Value) -> R
                 id: id.to_string(),
                 kind: ToolKind::ReadFile,
                 command: format!("cat {}", shell_quote(&params.path)),
-                explanation: format!("Read file: {}", params.path),
+                explanation: if params.explanation.is_empty() {
+                    format!("Read file: {}", params.path)
+                } else {
+                    params.explanation
+                },
             })
         }
         TOOL_LIST_DIR => {
@@ -176,11 +204,58 @@ pub fn parse_tool_call(id: &str, name: &str, arguments: &serde_json::Value) -> R
                 id: id.to_string(),
                 kind: ToolKind::ListDir,
                 command: format!("ls -la {}", shell_quote(&params.path)),
-                explanation: format!("List directory: {}", params.path),
+                explanation: if params.explanation.is_empty() {
+                    format!("List directory: {}", params.path)
+                } else {
+                    params.explanation
+                },
             })
         }
         other => Err(CoreError::Other(format!("unknown tool: {other}"))),
     }
+}
+
+/// Check if a tool call has a non-empty explanation (required in Explain mode).
+///
+/// Returns `Some(error_message)` if the explanation is missing or empty,
+/// `None` if the explanation is present (or the tool is unknown — let
+/// `parse_tool_call` handle that).
+pub fn check_explanation(name: &str, arguments: &serde_json::Value) -> Option<String> {
+    match name {
+        TOOL_RUN_COMMAND => {
+            let params: RunCommandParams = serde_json::from_value(arguments.clone()).ok()?;
+            if params.explanation.trim().is_empty() {
+                return Some(
+                    "Error: in safe mode, every command must include an `explanation` \
+                     describing what it does, why it is needed now, and what it changes. \
+                     Please resubmit with a meaningful explanation."
+                        .into(),
+                );
+            }
+        }
+        TOOL_READ_FILE => {
+            let params: ReadFileParams = serde_json::from_value(arguments.clone()).ok()?;
+            if params.explanation.trim().is_empty() {
+                return Some(
+                    "Error: in safe mode, read_file also requires an `explanation`. \
+                     Please describe why you need to read this file."
+                        .into(),
+                );
+            }
+        }
+        TOOL_LIST_DIR => {
+            let params: ListDirParams = serde_json::from_value(arguments.clone()).ok()?;
+            if params.explanation.trim().is_empty() {
+                return Some(
+                    "Error: in safe mode, list_dir also requires an `explanation`. \
+                     Please describe why you need to list this directory."
+                        .into(),
+                );
+            }
+        }
+        _ => {}
+    }
+    None
 }
 
 /// Execute a parsed tool call via the given executor and return the output string.
@@ -248,7 +323,7 @@ mod tests {
 
     #[test]
     fn tool_definitions_count() {
-        let defs = tool_definitions();
+        let defs = tool_definitions(CommandConfirmMode::Allowlist);
         assert_eq!(defs.len(), 3);
         assert!(defs.iter().any(|d| d.name == TOOL_RUN_COMMAND));
         assert!(defs.iter().any(|d| d.name == TOOL_READ_FILE));
@@ -311,5 +386,103 @@ mod tests {
     #[test]
     fn shell_quote_with_single_quote() {
         assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    }
+
+    // ── Explain mode tests ──────────────────────────────────────────
+
+    #[test]
+    fn tool_definitions_explain_requires_explanation() {
+        let defs = tool_definitions(CommandConfirmMode::Explain);
+        for def in &defs {
+            let required = def.parameters["required"].as_array().unwrap();
+            assert!(
+                required.iter().any(|v| v.as_str() == Some("explanation")),
+                "tool '{}' must require 'explanation' in Explain mode",
+                def.name
+            );
+        }
+    }
+
+    #[test]
+    fn tool_definitions_non_explain_no_explanation_required() {
+        for mode in [
+            CommandConfirmMode::Always,
+            CommandConfirmMode::Allowlist,
+            CommandConfirmMode::Never,
+        ] {
+            let defs = tool_definitions(mode);
+            for def in &defs {
+                let required = def.parameters["required"].as_array().unwrap();
+                assert!(
+                    !required.iter().any(|v| v.as_str() == Some("explanation")),
+                    "tool '{}' must NOT require 'explanation' in {:?} mode",
+                    def.name,
+                    mode
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn check_explanation_empty_run_command() {
+        let args = serde_json::json!({"command": "ls"});
+        assert!(check_explanation(TOOL_RUN_COMMAND, &args).is_some());
+    }
+
+    #[test]
+    fn check_explanation_whitespace_run_command() {
+        let args = serde_json::json!({"command": "ls", "explanation": "   "});
+        assert!(check_explanation(TOOL_RUN_COMMAND, &args).is_some());
+    }
+
+    #[test]
+    fn check_explanation_present_run_command() {
+        let args = serde_json::json!({"command": "ls", "explanation": "list files"});
+        assert!(check_explanation(TOOL_RUN_COMMAND, &args).is_none());
+    }
+
+    #[test]
+    fn check_explanation_empty_read_file() {
+        let args = serde_json::json!({"path": "/etc/hostname"});
+        assert!(check_explanation(TOOL_READ_FILE, &args).is_some());
+    }
+
+    #[test]
+    fn check_explanation_present_read_file() {
+        let args = serde_json::json!({"path": "/etc/hostname", "explanation": "check hostname"});
+        assert!(check_explanation(TOOL_READ_FILE, &args).is_none());
+    }
+
+    #[test]
+    fn check_explanation_empty_list_dir() {
+        let args = serde_json::json!({"path": "/var/log"});
+        assert!(check_explanation(TOOL_LIST_DIR, &args).is_some());
+    }
+
+    #[test]
+    fn check_explanation_unknown_tool() {
+        let args = serde_json::json!({});
+        assert!(check_explanation("unknown_tool", &args).is_none());
+    }
+
+    #[test]
+    fn parse_read_file_with_explanation() {
+        let args = serde_json::json!({"path": "/etc/hostname", "explanation": "check hostname"});
+        let call = parse_tool_call("call_1", TOOL_READ_FILE, &args).unwrap();
+        assert_eq!(call.explanation, "check hostname");
+    }
+
+    #[test]
+    fn parse_read_file_without_explanation_falls_back() {
+        let args = serde_json::json!({"path": "/etc/hostname"});
+        let call = parse_tool_call("call_1", TOOL_READ_FILE, &args).unwrap();
+        assert_eq!(call.explanation, "Read file: /etc/hostname");
+    }
+
+    #[test]
+    fn parse_list_dir_with_explanation() {
+        let args = serde_json::json!({"path": "/var/log", "explanation": "list logs"});
+        let call = parse_tool_call("call_1", TOOL_LIST_DIR, &args).unwrap();
+        assert_eq!(call.explanation, "list logs");
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -303,6 +303,10 @@ pub enum CommandConfirmMode {
     Allowlist,
     /// No confirmation required (dangerous — use only in trusted sandboxes).
     Never,
+    /// Safe mode: every command requires confirmation AND a mandatory
+    /// explanation from the model. Read-only commands are NOT auto-approved.
+    /// The system prompt gets a SAFE MODE block appended.
+    Explain,
 }
 
 // ---------------------------------------------------------------------------
@@ -425,6 +429,19 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_config_with_explain_mode() {
+        let toml = r#"
+confirm_mode = "explain"
+
+[llm]
+model = "glm-5.1"
+api_base_url = "https://open.bigmodel.cn/api/paas/v4"
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.confirm_mode, CommandConfirmMode::Explain);
+    }
 
     #[test]
     fn parse_minimal_config() {


### PR DESCRIPTION
## Summary

Implements the core of Explain (safe mode) — issue #262, milestone 0.9.0.

A new `CommandConfirmMode::Explain` variant where every command requires a mandatory `explanation` from the model, all commands (including read-only) require user confirmation, and a SAFE MODE block is appended to the system prompt.

### Changes

- **`crates/core/src/config.rs`**: Added `CommandConfirmMode::Explain` variant (serializes as `"explain"`).
- **`crates/agent/src/tools.rs`**:
  - `tool_definitions(mode)` now takes `CommandConfirmMode` — in Explain mode, `explanation` is in `required` for all tools.
  - `ReadFileParams` and `ListDirParams` gained an `explanation` field (`#[serde(default)]`).
  - `parse_tool_call()` uses model-provided explanation when available, falls back to auto-generated for backward compat.
  - New `check_explanation()` function validates non-empty explanation.
- **`crates/agent/src/agent.rs`**:
  - `SAFE_MODE_PROMPT` constant appended to system prompt in `build()` when `Explain` is active.
  - `run_loop()` validates explanations before processing tool calls; missing explanations return an error to the LLM with a retry limit of 2.
- **`crates/agent/src/security.rs`**: `Explain` behaves as `Always` in `check_command()` and `tool_needs_confirmation()`.

### Public API change

`tool_definitions()` signature changed: now takes `CommandConfirmMode`. External engine consumers must update calls. `CommandConfirmMode` gained a new `Explain` variant.

### Tests

- 16 new tests: tools (12), security (3), config (1)
- All tests pass: `cargo test -p filar-core -p filar-agent` → 133 passed, 0 failed
- `cargo check -p filar-tui` → compiles clean
- New tests fail on old code (behaviour didn't exist)
- Tests with `#[ignore]` (Docker sshd) not run — require manual verification

### Out of scope (issues #263–#265)

- F2 toggle for live mode switching (#263)
- Automatic Markdown session transcript (#264)
- F2 hints and documentation (#265)

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Explain confirmation mode requiring actionable explanations for commands and file or directory access.
  * Added validation that rejects missing or blank explanations and allows limited retries for corrections.
  * Explain mode now applies confirmation to read-only tools, similar to Always mode.
  * Added configuration support for enabling Explain mode.

* **Breaking Changes**
  * Tool definition integrations must now provide the selected confirmation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->