### PR TITLE
feat(core): extend Session with launch context (ssh_info, model, api_base_url, confirm_mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   F2 in the keyboard shortcuts table. `docs/SMOKE.md` includes a safe-mode
   checklist.
   ([#265](https://github.com/devlawey/filar/issues/265)).
+- Session launch context: saved sessions now record `ssh_info`, `model`,
+  `api_base_url`, and `confirm_mode`. On restore (`--session`), the saved
+  SSH host is surfaced in the tab label and the saved confirm mode is
+  re-applied.
+  ([#271](https://github.com/devlawey/filar/issues/271)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4309,3 +4309,30 @@ core+agent проходят. Тесты падают на старом коде 
 **Публичный API:** нет изменений. `Session::new()` сигнатура не изменилась.
 
 **Дальше:** issue #271–#274 (session persistence overhaul).
+
+---
+
+## Issue #271: feat(core) — Extend Session with launch context
+
+**Milestone:** 0.9.0. **Ветка:** `feat/271-session-launch-context`.
+
+**Что сделано:**
+- `filar_core::Session` получил 4 новых поля (все `#[serde(default)]`,
+  обратная совместимость): `ssh_info: Option<String>`, `model: Option<String>`,
+  `api_base_url: Option<String>`, `confirm_mode: Option<CommandConfirmMode>`.
+- `SessionMeta` получил `ssh_info` и `model` (для отображения в списках).
+- `runner.rs`: извлечён `session_snapshot()` — при сохранении сессии
+  заполняются новые поля (ssh_info из активной вкладки, model/api_base_url из
+  активного LLM-профиля, confirm_mode из активной вкладки).
+- `app/main.rs`: при восстановлении (`--session`) читаются `ssh_info` и
+  `confirm_mode`; `ssh_info` передаётся в TUI (`TuiConfig::initial_ssh_info`)
+  для отображения хоста, `confirm_mode` переопределяет конфиг.
+- `model`/`api_base_url` используются GUI-лаунчером (#274), сюда не входят.
+
+**Публичный контракт:** `filar_core::Session` и `SessionMeta` расширены
+(additive, serde-совместимо). `TuiConfig` получил поле `initial_ssh_info`.
+
+**Тесты:** 3 новых (launch_context_roundtrip, launch_context_backward_compat,
+session_meta_includes_launch_context). `cargo test --workspace` зелёные.
+
+**Дальше:** #272 (автосейв + panic-safe), #273 (F3 overlay), #274 (GUI авто-выбор).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -462,6 +462,8 @@ async fn run() -> anyhow::Result<()> {
         per_profile: HashMap<String, filar_core::ProfileUsage>,
         last_served_model: Option<String>,
         model_per_profile: HashMap<String, String>,
+        ssh_info: Option<String>,
+        confirm_mode: Option<filar_core::CommandConfirmMode>,
     }
     let loaded = if let Some(ref sid) = session_id {
         info!(session_id = %sid, "loading session");
@@ -479,6 +481,8 @@ async fn run() -> anyhow::Result<()> {
                         per_profile: session.per_profile,
                         last_served_model: session.last_served_model,
                         model_per_profile: session.model_per_profile,
+                        ssh_info: session.ssh_info,
+                        confirm_mode: session.confirm_mode,
                     }
                 }
                 Ok(None) => {
@@ -505,7 +509,7 @@ async fn run() -> anyhow::Result<()> {
     let key_checker_provider = secret_provider.clone();
     let tui_config = TuiConfig {
         target_name: target_name.clone(),
-        confirm_mode: config.confirm_mode,
+        confirm_mode: loaded.confirm_mode.unwrap_or(config.confirm_mode),
         llm_profile: default_profile_name.clone(),
         initial_messages: loaded.messages,
         initial_input_history: loaded.input_history,
@@ -518,6 +522,7 @@ async fn run() -> anyhow::Result<()> {
         initial_model_per_profile: loaded.model_per_profile,
         ssh_target: ssh_target.clone(),
         is_local: ssh_target.is_none(),
+        initial_ssh_info: loaded.ssh_info,
         secret_provider: secret_provider.clone(),
         log_rx,
         profiles: launch_profiles,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::chat::ChatBlock;
+use crate::config::CommandConfirmMode;
 use crate::error::{CoreError, Result};
 
 /// Maximum number of sessions to retain on disk.
@@ -76,6 +77,19 @@ pub struct Session {
     /// Keyed by profile name. `#[serde(default)]` for backward compat.
     #[serde(default)]
     pub model_per_profile: HashMap<String, String>,
+    /// SSH connection info the session was launched with (e.g. `user@host:port`).
+    /// `None` = local. `#[serde(default)]` for backward compat.
+    #[serde(default)]
+    pub ssh_info: Option<String>,
+    /// Model identifier used at launch (e.g. `glm-5.1`). `#[serde(default)]`.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// API base URL used at launch. `#[serde(default)]`.
+    #[serde(default)]
+    pub api_base_url: Option<String>,
+    /// Command confirmation mode at launch. `#[serde(default)]`.
+    #[serde(default)]
+    pub confirm_mode: Option<CommandConfirmMode>,
 }
 
 /// Lightweight metadata for listing sessions without loading full messages.
@@ -85,6 +99,12 @@ pub struct SessionMeta {
     pub timestamp: String,
     pub target: String,
     pub llm_profile: Option<String>,
+    /// SSH connection info (e.g. `user@host:port`). `None` = local.
+    #[serde(default)]
+    pub ssh_info: Option<String>,
+    /// Model identifier used at launch.
+    #[serde(default)]
+    pub model: Option<String>,
     /// Preview of the first user message (or system message).
     pub preview: String,
 }
@@ -103,6 +123,8 @@ impl From<&Session> for SessionMeta {
             timestamp: s.timestamp.clone(),
             target: s.target.clone(),
             llm_profile: s.llm_profile.clone(),
+            ssh_info: s.ssh_info.clone(),
+            model: s.model.clone(),
             preview,
         }
     }
@@ -318,6 +340,10 @@ mod tests {
             per_profile: HashMap::new(),
             last_served_model: None,
             model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
         };
         let meta = SessionMeta::from(&session);
         assert_eq!(meta.id, "123");
@@ -340,6 +366,10 @@ mod tests {
             per_profile: HashMap::new(),
             last_served_model: None,
             model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
         };
         let meta = SessionMeta::from(&session);
         assert!(meta.preview.is_empty());
@@ -371,6 +401,10 @@ mod tests {
             per_profile: HashMap::new(),
             last_served_model: None,
             model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
         };
 
         store.save(&session).unwrap();
@@ -415,6 +449,10 @@ mod tests {
             per_profile: HashMap::new(),
             last_served_model: None,
             model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
             };
             store.save(&session).unwrap();
         }
@@ -493,6 +531,7 @@ mod tests {
             llm_profile: Some("glm".into()), messages: vec![], input_history: vec![],
             tokens_in: 150, tokens_out: 300,
             cost_usd: None, per_profile: HashMap::new(), last_served_model: None, model_per_profile: HashMap::new(),
+            ssh_info: None, model: None, api_base_url: None, confirm_mode: None,
         };
         let json = serde_json::to_string(&s).unwrap();
         assert!(json.contains("tokens_in"), "must serialize tokens_in");
@@ -533,6 +572,10 @@ mod tests {
             per_profile: HashMap::new(),
             last_served_model: None,
             model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
         };
         let json = serde_json::to_string_pretty(&session).unwrap();
         assert!(json.contains("input_history"), "JSON must contain input_history");
@@ -573,6 +616,10 @@ mod tests {
             per_profile: HashMap::new(),
             last_served_model: None,
             model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
         };
         assert!(session.input_history.len() > MAX_INPUT_HISTORY);
         session.truncate_history();
@@ -606,6 +653,10 @@ mod tests {
             tokens_in: 0, tokens_out: 0,
             cost_usd: None, per_profile: HashMap::new(), last_served_model: None,
             model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
         };
         session.model_per_profile.insert("glm".into(), "openai/gpt-4o-mini".into());
         let json = serde_json::to_string(&session).unwrap();
@@ -622,5 +673,75 @@ mod tests {
         }"#;
         let s: Session = serde_json::from_str(old_json).unwrap();
         assert!(s.model_per_profile.is_empty());
+    }
+
+    #[test]
+    fn launch_context_roundtrip() {
+        let session = Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "prod".into(),
+            llm_profile: Some("glm".into()),
+            messages: vec![],
+            input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
+            cost_usd: None,
+            per_profile: HashMap::new(),
+            last_served_model: None,
+            model_per_profile: HashMap::new(),
+            ssh_info: Some("root@10.0.0.5:22".into()),
+            model: Some("glm-5.1".into()),
+            api_base_url: Some("https://open.bigmodel.cn/api/paas/v4".into()),
+            confirm_mode: Some(CommandConfirmMode::Always),
+        };
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.ssh_info.as_deref(), Some("root@10.0.0.5:22"));
+        assert_eq!(restored.model.as_deref(), Some("glm-5.1"));
+        assert_eq!(
+            restored.api_base_url.as_deref(),
+            Some("https://open.bigmodel.cn/api/paas/v4")
+        );
+        assert_eq!(restored.confirm_mode, Some(CommandConfirmMode::Always));
+    }
+
+    #[test]
+    fn launch_context_backward_compat() {
+        let old_json = r#"{
+            "id":"1","timestamp":"t","target":"t",
+            "messages":[], "input_history":[],
+            "tokens_in":0, "tokens_out":0
+        }"#;
+        let s: Session = serde_json::from_str(old_json).unwrap();
+        assert_eq!(s.ssh_info, None);
+        assert_eq!(s.model, None);
+        assert_eq!(s.api_base_url, None);
+        assert_eq!(s.confirm_mode, None);
+    }
+
+    #[test]
+    fn session_meta_includes_launch_context() {
+        let session = Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "prod".into(),
+            llm_profile: Some("glm".into()),
+            messages: vec![ChatBlock::User("hi".into())],
+            input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
+            cost_usd: None,
+            per_profile: HashMap::new(),
+            last_served_model: None,
+            model_per_profile: HashMap::new(),
+            ssh_info: Some("root@10.0.0.5:22".into()),
+            model: Some("glm-5.1".into()),
+            api_base_url: Some("https://example.com".into()),
+            confirm_mode: Some(CommandConfirmMode::Allowlist),
+        };
+        let meta = SessionMeta::from(&session);
+        assert_eq!(meta.ssh_info.as_deref(), Some("root@10.0.0.5:22"));
+        assert_eq!(meta.model.as_deref(), Some("glm-5.1"));
     }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -212,6 +212,10 @@ pub struct TuiConfig {
     /// SSH target for interactive terminal mode (Ctrl+T).
     /// If `None`, the agent runs in local mode.
     pub ssh_target: Option<filar_core::SshTarget>,
+    /// SSH connection info restored from a saved session (e.g. `user@host:port`).
+    /// Used to pre-populate the session's display info on restore; the actual
+    /// reconnection is handled by the session-select overlay / launcher.
+    pub initial_ssh_info: Option<String>,
     /// Whether commands execute on the local machine (true) or over SSH (false).
     pub is_local: bool,
     /// Secret provider for command substitution and output sanitisation.
@@ -371,6 +375,11 @@ async fn run_app(
     if let Some(ref target) = config.ssh_target {
         app.sessions[0].ssh_info =
             Some(format!("{}@{}:{}", target.user, target.host, target.port));
+    } else if let Some(ref info) = config.initial_ssh_info {
+        // Restored session was over SSH but no live ssh_target was provided
+        // (e.g. `--session` restore without `--target`). Surface the saved
+        // host in the tab label; reconnecting is handled by the overlay.
+        app.sessions[0].ssh_info = Some(info.clone());
     }
 
     // Crossterm event stream for async keyboard input.
@@ -1134,22 +1143,7 @@ async fn run_app(
     }
 
     // Save session to disk for future restore.
-    let (id, timestamp) = filar_core::session::now_session_id();
-    let mut session = filar_core::Session {
-        id,
-        timestamp,
-        target: config.target_name.clone(),
-        llm_profile: app.llm_profile.clone(),
-        messages: app.messages.clone(),
-        input_history: app.input_history().to_vec(),
-        tokens_in: app.tokens_in,
-        tokens_out: app.tokens_out,
-        cost_usd: app.cost_usd,
-        per_profile: app.per_profile.clone(),
-        last_served_model: app.last_served_model.clone(),
-        model_per_profile: app.model_per_profile.clone(),
-    };
-    session.truncate_history();
+    let session = session_snapshot(&app, &config.target_name);
     match filar_core::SessionStore::with_default_dir() {
         Ok(store) => {
             if let Err(e) = store.save(&session) {
@@ -1166,6 +1160,43 @@ async fn run_app(
 
     info!("TUI session ended");
     Ok(())
+}
+
+/// Build a serialisable [`filar_core::Session`] snapshot from the active TUI
+/// session, including launch context (ssh_info, model, api_base_url,
+/// confirm_mode) so a later restore can re-select the same host and model.
+fn session_snapshot(app: &App, target_name: &str) -> filar_core::Session {
+    let (id, timestamp) = filar_core::session::now_session_id();
+    let active_profile_name = app
+        .llm_profile
+        .clone()
+        .unwrap_or_else(|| app.default_profile_name.clone());
+    let (model, api_base_url) = app
+        .profiles
+        .iter()
+        .find(|p| p.name == active_profile_name)
+        .map(|p| (Some(p.model.clone()), Some(p.api_base_url.clone())))
+        .unwrap_or((None, None));
+    let mut session = filar_core::Session {
+        id,
+        timestamp,
+        target: target_name.to_string(),
+        llm_profile: app.llm_profile.clone(),
+        messages: app.messages.clone(),
+        input_history: app.input_history().to_vec(),
+        tokens_in: app.tokens_in,
+        tokens_out: app.tokens_out,
+        cost_usd: app.cost_usd,
+        per_profile: app.per_profile.clone(),
+        last_served_model: app.last_served_model.clone(),
+        model_per_profile: app.model_per_profile.clone(),
+        ssh_info: app.ssh_info.clone(),
+        model,
+        api_base_url,
+        confirm_mode: Some(app.active_session().confirm_mode),
+    };
+    session.truncate_history();
+    session
 }
 
 /// Await the next forwarded log line from the optional receiver.

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1420,17 +1420,32 @@ mod tests {
     fn session_snapshot_captures_launch_context() {
         use filar_core::{CommandConfirmMode, LlmProfile};
         let mut app = App::new("prod".into(), CommandConfirmMode::Always);
-        app.profiles = vec![LlmProfile {
-            name: "glm".into(),
-            model: "glm-5.1".into(),
-            api_base_url: "https://open.bigmodel.cn/api/paas/v4".into(),
-            max_tokens: 1024,
-            key_env: "GLM_API_KEY".into(),
-            temperature: None,
-            top_p: None,
-            extra_body: None,
-        }];
-        app.default_profile_name = "glm".into();
+        app.profiles = vec![
+            LlmProfile {
+                name: "glm".into(),
+                model: "glm-5.1".into(),
+                api_base_url: "https://open.bigmodel.cn/api/paas/v4".into(),
+                max_tokens: 1024,
+                key_env: "GLM_API_KEY".into(),
+                temperature: None,
+                top_p: None,
+                extra_body: None,
+            },
+            LlmProfile {
+                name: "other".into(),
+                model: "other-model".into(),
+                api_base_url: "https://other.example.com".into(),
+                max_tokens: 1024,
+                key_env: "OTHER_API_KEY".into(),
+                temperature: None,
+                top_p: None,
+                extra_body: None,
+            },
+        ];
+        // Default differs from the session's selected profile, so the test
+        // proves the snapshot resolves model/api_base_url from the session
+        // profile, not from default_profile_name.
+        app.default_profile_name = "other".into();
         {
             let s = &mut app.sessions[0];
             s.ssh_info = Some("root@10.0.0.5:22".into());

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1415,4 +1415,51 @@ mod tests {
             assert_eq!(t.cols(), 100);
         }
     }
+
+    #[test]
+    fn session_snapshot_captures_launch_context() {
+        use filar_core::{CommandConfirmMode, LlmProfile};
+        let mut app = App::new("prod".into(), CommandConfirmMode::Always);
+        app.profiles = vec![LlmProfile {
+            name: "glm".into(),
+            model: "glm-5.1".into(),
+            api_base_url: "https://open.bigmodel.cn/api/paas/v4".into(),
+            max_tokens: 1024,
+            key_env: "GLM_API_KEY".into(),
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        }];
+        app.default_profile_name = "glm".into();
+        {
+            let s = &mut app.sessions[0];
+            s.ssh_info = Some("root@10.0.0.5:22".into());
+            s.llm_profile = Some("glm".into());
+            s.confirm_mode = CommandConfirmMode::Explain;
+        }
+
+        let snapshot = session_snapshot(&app, "prod");
+
+        assert_eq!(snapshot.ssh_info.as_deref(), Some("root@10.0.0.5:22"));
+        assert_eq!(snapshot.model.as_deref(), Some("glm-5.1"));
+        assert_eq!(
+            snapshot.api_base_url.as_deref(),
+            Some("https://open.bigmodel.cn/api/paas/v4")
+        );
+        assert_eq!(snapshot.confirm_mode, Some(CommandConfirmMode::Explain));
+        assert_eq!(snapshot.target, "prod");
+        assert_eq!(snapshot.llm_profile.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn session_snapshot_nulls_launch_context_when_absent() {
+        use filar_core::CommandConfirmMode;
+        let app = App::new("local".into(), CommandConfirmMode::Allowlist);
+        let snapshot = session_snapshot(&app, "local");
+        assert_eq!(snapshot.ssh_info, None);
+        assert_eq!(snapshot.model, None);
+        assert_eq!(snapshot.api_base_url, None);
+        assert_eq!(snapshot.confirm_mode, Some(CommandConfirmMode::Allowlist));
+        assert_eq!(snapshot.llm_profile, None);
+    }
 }


### PR DESCRIPTION
Closes #271

## Summary

Extended the persisted session model so a restored session can recall its launch context (SSH host, model, API base URL, confirm mode) instead of asking the user to reselect everything manually.

- `filar_core::Session` gains four additive `#[serde(default)]` fields: `ssh_info: Option<String>`, `model: Option<String>`, `api_base_url: Option<String>`, `confirm_mode: Option<CommandConfirmMode>`.
- `SessionMeta` gains `ssh_info` and `model` for list display.
- `runner.rs` now builds the snapshot via `session_snapshot()`, filling the new fields from the active tab (`ssh_info`, `confirm_mode`) and the active LLM profile (`model`, `api_base_url`).
- `app/main.rs` reads `ssh_info` and `confirm_mode` on `--session` restore: `ssh_info` flows to the TUI via the new `TuiConfig::initial_ssh_info` (shown in the tab label), and the saved `confirm_mode` overrides the config default.

## Tests

- `cargo test -p filar-core` green (3 new tests: `launch_context_roundtrip`, `launch_context_backward_compat`, `session_meta_includes_launch_context`).
- `cargo test --workspace` green (no regressions). No `#[ignore]` tests touched.
- `cargo build --workspace` green.

## Out of scope

Actual SSH reconnect and launcher auto-selection on restore are the follow-up issues #273 (F3 overlay) and #274 (GUI launcher). `model` / `api_base_url` are written to the session here but consumed by #274.