### PR TITLE
fix(tui): label transcript date as UTC, add mode activation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   file. Previously the same file was reused across toggle cycles because
   `transcript_path` was never cleared on exit.
   ([#275](https://github.com/devlawey/filar/issues/275)).
+- Transcript date now labeled as UTC (`Date: ... UTC`). Safe mode
+  activation/deactivation messages added to the chat feed and transcript.
+  ([#277](https://github.com/devlawey/filar/issues/277)).
 
 ### Changed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4273,3 +4273,20 @@ core+agent проходят. Тесты падают на старом коде 
 **Публичный API:** нет изменений.
 
 **Тесты:** 1 обновлён. Все 307 tui-тестов проходят.
+
+---
+
+## Issue #277: fix(tui) — Transcript: UTC time label and mode activation messages
+
+**Milestone:** 0.9.0. **Ветка:** `fix/277-transcript-utc-mode`.
+
+**Что сделано:**
+- `messages_to_markdown()`: дата помечена как UTC — `Date: ... UTC`.
+- `toggle_explain_mode()`: при входе в Explain добавляется системное сообщение
+  `Safe mode (Explain) activated. Transcript: {path}`. При выходе —
+  `Safe mode (Explain) deactivated`. Транскрипт теперь показывает смену режима.
+- Тест обновлён: проверяет `contains("Safe mode")`.
+
+**Публичный API:** нет изменений.
+
+**Тесты:** 1 обновлён. Все 307 tui-тестов проходят.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -503,7 +503,7 @@ impl App {
                 session.transcript_path = Some(path.clone());
                 session.transcript_error_shown = false;
                 self.push_message(ChatBlock::System(format!(
-                    "Transcript: {}", path.display()
+                    "Safe mode (Explain) activated. Transcript: {}", path.display()
                 )));
             }
         } else {
@@ -512,6 +512,9 @@ impl App {
             self.save_transcript_silent();
             self.sessions[self.active].transcript_path = None;
             self.sessions[self.active].transcript_error_shown = false;
+            self.push_message(ChatBlock::System(
+                "Safe mode (Explain) deactivated".into(),
+            ));
         }
     }
 
@@ -779,7 +782,7 @@ fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &O
             .unwrap_or_default()
             .as_secs();
         let (y, mo, d, h, mi, s) = unix_to_ymdhms(secs);
-        format!("{y:04}-{mo:02}-{d:02} {h:02}:{mi:02}:{s:02}")
+        format!("{y:04}-{mo:02}-{d:02} {h:02}:{mi:02}:{s:02} UTC")
     };
     md.push_str(&format!("Date: {ts}\n"));
     if let Some(ref info) = ssh_info {
@@ -6553,8 +6556,8 @@ mod tests {
 
         // A system message with the path should be in the feed.
         assert!(
-            app.messages.iter().any(|m| matches!(m, ChatBlock::System(s) if s.contains("Transcript:"))),
-            "feed should contain transcript path"
+            app.messages.iter().any(|m| matches!(m, ChatBlock::System(s) if s.contains("Safe mode") && s.contains("Transcript:"))),
+            "feed should contain safe mode activation with transcript path"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes issue #277: two transcript issues found during manual testing.

### Changes

1. **UTC label** — `messages_to_markdown()` date now includes `UTC` suffix:
   ```
   Date: 2026-08-13 20:07:22 UTC
   ```
   The timestamp was already UTC (via `unix_to_ymdhms`), just not labeled. Full local-time conversion would require adding `chrono` as a dependency — out of scope for this fix.

2. **Mode activation messages** — `toggle_explain_mode()` now adds system messages:
   - On entry: `Safe mode (Explain) activated. Transcript: {path}`
   - On exit: `Safe mode (Explain) deactivated`
   
   Previously the only system message was `Connected to: ssh | Mode: Allowlist` from session creation, which was misleading after toggling to Explain. Now the transcript shows mode changes.

### Tests

- `toggle_explain_creates_transcript_path` — updated to check for `contains("Safe mode")` and `contains("Transcript:")`
- All 4 transcript tests pass: `cargo test -p filar-tui -- toggle_explain messages_to_markdown` → 4 passed, 0 failed

Closes #277