### PR TITLE
feat(tui): F2 toggle for Explain mode with abort of pending confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   (including read-only) require confirmation. Missing explanations are
   rejected with a retry limit of 2.
   ([#262](https://github.com/devlawey/filar/issues/262)).
+- F2 key toggles Explain (safe mode) on/off at runtime, per-tab. If a
+  confirmation is pending when F2 is pressed, it is aborted (denied).
+  The status bar highlights Explain mode with an accent color.
+  ([#263](https://github.com/devlawey/filar/issues/263)).
 
 ### Changed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4193,5 +4193,11 @@ core+agent проходят. Тесты падают на старом коде 
   актуальным режимом активной вкладки.
 - Статус-бар: режим `Explain` подсвечен акцентным цветом.
 
-**Тесты:** 4 новых (f2_toggles, f2_aborts_pending_confirm,
-  f2_in_interactive_mode, tab_switch_syncs). Все 300 tui-тестов проходят.
+**Тесты:** 5 новых (f2_toggles, f2_toggles_off_when_session_starts_in_explain,
+  f2_aborts_pending_confirm, f2_in_interactive_mode, tab_switch_syncs).
+  Все 301 tui-тест проходит.
+
+**Публичный API:** нет изменений. `Session` (TUI crate) получил поля `confirm_mode`
+и `prev_confirm_mode`, но `Session` не является публичным контрактом.
+
+**Дальше:** #264 (авто-расшифровка), #265 (подсказки/документация).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -339,13 +339,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 ## 8. Тесты
 
-- **491 unit-тестов** проходят (включая doc-тесты):
+- **495 unit-тестов** проходят (включая doc-тесты):
   - filar-agent: 87 тестов
   - filar-app: 14 тестов
   - filar-core: 50 тестов + 2 doc-теста
   - filar-gui: 16 тестов
   - filar-transport: 26 тестов (7 ignored — требуют Docker sshd)
-  - filar-tui: 296 тестов
+  - filar-tui: 300 тестов
 - **0 failures**, 7 ignored (Docker)
 
 ```powershell
@@ -4172,3 +4172,26 @@ agent (session_id). Тег `engine-v0.6.1` ставится.
 core+agent проходят. Тесты падают на старом коде (новые behaviour не существует).
 
 **Не вошло (вынесено в #263–#265):** F2 toggle, авто-расшифровка, подсказки/документация.
+
+---
+
+## Issue #263: feat(tui) — Explain mode: F2 toggle with abort of pending confirmation
+
+**Milestone:** 0.9.0. **Ветка:** `feat/263-f2-toggle-explain-mode`.
+
+**Что сделано:**
+- `confirm_mode` и `prev_confirm_mode` добавлены на `Session` (per-tab).
+  `App.confirm_mode` — зеркало активной вкладки, синхронизируется при переключении.
+- `toggle_explain_mode()` на `App`: переключает Explain ↔ предыдущий режим,
+  обрывает `pending_confirm` (отправляет `false` в `respond_to`), добавляет
+  системную строку «Command cancelled: confirm mode switched».
+- `F2` в `handle_key()`: обрабатывается до mode-specific кода (как `F1`),
+  перехватывается в интерактивном режиме (не уходит в терминал как `\x1bOQ`).
+- Синхронизация `App.confirm_mode` на всех tab-switch методах: `prev_tab`,
+  `next_tab`, `switch_to_tab`, `new_tab`, `close_tab`.
+- Runner: `config.confirm_mode` → `app.confirm_mode` — агент строится с
+  актуальным режимом активной вкладки.
+- Статус-бар: режим `Explain` подсвечен акцентным цветом.
+
+**Тесты:** 4 новых (f2_toggles, f2_aborts_pending_confirm,
+  f2_in_interactive_mode, tab_switch_syncs). Все 300 tui-тестов проходят.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -468,6 +468,9 @@ impl App {
         if let Some(confirm) = self.pending_confirm.take() {
             let _ = confirm.respond_to.send(false);
             self.mode = AppMode::Thinking;
+            self.awaiting_confirmation = false;
+            self.confirm_button_areas.clear();
+            self.hovered_button = None;
             self.push_message(ChatBlock::System(
                 "Command cancelled: confirm mode switched".into(),
             ));
@@ -6293,6 +6296,9 @@ mod tests {
             respond_to: tx,
         });
         app.mode = AppMode::Confirming;
+        app.awaiting_confirmation = true;
+        app.confirm_button_areas = vec![(Rect::new(0, 0, 10, 3), true), (Rect::new(0, 0, 10, 3), false)];
+        app.hovered_button = Some(true);
 
         // Press F2 → should abort the pending confirmation.
         app.handle_key(crossterm::event::KeyEvent::new(
@@ -6304,6 +6310,12 @@ mod tests {
         assert!(app.pending_confirm.is_none(), "pending_confirm must be cleared");
         assert_eq!(app.mode, AppMode::Thinking, "mode should return to Thinking");
         assert!(!rx.try_recv().unwrap(), "respond_to should have received false (denied)");
+
+        // All confirmation UI state must be cleared — stale hit-areas must not
+        // consume subsequent clicks.
+        assert!(!app.awaiting_confirmation, "awaiting_confirmation must be cleared");
+        assert!(app.confirm_button_areas.is_empty(), "confirm_button_areas must be cleared");
+        assert!(app.hovered_button.is_none(), "hovered_button must be cleared");
 
         // A system message about cancellation should be present.
         assert!(

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -359,6 +359,10 @@ pub struct Session {
     /// Used to attribute the response to the correct profile even if the
     /// user pressed Ctrl+L before the response arrived.
     pub pending_llm_profile: Option<String>,
+    /// Command confirmation mode for this tab (per-session, toggled via F2).
+    pub confirm_mode: CommandConfirmMode,
+    /// Previous confirm mode (to toggle back from Explain via F2).
+    pub prev_confirm_mode: CommandConfirmMode,
 }
 
 impl App {
@@ -418,6 +422,7 @@ impl App {
         self.pending_local_executors.push(session.id);
         self.sessions.push(session);
         self.active = self.sessions.len() - 1;
+        self.confirm_mode = self.sessions[self.active].confirm_mode;
     }
 
     /// Close the active tab. If it's the last tab, set should_quit.
@@ -438,7 +443,35 @@ impl App {
         if self.active >= self.sessions.len() {
             self.active = self.sessions.len() - 1;
         }
+        self.confirm_mode = self.sessions[self.active].confirm_mode;
         self.closed_ids.push(sid);
+    }
+
+    /// Toggle Explain (safe mode) for the active tab via F2.
+    ///
+    /// Switches between `Explain` and the previous mode. If a confirmation
+    /// is pending, it is aborted (sent `false`) so the toggle doesn't block.
+    pub fn toggle_explain_mode(&mut self) {
+        {
+            let session = &mut self.sessions[self.active];
+            if session.confirm_mode == CommandConfirmMode::Explain {
+                session.confirm_mode = session.prev_confirm_mode;
+            } else {
+                session.prev_confirm_mode = session.confirm_mode;
+                session.confirm_mode = CommandConfirmMode::Explain;
+            }
+        }
+        // Sync App-level mirror.
+        self.confirm_mode = self.sessions[self.active].confirm_mode;
+
+        // Abort pending confirmation if any — toggle must not block.
+        if let Some(confirm) = self.pending_confirm.take() {
+            let _ = confirm.respond_to.send(false);
+            self.mode = AppMode::Thinking;
+            self.push_message(ChatBlock::System(
+                "Command cancelled: confirm mode switched".into(),
+            ));
+        }
     }
 
     /// Take and clear the list of closed session IDs (for runner to process).
@@ -460,6 +493,7 @@ impl App {
         };
         self.sessions[prev].has_new = false;
         self.active = prev;
+        self.confirm_mode = self.sessions[self.active].confirm_mode;
     }
 
     /// Switch to the next tab (wraps around).
@@ -467,6 +501,7 @@ impl App {
         let next = (self.active + 1) % self.sessions.len();
         self.sessions[next].has_new = false;
         self.active = next;
+        self.confirm_mode = self.sessions[self.active].confirm_mode;
     }
 
     /// Switch to tab at index (1-based from user, clamped).
@@ -477,6 +512,7 @@ impl App {
             self.sessions[idx].has_new = false;
         }
         self.active = idx;
+        self.confirm_mode = self.sessions[self.active].confirm_mode;
     }
 
     /// Find the index of a session by its stable id.
@@ -559,6 +595,8 @@ impl Session {
             last_served_model: None,
             model_per_profile: HashMap::new(),
             pending_llm_profile: None,
+            confirm_mode,
+            prev_confirm_mode: confirm_mode,
         }
     }
 
@@ -1103,6 +1141,14 @@ impl App {
         // the overlay would steal Esc from the password-cancel flow.
         if key.code == KeyCode::F(1) && self.mode != AppMode::PasswordInput {
             self.toggle_help_overlay();
+            return;
+        }
+
+        // F2 toggles Explain (safe mode) — same availability as F1.
+        // Intercepted before mode-specific handling so it works in Interactive
+        // mode too (doesn't get sent to the terminal as \x1bOQ).
+        if key.code == KeyCode::F(2) && self.mode != AppMode::PasswordInput {
+            self.toggle_explain_mode();
             return;
         }
 
@@ -6190,5 +6236,114 @@ mod tests {
         // finish_save must allow a new save.
         app.finish_save();
         assert!(!app.save_in_flight, "finish_save must clear the flag");
+    }
+
+    // ── F2 Explain mode toggle tests ───────────────────────────────────
+
+    #[test]
+    fn f2_toggles_explain_mode() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Allowlist);
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Allowlist);
+
+        // Press F2 → should switch to Explain.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Explain);
+
+        // Press F2 again → should switch back to Allowlist.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Allowlist);
+    }
+
+    #[test]
+    fn f2_aborts_pending_confirm() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Allowlist);
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        app.pending_confirm = Some(PendingConfirm {
+            command: "ls".into(),
+            explanation: "list".into(),
+            destructive: false,
+            respond_to: tx,
+        });
+        app.mode = AppMode::Confirming;
+
+        // Press F2 → should abort the pending confirmation.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        // Confirmation should be cleared and denied.
+        assert!(app.pending_confirm.is_none(), "pending_confirm must be cleared");
+        assert_eq!(app.mode, AppMode::Thinking, "mode should return to Thinking");
+        assert!(!rx.try_recv().unwrap(), "respond_to should have received false (denied)");
+
+        // A system message about cancellation should be present.
+        assert!(
+            app.messages.iter().any(|m| matches!(m, ChatBlock::System(s) if s.contains("cancelled"))),
+            "a system message about cancellation should be present"
+        );
+
+        // Mode should have toggled to Explain.
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Explain);
+    }
+
+    #[test]
+    fn f2_in_interactive_mode_does_not_go_to_terminal() {
+        let mut app = make_interactive_app();
+        // make_interactive_app uses Always mode.
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Always);
+
+        // Press F2 in interactive mode.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        // F2 should be intercepted — no terminal input should be produced.
+        assert!(
+            app.pending_term_input.is_none(),
+            "F2 must not be sent to terminal in interactive mode"
+        );
+
+        // Mode should have toggled to Explain.
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Explain);
+    }
+
+    #[test]
+    fn tab_switch_syncs_confirm_mode() {
+        let mut app = App::new("tab1".into(), CommandConfirmMode::Allowlist);
+        app.new_tab(); // Creates tab2, makes it active (index 1)
+        assert_eq!(app.active, 1);
+
+        // Switch back to tab 1.
+        app.prev_tab(); // active = 0
+        assert_eq!(app.active, 0);
+
+        // Toggle Explain on tab 1.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Explain);
+
+        // Switch to tab 2 — app.confirm_mode should reflect tab 2's mode (Allowlist).
+        app.next_tab();
+        assert_eq!(
+            app.confirm_mode, CommandConfirmMode::Allowlist,
+            "tab switch must sync confirm_mode"
+        );
+
+        // Switch back to tab 1 — should be Explain again.
+        app.prev_tab();
+        assert_eq!(
+            app.confirm_mode, CommandConfirmMode::Explain,
+            "switching back should restore Explain"
+        );
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -596,7 +596,7 @@ impl Session {
             model_per_profile: HashMap::new(),
             pending_llm_profile: None,
             confirm_mode,
-            prev_confirm_mode: confirm_mode,
+            prev_confirm_mode: CommandConfirmMode::Allowlist,
         }
     }
 
@@ -6258,6 +6258,28 @@ mod tests {
             crossterm::event::KeyModifiers::NONE,
         ));
         assert_eq!(app.confirm_mode, CommandConfirmMode::Allowlist);
+    }
+
+    #[test]
+    fn f2_toggles_off_when_session_starts_in_explain() {
+        // Session starts in Explain (e.g. from config.toml) — prev_confirm_mode
+        // must default to Allowlist so F2 can toggle it off.
+        let mut app = App::new("test".into(), CommandConfirmMode::Explain);
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Explain);
+
+        // Press F2 → should switch to Allowlist (not back to Explain).
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Allowlist);
+
+        // Press F2 again → should switch back to Explain.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.confirm_mode, CommandConfirmMode::Explain);
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -707,7 +707,7 @@ async fn run_app(
                             session_llm,
                             agent_exec,
                             confirmer.clone(),
-                            config.confirm_mode,
+                            app.confirm_mode,
                             user_input,
                             app.messages.clone(),
                             agent_tx.clone(),

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -155,6 +155,11 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
     // toast, pushed afterwards, starts at column == width and gets clipped by
     // ratatui (the original bug: the toast was never visible).
     let confirm_text = format!(" {:?}", app.confirm_mode);
+    let confirm_style = if app.confirm_mode == filar_core::CommandConfirmMode::Explain {
+        app.theme.muted().fg(app.theme.accent)
+    } else {
+        app.theme.muted()
+    };
     // left_len already includes mode-badge spans (pushed above), so we
     // must NOT add mode_len again — that would double-count and break
     // the right-alignment in non-Normal modes.
@@ -178,7 +183,7 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
     if padding > 0 {
         spans.push(Span::raw(" ".repeat(padding)));
     }
-    spans.push(Span::styled(confirm_text, app.theme.muted()));
+    spans.push(Span::styled(confirm_text, confirm_style));
     if let Some(text) = toast_span_text {
         spans.push(Span::styled(text, app.theme.success_fg()));
     }


### PR DESCRIPTION
## Summary

Implements issue #263 (milestone 0.9.0): F2 key toggles Explain (safe mode) on/off at runtime, per-tab, with abort of pending confirmation.

### Changes

- **`crates/tui/src/app.rs`**:
  - `confirm_mode` and `prev_confirm_mode` added to `Session` (per-tab).
  - `App.confirm_mode` mirrors the active session, synced on all tab switches (`prev_tab`, `next_tab`, `switch_to_tab`, `new_tab`, `close_tab`).
  - `toggle_explain_mode()`: toggles Explain ↔ previous mode. If `pending_confirm` exists, sends `false` (denied), clears state, adds system message.
  - `F2` in `handle_key()`: intercepted before mode-specific code (same pattern as `F1`), works in Interactive mode (doesn't go to terminal).
  - 4 new tests: `f2_toggles_explain_mode`, `f2_aborts_pending_confirm`, `f2_in_interactive_mode_does_not_go_to_terminal`, `tab_switch_syncs_confirm_mode`.

- **`crates/tui/src/runner.rs`**: Changed `config.confirm_mode` → `app.confirm_mode` when spawning agent — agent is built with the active tab's current mode.

- **`crates/tui/src/ui/bars.rs`**: Status bar highlights `Explain` mode with accent color.

### Tests

- 4 new TUI tests, all pass: `cargo test -p filar-tui -- f2_ tab_switch_syncs` → 4 passed, 0 failed
- `cargo check -p filar-tui` → compiles clean
- New tests fail on old code (F2 was not handled)
- Tests with `#[ignore]` (Docker sshd) not run — require manual verification

### Out of scope (issues #264–#265)

- Automatic Markdown session transcript (#264)
- F2 hints and documentation (#265)

Closes #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added F2 support to toggle Explain mode independently for each tab.
  * Pending confirmations are automatically denied when Explain mode is toggled.
  * The status bar now highlights when Explain mode is active.

* **Bug Fixes**
  * Confirmation settings now stay synchronized when switching, creating, or closing tabs.

* **Tests**
  * Expanded coverage for Explain mode toggling, tab synchronization, and confirmation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->