### PR TITLE
feat(tui): automatic Markdown session transcript in Explain mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   confirmation is pending when F2 is pressed, it is aborted (denied).
   The status bar highlights Explain mode with an accent color.
   ([#263](https://github.com/devlawey/filar/issues/263)).
+- Automatic Markdown session transcript in Explain mode: all commands,
+  explanations, outputs, and denials are written to a single `.md` file
+  in the configured save directory. The file is overwritten on each save.
+  Errors are shown once per session without blocking the agent.
+  ([#264](https://github.com/devlawey/filar/issues/264)).
 
 ### Changed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -339,13 +339,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 ## 8. Тесты
 
-- **495 unit-тестов** проходят (включая doc-тесты):
+- **501 unit-тестов** проходят (включая doc-тесты):
   - filar-agent: 87 тестов
   - filar-app: 14 тестов
   - filar-core: 50 тестов + 2 doc-теста
   - filar-gui: 16 тестов
   - filar-transport: 26 тестов (7 ignored — требуют Docker sshd)
-  - filar-tui: 300 тестов
+  - filar-tui: 306 тестов
 - **0 failures**, 7 ignored (Docker)
 
 ```powershell
@@ -4201,3 +4201,36 @@ core+agent проходят. Тесты падают на старом коде 
 и `prev_confirm_mode`, но `Session` не является публичным контрактом.
 
 **Дальше:** #264 (авто-расшифровка), #265 (подсказки/документация).
+
+---
+
+## Issue #264: feat(tui) — Explain mode: automatic Markdown session transcript
+
+**Milestone:** 0.9.0. **Ветка:** `feat/264-auto-transcript`.
+
+**Что сделано:**
+- `transcript_path`, `transcript_saving`, `transcript_error_shown` добавлены на
+  `Session`. Путь фиксируется один раз при первом входе в Explain через F2.
+- `transcript_filename()` — sync-хелпер (без collision check, т.к. файл
+  перезаписывается).
+- `save_transcript_silent()` — тихий путь записи: переиспользует
+  `messages_to_markdown`, не показывает оверлей, учитывает `save_in_flight`
+  и `transcript_saving` для сериализации.
+- `SaveProgress::TranscriptDone(SessionId, Option<String>)` — новый вариант
+  для результата тихой записи. Runner очищает `transcript_saving` и показывает
+  ошибку один раз (флаг `transcript_error_shown`).
+- Хуки: `toggle_explain_mode` (создание пути + final save),
+  `respond_to_confirmation` (после отказа), `CommandFinished` (после вывода),
+  `close_tab` и `quit` (final save).
+- `messages_to_markdown` обновлён: explanation как blockquote, `*(denied)*`
+  маркер для отклонённых команд.
+
+**Публичный API:** `SaveProgress` получил новый вариант `TranscriptDone`.
+`Session` (TUI crate) — не публичный контракт.
+
+**Тесты:** 6 новых (transcript_filename, save_transcript_silent_noop,
+  save_transcript_silent_skips, toggle_explain_creates_transcript_path,
+  toggle_explain_path_persists, messages_to_markdown_includes_explanation_denied).
+  Все 306 tui-тестов проходят.
+
+**Дальше:** #265 (подсказки/документация).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -6502,6 +6502,9 @@ mod tests {
             "expected slug.date.time.md format, got: {name}"
         );
         assert!(!name.contains(' '), "filename must not contain spaces");
+        // Verify format: slug.date.time.md — at least 3 dots.
+        let dot_count = name.chars().filter(|&c| c == '.').count();
+        assert!(dot_count >= 3, "expected at least 3 dots (slug.date.time.md), got {dot_count} dots in: {name}");
     }
 
     #[test]
@@ -6519,6 +6522,16 @@ mod tests {
         app.save_in_flight = true;
         app.save_transcript_silent();
         assert!(!app.sessions[0].transcript_saving, "must skip when save_in_flight is true");
+    }
+
+    #[test]
+    fn save_transcript_silent_skips_when_already_saving() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Explain);
+        app.sessions[0].transcript_path = Some(std::path::PathBuf::from("/tmp/test.md"));
+        app.sessions[0].transcript_saving = true;
+        app.save_transcript_silent();
+        // Should not reset the flag or spawn another task.
+        assert!(app.sessions[0].transcript_saving, "must skip when transcript_saving is already true");
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -363,6 +363,12 @@ pub struct Session {
     pub confirm_mode: CommandConfirmMode,
     /// Previous confirm mode (to toggle back from Explain via F2).
     pub prev_confirm_mode: CommandConfirmMode,
+    /// Fixed path for auto-transcript in Explain mode (set once on first entry).
+    pub transcript_path: Option<std::path::PathBuf>,
+    /// Whether a silent transcript save is currently in flight.
+    pub transcript_saving: bool,
+    /// Whether the transcript write error warning has been shown (show once).
+    pub transcript_error_shown: bool,
 }
 
 impl App {
@@ -430,9 +436,12 @@ impl App {
     /// runner can teardown its interactive backend (PTY/reader task).
     pub fn close_tab(&mut self) {
         if self.sessions.len() <= 1 {
+            self.save_transcript_silent();
             self.should_quit = true;
             return;
         }
+        // Final transcript save before closing the tab.
+        self.save_transcript_silent();
         let sid = self.sessions[self.active].id;
         // Cancel the agent task for the tab being closed so leftover
         // events don't land on the next active session.
@@ -452,6 +461,7 @@ impl App {
     /// Switches between `Explain` and the previous mode. If a confirmation
     /// is pending, it is aborted (sent `false`) so the toggle doesn't block.
     pub fn toggle_explain_mode(&mut self) {
+        let was_explain = self.sessions[self.active].confirm_mode == CommandConfirmMode::Explain;
         {
             let session = &mut self.sessions[self.active];
             if session.confirm_mode == CommandConfirmMode::Explain {
@@ -474,6 +484,31 @@ impl App {
             self.push_message(ChatBlock::System(
                 "Command cancelled: confirm mode switched".into(),
             ));
+        }
+
+        // Transcript handling.
+        if !was_explain {
+            // Entering Explain mode — create transcript path if not yet set.
+            let session = &mut self.sessions[self.active];
+            if session.transcript_path.is_none() {
+                let base_dir = self
+                    .save_dir
+                    .clone()
+                    .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")));
+                let filename = transcript_filename(
+                    &session.target_name,
+                    &session.ssh_info,
+                );
+                let path = base_dir.join(&filename);
+                session.transcript_path = Some(path.clone());
+                session.transcript_error_shown = false;
+                self.push_message(ChatBlock::System(format!(
+                    "Transcript: {}", path.display()
+                )));
+            }
+        } else {
+            // Exiting Explain mode — final transcript save.
+            self.save_transcript_silent();
         }
     }
 
@@ -600,6 +635,9 @@ impl Session {
             pending_llm_profile: None,
             confirm_mode,
             prev_confirm_mode: CommandConfirmMode::Allowlist,
+            transcript_path: None,
+            transcript_saving: false,
+            transcript_error_shown: false,
         }
     }
 
@@ -633,6 +671,8 @@ pub enum SaveProgress {
     Writing,
     Done(String),   // display filename
     Error(String),  // error message
+    /// Silent transcript save completed. `None` = success, `Some` = error.
+    TranscriptDone(SessionId, Option<String>),
 }
 
 /// Convert a Unix timestamp (seconds) to broken-down UTC time.
@@ -683,6 +723,15 @@ fn slugify(s: &str) -> String {
         }
     }
     result.trim_matches('-').chars().take(80).collect()
+}
+
+/// Generate a transcript filename: `{slug}.{date}.{time}.md`.
+/// No collision check — the file is overwritten on each save.
+fn transcript_filename(session_name: &str, ssh_info: &Option<String>) -> String {
+    let base = ssh_info.as_deref().unwrap_or(session_name);
+    let slug = slugify(base);
+    let ts = format_now_utc();
+    format!("{slug}.{ts}.md")
 }
 
 /// Generate a save filename: `{slug}.{date}.{time}.md`, avoiding collisions
@@ -743,8 +792,15 @@ fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &O
             ChatBlock::Agent(s) => {
                 md.push_str(&format!("**Agent:** {s}\n\n"));
             }
-            ChatBlock::Command { command, output, .. } => {
-                md.push_str(&format!("**$ {command}**\n"));
+            ChatBlock::Command { command, explanation, output, approved } => {
+                if !explanation.is_empty() {
+                    md.push_str(&format!("> {explanation}\n\n"));
+                }
+                md.push_str(&format!("**$ {command}**"));
+                if !*approved {
+                    md.push_str(" *(denied)*");
+                }
+                md.push('\n');
                 if let Some(out) = output {
                     let max_ticks = out
                         .chars()
@@ -979,6 +1035,8 @@ impl App {
             }
             _ => {}
         }
+        // Final transcript save before quitting.
+        self.save_transcript_silent();
         self.should_quit = true;
     }
 
@@ -1114,6 +1172,55 @@ impl App {
     /// Esc while the task was still running.
     pub fn finish_save(&mut self) {
         self.save_in_flight = false;
+    }
+
+    /// Silently save the transcript for the active session (Explain mode only).
+    ///
+    /// No overlay, no progress bar. Skips if:
+    /// - `transcript_path` is not set (not in Explain mode or not yet initialized)
+    /// - `save_in_flight` is true (manual Ctrl+S in progress)
+    /// - `transcript_saving` is true (a silent save is already in flight)
+    ///
+    /// On error: warns in the log and shows a feed warning once per session.
+    pub fn save_transcript_silent(&mut self) {
+        let session = &mut self.sessions[self.active];
+
+        // Only if transcript path is set (Explain mode was entered).
+        let path = match &session.transcript_path {
+            Some(p) => p.clone(),
+            None => return,
+        };
+
+        // Skip if manual save or silent save is in flight.
+        if self.save_in_flight || session.transcript_saving {
+            return;
+        }
+
+        let Some(ref tx) = self.save_tx else {
+            return;
+        };
+
+        session.transcript_saving = true;
+
+        let sid = session.id;
+        let messages = session.messages.clone();
+        let session_name = session.target_name.clone();
+        let ssh_info = session.ssh_info.clone();
+        let tx = tx.clone();
+
+        tokio::spawn(async move {
+            let md = messages_to_markdown(&messages, &session_name, &ssh_info);
+            let result = tokio::fs::write(&path, &md).await;
+            match result {
+                Ok(()) => {
+                    tx.send(SaveProgress::TranscriptDone(sid, None)).ok();
+                }
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), error = %e, "transcript write failed");
+                    tx.send(SaveProgress::TranscriptDone(sid, Some(e.to_string()))).ok();
+                }
+            }
+        });
     }
 
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
@@ -2410,6 +2517,8 @@ impl App {
             self.confirm_button_areas.clear();
             self.hovered_button = None;
         }
+        // Save transcript if in Explain mode (denied commands are part of the protocol).
+        self.save_transcript_silent();
     }
 
     /// Compute the default collapse state for a chat block.
@@ -2549,6 +2658,8 @@ impl App {
                         auto_scroll = self.scroll == 0;
                     }
                     self.pending_proposal = None;
+                    // Save transcript if in Explain mode.
+                    self.save_transcript_silent();
                 }
                 filar_agent::AgentEvent::Finished(text) => {
                     if self.streaming {
@@ -6379,5 +6490,108 @@ mod tests {
             app.confirm_mode, CommandConfirmMode::Explain,
             "switching back should restore Explain"
         );
+    }
+
+    // ── Auto-transcript tests ───────────────────────────────────────────
+
+    #[test]
+    fn transcript_filename_has_correct_format() {
+        let name = transcript_filename("my-server", &Some("root@10.0.0.5:22".into()));
+        assert!(
+            name.starts_with("root-10.0.0.5-22.") && name.ends_with(".md"),
+            "expected slug.date.time.md format, got: {name}"
+        );
+        assert!(!name.contains(' '), "filename must not contain spaces");
+    }
+
+    #[test]
+    fn save_transcript_silent_noop_without_path() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Explain);
+        // transcript_path is None by default — save should be a no-op.
+        app.save_transcript_silent();
+        assert!(!app.sessions[0].transcript_saving, "transcript_saving must not be set without path");
+    }
+
+    #[test]
+    fn save_transcript_silent_skips_when_save_in_flight() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Explain);
+        app.sessions[0].transcript_path = Some(std::path::PathBuf::from("/tmp/test.md"));
+        app.save_in_flight = true;
+        app.save_transcript_silent();
+        assert!(!app.sessions[0].transcript_saving, "must skip when save_in_flight is true");
+    }
+
+    #[test]
+    fn toggle_explain_creates_transcript_path() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Allowlist);
+        assert!(app.sessions[0].transcript_path.is_none(), "transcript_path must start as None");
+
+        // Press F2 to enter Explain mode.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        // transcript_path should now be set.
+        assert!(app.sessions[0].transcript_path.is_some(), "transcript_path must be set on entering Explain");
+
+        // A system message with the path should be in the feed.
+        assert!(
+            app.messages.iter().any(|m| matches!(m, ChatBlock::System(s) if s.contains("Transcript:"))),
+            "feed should contain transcript path"
+        );
+    }
+
+    #[test]
+    fn toggle_explain_path_persists_across_toggle() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Allowlist);
+
+        // Enter Explain.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        let path = app.sessions[0].transcript_path.clone();
+        assert!(path.is_some());
+
+        // Exit Explain.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        // Path should NOT change — it persists across toggles.
+        assert_eq!(app.sessions[0].transcript_path, path, "transcript_path must persist across toggles");
+
+        // Re-enter Explain — path should still be the same.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::F(2),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.sessions[0].transcript_path, path, "transcript_path must not change on re-entry");
+    }
+
+    #[test]
+    fn messages_to_markdown_includes_explanation_and_denied() {
+        let blocks = vec![
+            ChatBlock::Command {
+                command: "ls".into(),
+                explanation: "List files to diagnose disk usage".into(),
+                output: Some("file.txt".into()),
+                approved: true,
+            },
+            ChatBlock::Command {
+                command: "rm -rf /tmp".into(),
+                explanation: "Clean temp files".into(),
+                output: None,
+                approved: false,
+            },
+        ];
+        let md = messages_to_markdown(&blocks, "test", &None);
+        // Explanation rendered as blockquote.
+        assert!(md.contains("> List files to diagnose disk usage"), "must include explanation");
+        // Approved command — no *(denied)* marker.
+        assert!(md.contains("**$ ls**\n"), "approved command must be rendered");
+        // Denied command — has *(denied)* marker.
+        assert!(md.contains("**$ rm -rf /tmp** *(denied)*"), "denied command must have *(denied)* marker");
     }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -440,6 +440,21 @@ async fn run_app(
                         }
                         app.finish_save();
                     }
+                    SaveProgress::TranscriptDone(sid, result) => {
+                        if let Some(idx) = app.find_session_idx(sid) {
+                            app.sessions[idx].transcript_saving = false;
+                            if let Some(err) = result {
+                                if !app.sessions[idx].transcript_error_shown {
+                                    app.sessions[idx].transcript_error_shown = true;
+                                    app.sessions[idx].messages.push(filar_core::ChatBlock::Error(
+                                        format!("Transcript write failed: {err}")
+                                    ));
+                                    app.sessions[idx].message_rev =
+                                        app.sessions[idx].message_rev.wrapping_add(1);
+                                }
+                            }
+                        }
+                    }
                 }
                 // Drain any remaining messages delivered during this iteration.
                 while let Ok(p) = save_rx.try_recv() {
@@ -464,6 +479,21 @@ async fn run_app(
                         }
                         SaveProgress::Writing => {
                             app.save_progress = 50;
+                        }
+                        SaveProgress::TranscriptDone(sid, result) => {
+                            if let Some(idx) = app.find_session_idx(sid) {
+                                app.sessions[idx].transcript_saving = false;
+                                if let Some(err) = result {
+                                    if !app.sessions[idx].transcript_error_shown {
+                                        app.sessions[idx].transcript_error_shown = true;
+                                        app.sessions[idx].messages.push(filar_core::ChatBlock::Error(
+                                            format!("Transcript write failed: {err}")
+                                        ));
+                                        app.sessions[idx].message_rev =
+                                            app.sessions[idx].message_rev.wrapping_add(1);
+                                    }
+                                }
+                            }
                         }
                         _ => {}
                     }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -480,21 +480,6 @@ async fn run_app(
                         SaveProgress::Writing => {
                             app.save_progress = 50;
                         }
-                        SaveProgress::TranscriptDone(sid, result) => {
-                            if let Some(idx) = app.find_session_idx(sid) {
-                                app.sessions[idx].transcript_saving = false;
-                                if let Some(err) = result {
-                                    if !app.sessions[idx].transcript_error_shown {
-                                        app.sessions[idx].transcript_error_shown = true;
-                                        app.sessions[idx].messages.push(filar_core::ChatBlock::Error(
-                                            format!("Transcript write failed: {err}")
-                                        ));
-                                        app.sessions[idx].message_rev =
-                                            app.sessions[idx].message_rev.wrapping_add(1);
-                                    }
-                                }
-                            }
-                        }
                         _ => {}
                     }
                 }


### PR DESCRIPTION
## Summary

Implements issue #264 (milestone 0.9.0): automatic Markdown session transcript in Explain mode.

In Explain mode, all commands with explanations, outputs, and denials are automatically written to a single `.md` file in the configured save directory. The file is overwritten on each save and persists across F2 toggles.

### Changes

- **`crates/tui/src/app.rs`**:
  - `transcript_path`, `transcript_saving`, `transcript_error_shown` fields on `Session`.
  - `transcript_filename()` — sync helper (no collision check, file is overwritten).
  - `save_transcript_silent()` — silent save: reuses `messages_to_markdown`, no overlay, serializes with `save_in_flight` and `transcript_saving`.
  - `SaveProgress::TranscriptDone(SessionId, Option<String>)` — new variant for silent save results.
  - `toggle_explain_mode()`: creates `transcript_path` on first entry (shows path in feed), final save on exit.
  - Hooks: `respond_to_confirmation` (after denial), `CommandFinished` (after output), `close_tab` and `quit` (final save).
  - `messages_to_markdown`: explanation rendered as blockquote, `*(denied)*` marker for denied commands.
  - 6 new tests.

- **`crates/tui/src/runner.rs`**: Handles `TranscriptDone` — clears `transcript_saving` on the originating session, shows error once via `transcript_error_shown`.

### Tests

- 6 new TUI tests, all pass: `cargo test -p filar-tui -- transcript_ save_transcript_ toggle_explain_creates toggle_explain_path messages_to_markdown_includes`
- `cargo check -p filar-tui` → compiles clean
- New tests fail on old code (behavior didn't exist)
- Tests with `#[ignore]` (Docker sshd) not run — require manual verification

### Out of scope (issue #265)

- F2 hints and documentation

Closes #264