### PR TITLE
fix(tui): each F2 toggle cycle creates a new transcript file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   checklist.
   ([#265](https://github.com/devlawey/filar/issues/265)).
 
+### Fixed
+
+- Explain mode transcript: each F2 toggle cycle now creates a new `.md`
+  file. Previously the same file was reused across toggle cycles because
+  `transcript_path` was never cleared on exit.
+  ([#275](https://github.com/devlawey/filar/issues/275)).
+
 ### Changed
 
 - Session-save directory, LLM profiles and SSH targets are now passed from

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4256,3 +4256,20 @@ core+agent проходят. Тесты падают на старом коде 
 **Тесты:** 1 новый (normal_mode_help_includes_f2). Все 307 tui-тестов проходят.
 
 **Дальше:** milestone 0.9.0 завершён (все 4 issue: #262–#265). Релиз v0.9.0.
+
+---
+
+## Issue #275: fix(tui) — Explain mode: each F2 entry creates a new transcript file
+
+**Milestone:** 0.9.0. **Ветка:** `fix/275-transcript-new-file-per-toggle`.
+
+**Что сделано:**
+- `toggle_explain_mode()`: при выходе из Explain (F2) `transcript_path`
+  очищается в `None` + `transcript_error_shown = false`. Следующий вход в
+  Explain создаёт новый файл (новый timestamp).
+- Тест `toggle_explain_creates_new_file_each_entry` заменяет старый
+  `toggle_explain_path_persists_across_toggle`.
+
+**Публичный API:** нет изменений.
+
+**Тесты:** 1 обновлён. Все 307 tui-тестов проходят.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -507,8 +507,11 @@ impl App {
                 )));
             }
         } else {
-            // Exiting Explain mode — final transcript save.
+            // Exiting Explain mode — final transcript save, then clear path
+            // so the next F2 entry creates a new file.
             self.save_transcript_silent();
+            self.sessions[self.active].transcript_path = None;
+            self.sessions[self.active].transcript_error_shown = false;
         }
     }
 
@@ -6556,31 +6559,35 @@ mod tests {
     }
 
     #[test]
-    fn toggle_explain_path_persists_across_toggle() {
+    fn toggle_explain_creates_new_file_each_entry() {
         let mut app = App::new("test".into(), CommandConfirmMode::Allowlist);
 
-        // Enter Explain.
+        // Enter Explain — first file created.
         app.handle_key(crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::F(2),
             crossterm::event::KeyModifiers::NONE,
         ));
-        let path = app.sessions[0].transcript_path.clone();
-        assert!(path.is_some());
+        let path1 = app.sessions[0].transcript_path.clone();
+        assert!(path1.is_some(), "transcript_path must be set on first entry");
 
-        // Exit Explain.
+        // Exit Explain — path should be cleared.
         app.handle_key(crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::F(2),
             crossterm::event::KeyModifiers::NONE,
         ));
-        // Path should NOT change — it persists across toggles.
-        assert_eq!(app.sessions[0].transcript_path, path, "transcript_path must persist across toggles");
+        assert!(app.sessions[0].transcript_path.is_none(), "transcript_path must be cleared on exit");
 
-        // Re-enter Explain — path should still be the same.
+        // Wait 1 second so the new file gets a different timestamp.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // Re-enter Explain — new file created (different path).
         app.handle_key(crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::F(2),
             crossterm::event::KeyModifiers::NONE,
         ));
-        assert_eq!(app.sessions[0].transcript_path, path, "transcript_path must not change on re-entry");
+        let path2 = app.sessions[0].transcript_path.clone();
+        assert!(path2.is_some(), "transcript_path must be set on re-entry");
+        assert_ne!(path1, path2, "each F2 entry must create a new file");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes issue #275: Explain mode transcript file was reused across F2 toggle cycles.

### Bug

`transcript_path` was set on first F2 entry and never cleared. Subsequent F2 entries reused the same file instead of creating a new one.

### Fix

In `toggle_explain_mode()`, the exit branch now clears `transcript_path = None` and `transcript_error_shown = false` after the final save. The next F2 entry creates a new file with a fresh timestamp.

### Behavior after fix

```
F2 (enter)  → new .md file (timestamp #1)
work        → writes to file #1
F2 (exit)   → final save to file #1, path cleared
F2 (enter)  → new .md file (timestamp #2)
Ctrl+S      → manual save — unaffected
```

### Test

`toggle_explain_creates_new_file_each_entry` (replaces `toggle_explain_path_persists_across_toggle`):
- Asserts `transcript_path` is `None` after exit
- Asserts new `Some` path after re-entry
- Asserts paths differ (with 1s sleep for timestamp uniqueness)

`cargo test -p filar-tui -- toggle_explain_creates_new_file` → 1 passed, 0 failed

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Explain mode now creates a new timestamped Markdown transcript each time it is entered.
  - Exiting Explain mode saves the current transcript and resets its state, preventing later sessions from overwriting earlier transcripts.

- **Documentation**
  - Added release notes and usage documentation describing the updated Explain mode transcript behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->