### PR TITLE
fix(tui): local time via chrono, remove stale mode from Connected message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   file. Previously the same file was reused across toggle cycles because
   `transcript_path` was never cleared on exit.
   ([#275](https://github.com/devlawey/filar/issues/275)).
-- Transcript date now labeled as UTC (`Date: ... UTC`). Safe mode
-  activation/deactivation messages added to the chat feed and transcript.
+- Transcript date now uses local time (via `chrono`). The initial "Connected to"
+  message no longer includes the mode — mode changes are shown via F2
+  activation/deactivation messages.
   ([#277](https://github.com/devlawey/filar/issues/277)).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   file. Previously the same file was reused across toggle cycles because
   `transcript_path` was never cleared on exit.
   ([#275](https://github.com/devlawey/filar/issues/275)).
-- Transcript date now uses local time (via `chrono`). The initial "Connected to"
-  message no longer includes the mode — mode changes are shown via F2
-  activation/deactivation messages.
+- Transcript date now uses local time with timezone offset (via `chrono`).
+  The initial "Connected to" message no longer includes the mode.
+  ([#277](https://github.com/devlawey/filar/issues/277)).
+- Safe mode (Explain) activation/deactivation messages added to the chat feed
+  and transcript: "Safe mode (Explain) activated. Transcript: {path}" on F2
+  entry, "Safe mode (Explain) deactivated" on exit.
   ([#277](https://github.com/devlawey/filar/issues/277)).
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ keyring = { version = "3", default-features = false, features = ["apple-native",
 # Clipboard
 arboard = "3"
 
+# Date/time
+chrono = "0.4"
+
 # Secret zeroization
 zeroize = { version = "1", features = ["derive"] }
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4298,10 +4298,14 @@ core+agent проходят. Тесты падают на старом коде 
 **Milestone:** 0.9.0. **Ветка:** `fix/277b-remove-mode-from-connected`.
 
 **Что сделано:**
-- `messages_to_markdown()`: вместо UTC с меткой используется `chrono::Local::now()` —
-  местное время без суффикса UTC.
+- `messages_to_markdown()`: местное время с numeric timezone offset
+  (`chrono::Local::now().format("%Y-%m-%d %H:%M:%S %:z")`), например `+03:00`.
 - `Session::new()`: убран `| Mode: {confirm_mode:?}` из начального сообщения.
   Режим теперь виден только через F2 activation/deactivation messages.
+- `toggle_explain_mode()`: deactivation message добавляется ДО `save_transcript_silent()`,
+  чтобы попасть в финальный транскрипт.
 - `chrono` добавлен как зависимость workspace + tui crate.
 
-**Публичный API:** добавлена зависимость `chrono` в `filar-tui`.
+**Публичный API:** нет изменений. `Session::new()` сигнатура не изменилась.
+
+**Дальше:** issue #271–#274 (session persistence overhaul).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4290,3 +4290,18 @@ core+agent проходят. Тесты падают на старом коде 
 **Публичный API:** нет изменений.
 
 **Тесты:** 1 обновлён. Все 307 tui-тестов проходят.
+
+---
+
+## Issue #277 (follow-up): fix(tui) — Local time + remove stale mode from Connected message
+
+**Milestone:** 0.9.0. **Ветка:** `fix/277b-remove-mode-from-connected`.
+
+**Что сделано:**
+- `messages_to_markdown()`: вместо UTC с меткой используется `chrono::Local::now()` —
+  местное время без суффикса UTC.
+- `Session::new()`: убран `| Mode: {confirm_mode:?}` из начального сообщения.
+  Режим теперь виден только через F2 activation/deactivation messages.
+- `chrono` добавлен как зависимость workspace + tui crate.
+
+**Публичный API:** добавлена зависимость `chrono` в `filar-tui`.

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -17,4 +17,5 @@ futures = { workspace = true }
 async-trait = { workspace = true }
 alacritty_terminal = { workspace = true }
 arboard = { workspace = true }
+chrono = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -587,7 +587,7 @@ impl Session {
             id: SessionId::next(),
             target_name,
             messages: vec![ChatBlock::System(format!(
-                "Connected to: {name} | Mode: {confirm_mode:?}"
+                "Connected to: {name}"
             ))],
             input: String::new(),
             cursor_pos: 0,
@@ -776,14 +776,7 @@ async fn generate_save_filename(
 fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &Option<String>) -> String {
     let mut md = String::new();
     md.push_str(&format!("# Session: {session_name}\n\n"));
-    let ts = {
-        let secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let (y, mo, d, h, mi, s) = unix_to_ymdhms(secs);
-        format!("{y:04}-{mo:02}-{d:02} {h:02}:{mi:02}:{s:02} UTC")
-    };
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
     md.push_str(&format!("Date: {ts}\n"));
     if let Some(ref info) = ssh_info {
         md.push_str(&format!("Target: {info}\n"));

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -507,14 +507,15 @@ impl App {
                 )));
             }
         } else {
-            // Exiting Explain mode — final transcript save, then clear path
+            // Exiting Explain mode — push deactivation message BEFORE the
+            // final save so it appears in the transcript, then clear path
             // so the next F2 entry creates a new file.
-            self.save_transcript_silent();
-            self.sessions[self.active].transcript_path = None;
-            self.sessions[self.active].transcript_error_shown = false;
             self.push_message(ChatBlock::System(
                 "Safe mode (Explain) deactivated".into(),
             ));
+            self.save_transcript_silent();
+            self.sessions[self.active].transcript_path = None;
+            self.sessions[self.active].transcript_error_shown = false;
         }
     }
 
@@ -6625,15 +6626,14 @@ mod tests {
     fn messages_to_markdown_date_has_timezone_offset() {
         let blocks = vec![ChatBlock::User("hi".into())];
         let md = messages_to_markdown(&blocks, "test", &None);
-        // Date line should contain a timezone offset like +03:00
+        // Date line must match "YYYY-MM-DD HH:MM:SS ±HH:MM" format.
         let date_line = md.lines().find(|l| l.starts_with("Date:"));
         assert!(date_line.is_some(), "must have Date line");
         let date_line = date_line.unwrap();
-        assert!(!date_line.contains("UTC"), "must not say UTC");
-        // Should end with a timezone offset like +03:00 or -05:00
+        let rest = date_line.strip_prefix("Date: ").expect("Date line");
         assert!(
-            date_line.chars().last().map(|c| c.is_ascii_digit()).unwrap_or(false),
-            "Date line should end with timezone offset digit: {date_line}"
+            chrono::DateTime::parse_from_str(rest, "%Y-%m-%d %H:%M:%S %:z").is_ok(),
+            "Date line must contain timezone offset (YYYY-MM-DD HH:MM:SS ±HH:MM): {date_line}"
         );
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -776,7 +776,7 @@ async fn generate_save_filename(
 fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &Option<String>) -> String {
     let mut md = String::new();
     md.push_str(&format!("# Session: {session_name}\n\n"));
-    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %:z").to_string();
     md.push_str(&format!("Date: {ts}\n"));
     if let Some(ref info) = ssh_info {
         md.push_str(&format!("Target: {info}\n"));
@@ -6609,5 +6609,31 @@ mod tests {
         assert!(md.contains("**$ ls**\n"), "approved command must be rendered");
         // Denied command — has *(denied)* marker.
         assert!(md.contains("**$ rm -rf /tmp** *(denied)*"), "denied command must have *(denied)* marker");
+    }
+
+    #[test]
+    fn session_initial_message_has_no_mode() {
+        let app = App::new("test-server".into(), CommandConfirmMode::Explain);
+        let first_msg = &app.messages[0];
+        assert!(
+            matches!(first_msg, ChatBlock::System(s) if s == "Connected to: test-server"),
+            "initial message must be 'Connected to: {{name}}' without Mode"
+        );
+    }
+
+    #[test]
+    fn messages_to_markdown_date_has_timezone_offset() {
+        let blocks = vec![ChatBlock::User("hi".into())];
+        let md = messages_to_markdown(&blocks, "test", &None);
+        // Date line should contain a timezone offset like +03:00
+        let date_line = md.lines().find(|l| l.starts_with("Date:"));
+        assert!(date_line.is_some(), "must have Date line");
+        let date_line = date_line.unwrap();
+        assert!(!date_line.contains("UTC"), "must not say UTC");
+        // Should end with a timezone offset like +03:00 or -05:00
+        assert!(
+            date_line.chars().last().map(|c| c.is_ascii_digit()).unwrap_or(false),
+            "Date line should end with timezone offset digit: {date_line}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fix for #277 — two issues found during manual testing of PR #278.

### Changes

1. **Local time** — `messages_to_markdown()` now uses `chrono::Local::now()` instead of UTC. Transcript header:
   ```
   Date: 2026-08-13 23:29:21
   ```
   (was `2026-08-13 20:29:21 UTC` — 3 hours off for UTC+3)

2. **Removed stale mode** — `Session::new()` initial message is now just `Connected to: ssh` (was `Connected to: ssh | Mode: Allowlist`). Mode changes are shown via F2 activation/deactivation messages added in PR #278.

3. **Dependency** — added `chrono = "0.4"` to workspace + `filar-tui`.

### Tests

- `cargo build -p filar-tui` → compiles clean
- All existing tests pass

Closes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Transcript dates now display in local time with the appropriate numeric timezone offset.
  * Initial connection messages are simpler and no longer include the confirmation mode.
  * Explain-mode activation and deactivation are communicated clearly in the chat feed and transcript.
* **Documentation**
  * Updated the unreleased changelog to document the revised date formatting and mode messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->