### PR TITLE
feat(tui): periodic session auto-save (30s) + panic-safe save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   SSH host is surfaced in the tab label and the saved confirm mode is
   re-applied.
   ([#271](https://github.com/devlawey/filar/issues/271)).
+- Periodic session auto-save: the active session is persisted every 30
+  seconds (only when it changed) and once more from the panic hook, so
+  closing the window or killing the process loses at most ~30 seconds of
+  history. Each run reuses a single session id, and pruning keeps at most 10
+  session files.
+  ([#272](https://github.com/devlawey/filar/issues/272)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   seconds (only when it changed) and once more from the panic hook, so
   closing the window or killing the process loses at most ~30 seconds of
   history. Each run reuses a single session id, and pruning keeps at most 10
-  session files.
+  session files. Session writes are now atomic (temp file + rename), so a
+  crash mid-write cannot corrupt a saved session.
   ([#272](https://github.com/devlawey/filar/issues/272)).
 
 ### Fixed

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4350,13 +4350,15 @@ session_meta_includes_launch_context). `cargo test --workspace` зелёные.
   сохраняется только если активная вкладка изменилась (`session_changed`:
   `message_rev` или смена вкладки). После каждого сохранения — prune до 10.
 - Panic-safe: `PanicHookGuard` принимает `Arc<Mutex<Option<Session>>>`
-  (shared snapshot), обновляемый при каждом сохранении; panic hook делает
-  best-effort сохранение (`try_lock`, без блокировки event loop).
-- `session_snapshot()` и `save_session_now()` переработаны под стабильный id.
+  (shared snapshot); panic hook делает best-effort сохранение (`try_lock`).
+- Crash-safe запись: `SessionStore::save` стал атомарным (tmp-файл + `rename`).
+- Сохранение вынесено в `tokio::task::spawn_blocking` (`save_session_async`),
+  чтобы не блокировать event loop; запись сериализуется с panic hook общим
+  мьютексом (мьютекс удерживается на время `store.save`).
 
-**Публичный API:** нет изменений (внутренние функции runner).
+**Публичный API:** `SessionStore::save` теперь атомарный (семантика прежняя).
 
-**Тесты:** 2 новых (session_changed_detects_rev_and_tab, id/timestamp-ассерты в
-session_snapshot-тестах). `cargo test -p filar-tui` — 314 passed.
+**Тесты:** 3 новых (session_store_save_is_atomic в core, session_changed_detects_rev_and_tab
+и id/timestamp-ассерты в tui). `cargo test --workspace` зелёные (core 54, tui 314).
 
 **Дальше:** #273 (F3 overlay), #274 (GUI авто-выбор).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4336,3 +4336,27 @@ core+agent проходят. Тесты падают на старом коде 
 session_meta_includes_launch_context). `cargo test --workspace` зелёные.
 
 **Дальше:** #272 (автосейв + panic-safe), #273 (F3 overlay), #274 (GUI авто-выбор).
+
+---
+
+## Issue #272: feat(tui) — Periodic auto-save + panic-safe session save
+
+**Milestone:** 0.9.0. **Ветка:** `feat/272-session-auto-save`.
+
+**Что сделано:**
+- `runner.rs`: стабильный id сессии генерируется один раз на запуск — каждый
+  30-секундный автосейв перезаписывает тот же файл (не плодит новые).
+- В `select!` добавлен `auto_save_interval` (30s, `MissedTickBehavior::Skip`);
+  сохраняется только если активная вкладка изменилась (`session_changed`:
+  `message_rev` или смена вкладки). После каждого сохранения — prune до 10.
+- Panic-safe: `PanicHookGuard` принимает `Arc<Mutex<Option<Session>>>`
+  (shared snapshot), обновляемый при каждом сохранении; panic hook делает
+  best-effort сохранение (`try_lock`, без блокировки event loop).
+- `session_snapshot()` и `save_session_now()` переработаны под стабильный id.
+
+**Публичный API:** нет изменений (внутренние функции runner).
+
+**Тесты:** 2 новых (session_changed_detects_rev_and_tab, id/timestamp-ассерты в
+session_snapshot-тестах). `cargo test -p filar-tui` — 314 passed.
+
+**Дальше:** #273 (F3 overlay), #274 (GUI авто-выбор).

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -181,12 +181,26 @@ impl SessionStore {
         Self::new(default_base_dir()?)
     }
 
-    /// Save a session to disk (overwrites if the ID already exists).
+    /// Save a session to disk atomically (overwrites if the ID already exists).
+    ///
+    /// The JSON is written to a temporary file first and then renamed over the
+    /// target, so a crash mid-write never leaves a truncated or corrupt session
+    /// file — the previous (complete) version stays in place until the rename.
     pub fn save(&self, session: &Session) -> Result<()> {
         let path = self.dir.join(format!("{}.json", session.id));
+        let tmp = self
+            .dir
+            .join(format!("{}.json.tmp{}", session.id, std::process::id()));
         let json = serde_json::to_string_pretty(session)
             .map_err(|e| CoreError::Other(format!("failed to serialise session: {e}")))?;
-        std::fs::write(&path, json)?;
+        std::fs::write(&tmp, json)?;
+        if let Err(e) = std::fs::rename(&tmp, &path) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(CoreError::Other(format!(
+                "failed to replace session file {}: {e}",
+                path.display()
+            )));
+        }
         tracing::info!(session_id = %session.id, path = %path.display(), "session saved");
         Ok(())
     }
@@ -373,6 +387,46 @@ mod tests {
         };
         let meta = SessionMeta::from(&session);
         assert!(meta.preview.is_empty());
+    }
+
+    #[test]
+    fn session_store_save_is_atomic() {
+        let tmp = std::env::temp_dir().join(format!("filar_atomic_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let store = SessionStore { dir: tmp.clone() };
+        let session = Session {
+            id: "777".into(),
+            timestamp: "2026-01-01 00:00:00".into(),
+            target: "test".into(),
+            llm_profile: Some("glm".into()),
+            messages: vec![ChatBlock::User("hello".into())],
+            input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
+            cost_usd: None,
+            per_profile: HashMap::new(),
+            last_served_model: None,
+            model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
+        };
+
+        store.save(&session).unwrap();
+
+        // The temp file must be renamed away and only the final file remain.
+        assert!(tmp.join("777.json").exists());
+        let leftovers: Vec<_> = std::fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "no temp files should remain: {leftovers:?}");
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -182,10 +182,14 @@ impl PanicHookGuard {
 
             // Best-effort session save. `try_lock` avoids blocking (and a
             // potential double-panic) if the mutex is somehow still held.
-            if let Some(session) = snapshot.try_lock().ok().and_then(|g| g.clone()) {
-                if let Ok(store) = filar_core::SessionStore::with_default_dir() {
-                    let _ = store.save(&session);
-                    let _ = store.prune_to(filar_core::session::MAX_SESSIONS);
+            // Holding the lock while writing serialises this save with the
+            // periodic auto-save (which uses the same mutex around its write).
+            if let Ok(guard) = snapshot.try_lock() {
+                if let Some(session) = guard.clone() {
+                    if let Ok(store) = filar_core::SessionStore::with_default_dir() {
+                        let _ = store.save(&session);
+                        let _ = store.prune_to(filar_core::session::MAX_SESSIONS);
+                    }
                 }
             }
 
@@ -532,14 +536,14 @@ async fn run_app(
             _ = auto_save_interval.tick() => {
                 let changed = session_changed(&app, last_saved_rev, last_saved_session);
                 if changed {
-                    match save_session_now(
+                    let session = session_snapshot(
                         &app,
                         &config.target_name,
                         &session_id,
                         &session_timestamp,
-                        &snapshot,
-                    ) {
-                        Ok(_) => {
+                    );
+                    match save_session_async(session, snapshot.clone()).await {
+                        Ok(()) => {
                             last_saved_rev = app.active_session().message_rev;
                             last_saved_session = app.active_session().id;
                             info!("session auto-saved");
@@ -1199,9 +1203,11 @@ async fn run_app(
     }
 
     // Save session to disk for future restore.
-    match save_session_now(&app, &config.target_name, &session_id, &session_timestamp, &snapshot) {
-        Ok(session) => {
-            eprintln!("\nSession saved ({} messages).", session.messages.len());
+    let session = session_snapshot(&app, &config.target_name, &session_id, &session_timestamp);
+    let msg_count = session.messages.len();
+    match save_session_async(session, snapshot.clone()).await {
+        Ok(()) => {
+            eprintln!("\nSession saved ({msg_count} messages).");
         }
         Err(e) => {
             eprintln!("\nFailed to save session: {e}");
@@ -1212,23 +1218,24 @@ async fn run_app(
     Ok(())
 }
 
-/// Save the active session snapshot to disk and refresh the shared
-/// panic-safe snapshot. Returns the saved session on success.
-fn save_session_now(
-    app: &App,
-    target_name: &str,
-    id: &str,
-    timestamp: &str,
-    snapshot: &SessionSnapshot,
-) -> std::result::Result<filar_core::Session, CoreError> {
-    let session = session_snapshot(app, target_name, id, timestamp);
-    let store = filar_core::SessionStore::with_default_dir()?;
-    store.save(&session)?;
-    let _ = store.prune_to(filar_core::session::MAX_SESSIONS);
-    if let Ok(mut guard) = snapshot.lock() {
-        *guard = Some(session.clone());
-    }
-    Ok(session)
+/// Persist an already-built session snapshot off the event loop, refresh the
+/// shared panic-safe snapshot, and prune old sessions. The file write runs on
+/// a blocking thread and is serialised with the panic hook via the shared
+/// mutex (see [`PanicHookGuard`]).
+async fn save_session_async(
+    session: filar_core::Session,
+    snapshot: SessionSnapshot,
+) -> std::result::Result<(), CoreError> {
+    tokio::task::spawn_blocking(move || {
+        let store = filar_core::SessionStore::with_default_dir()?;
+        let mut guard = snapshot.lock().unwrap_or_else(|e| e.into_inner());
+        store.save(&session)?;
+        let _ = store.prune_to(filar_core::session::MAX_SESSIONS);
+        *guard = Some(session);
+        Ok(())
+    })
+    .await
+    .map_err(|e| CoreError::Other(format!("session save task panicked: {e}")))?
 }
 
 /// Build a serialisable [`filar_core::Session`] snapshot from the active TUI

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::io::{self, Stdout};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crossterm::event::{EnableBracketedPaste, DisableBracketedPaste, EnableMouseCapture, DisableMouseCapture, Event, EventStream};
@@ -143,6 +143,12 @@ struct ExecutorEntry {
 // Panic hook guard
 // ---------------------------------------------------------------------------
 
+/// Shared panic-safe session snapshot.
+///
+/// The periodic auto-save keeps this fresh so the panic hook can persist the
+/// last known-good session even when the app dies unexpectedly.
+type SessionSnapshot = Arc<Mutex<Option<filar_core::Session>>>;
+
 /// RAII guard that restores the default panic hook when dropped.
 ///
 /// Installs a custom panic hook that restores the terminal state
@@ -151,6 +157,9 @@ struct ExecutorEntry {
 /// the panic text and select it with the mouse even if a panic occurs
 /// inside the event loop or rendering code.
 ///
+/// The hook also performs a best-effort session save from the shared
+/// snapshot (see [`run`]), so a panic loses at most one auto-save period.
+///
 /// When the guard is dropped (either after normal teardown or on early
 /// return), the original panic hook is restored via `take_hook()`, so
 /// code running after the TUI is unaffected.
@@ -158,7 +167,7 @@ struct PanicHookGuard;
 
 impl PanicHookGuard {
     /// Install the terminal-restoring panic hook and return a guard.
-    fn install() -> Self {
+    fn install(snapshot: SessionSnapshot) -> Self {
         let default_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             // Restore terminal state BEFORE printing the panic message
@@ -170,6 +179,16 @@ impl PanicHookGuard {
                 crossterm::terminal::LeaveAlternateScreen
             );
             let _ = crossterm::terminal::disable_raw_mode();
+
+            // Best-effort session save. `try_lock` avoids blocking (and a
+            // potential double-panic) if the mutex is somehow still held.
+            if let Some(session) = snapshot.try_lock().ok().and_then(|g| g.clone()) {
+                if let Ok(store) = filar_core::SessionStore::with_default_dir() {
+                    let _ = store.save(&session);
+                    let _ = store.prune_to(filar_core::session::MAX_SESSIONS);
+                }
+            }
+
             default_hook(info);
         }));
         Self
@@ -249,8 +268,10 @@ pub async fn run(
 ) -> Result<()> {
     // Install panic hook to restore terminal state on panic.
     // The hook is automatically uninstalled when _hook_guard is dropped
-    // (on normal return, early error, or panic).
-    let _hook_guard = PanicHookGuard::install();
+    // (on normal return, early error, or panic). The shared snapshot lets
+    // the hook persist the last auto-saved session on a crash.
+    let snapshot: SessionSnapshot = Arc::new(Mutex::new(None));
+    let _hook_guard = PanicHookGuard::install(snapshot.clone());
 
     // Set up terminal.
     enable_raw_mode().map_err(|e| CoreError::Other(format!("failed to enable raw mode: {e}")))?;
@@ -273,7 +294,7 @@ pub async fn run(
     let mut terminal = Terminal::new(backend)
         .map_err(|e| CoreError::Other(format!("failed to create terminal: {e}")))?;
 
-    let result = run_app(&mut terminal, _llm, executor, config).await;
+    let result = run_app(&mut terminal, _llm, executor, config, snapshot).await;
 
     // Restore the original panic hook before terminal teardown.
     // The custom hook is no longer needed — teardown uses .ok() and
@@ -294,6 +315,7 @@ async fn run_app(
     _llm: Arc<dyn LlmClient>,
     executor: Arc<dyn CommandExecutor>,
     mut config: TuiConfig,
+    snapshot: SessionSnapshot,
 ) -> Result<()> {
     let profiles_for_restore = std::mem::take(&mut config.profiles);
     let default_for_restore = std::mem::take(&mut config.default_profile_name);
@@ -415,6 +437,15 @@ async fn run_app(
     // and a frame deadline has passed, avoiding competition with read_output.
     let mut last_draw = Instant::now();
 
+    // Periodic auto-save (#272): one stable id for the whole run so each
+    // 30s save overwrites the same file, plus the revision/session of the
+    // last saved snapshot so unchanged sessions skip the write.
+    let (session_id, session_timestamp) = filar_core::session::now_session_id();
+    let mut auto_save_interval = tokio::time::interval(Duration::from_secs(30));
+    auto_save_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_saved_rev = app.active_session().message_rev;
+    let mut last_saved_session = app.active_session().id;
+
     loop {
         let in_interactive = app.mode == AppMode::Interactive;
         tokio::select! {
@@ -493,6 +524,31 @@ async fn run_app(
                     }
                 }
                 needs_redraw = true;
+            }
+
+            // Periodic auto-save (#272): every 30 seconds, persist the active
+            // session if it changed since the last save (message_rev or tab).
+            // The write is synchronous but tiny (<100 KB, ~a few ms).
+            _ = auto_save_interval.tick() => {
+                let changed = session_changed(&app, last_saved_rev, last_saved_session);
+                if changed {
+                    match save_session_now(
+                        &app,
+                        &config.target_name,
+                        &session_id,
+                        &session_timestamp,
+                        &snapshot,
+                    ) {
+                        Ok(_) => {
+                            last_saved_rev = app.active_session().message_rev;
+                            last_saved_session = app.active_session().id;
+                            info!("session auto-saved");
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "session auto-save failed");
+                        }
+                    }
+                }
             }
 
             // Terminal keyboard / resize event.
@@ -1143,18 +1199,12 @@ async fn run_app(
     }
 
     // Save session to disk for future restore.
-    let session = session_snapshot(&app, &config.target_name);
-    match filar_core::SessionStore::with_default_dir() {
-        Ok(store) => {
-            if let Err(e) = store.save(&session) {
-                eprintln!("\nFailed to save session: {e}");
-            } else {
-                eprintln!("\nSession saved ({} messages).", session.messages.len());
-            }
-            let _ = store.prune_to(filar_core::session::MAX_SESSIONS);
+    match save_session_now(&app, &config.target_name, &session_id, &session_timestamp, &snapshot) {
+        Ok(session) => {
+            eprintln!("\nSession saved ({} messages).", session.messages.len());
         }
         Err(e) => {
-            eprintln!("\nFailed to create session store: {e}");
+            eprintln!("\nFailed to save session: {e}");
         }
     }
 
@@ -1162,11 +1212,29 @@ async fn run_app(
     Ok(())
 }
 
+/// Save the active session snapshot to disk and refresh the shared
+/// panic-safe snapshot. Returns the saved session on success.
+fn save_session_now(
+    app: &App,
+    target_name: &str,
+    id: &str,
+    timestamp: &str,
+    snapshot: &SessionSnapshot,
+) -> std::result::Result<filar_core::Session, CoreError> {
+    let session = session_snapshot(app, target_name, id, timestamp);
+    let store = filar_core::SessionStore::with_default_dir()?;
+    store.save(&session)?;
+    let _ = store.prune_to(filar_core::session::MAX_SESSIONS);
+    if let Ok(mut guard) = snapshot.lock() {
+        *guard = Some(session.clone());
+    }
+    Ok(session)
+}
+
 /// Build a serialisable [`filar_core::Session`] snapshot from the active TUI
 /// session, including launch context (ssh_info, model, api_base_url,
 /// confirm_mode) so a later restore can re-select the same host and model.
-fn session_snapshot(app: &App, target_name: &str) -> filar_core::Session {
-    let (id, timestamp) = filar_core::session::now_session_id();
+fn session_snapshot(app: &App, target_name: &str, id: &str, timestamp: &str) -> filar_core::Session {
     let active_profile_name = app
         .llm_profile
         .clone()
@@ -1178,8 +1246,8 @@ fn session_snapshot(app: &App, target_name: &str) -> filar_core::Session {
         .map(|p| (Some(p.model.clone()), Some(p.api_base_url.clone())))
         .unwrap_or((None, None));
     let mut session = filar_core::Session {
-        id,
-        timestamp,
+        id: id.to_string(),
+        timestamp: timestamp.to_string(),
         target: target_name.to_string(),
         llm_profile: app.llm_profile.clone(),
         messages: app.messages.clone(),
@@ -1197,6 +1265,12 @@ fn session_snapshot(app: &App, target_name: &str) -> filar_core::Session {
     };
     session.truncate_history();
     session
+}
+
+/// Whether the active session changed since the last auto-save: either its
+/// message revision advanced or the user switched to a different tab.
+fn session_changed(app: &App, last_rev: u64, last_session: crate::app::SessionId) -> bool {
+    app.active_session().message_rev != last_rev || app.active_session().id != last_session
 }
 
 /// Await the next forwarded log line from the optional receiver.
@@ -1453,8 +1527,10 @@ mod tests {
             s.confirm_mode = CommandConfirmMode::Explain;
         }
 
-        let snapshot = session_snapshot(&app, "prod");
+        let snapshot = session_snapshot(&app, "prod", "123456", "2026-08-14 00:00:00");
 
+        assert_eq!(snapshot.id, "123456");
+        assert_eq!(snapshot.timestamp, "2026-08-14 00:00:00");
         assert_eq!(snapshot.ssh_info.as_deref(), Some("root@10.0.0.5:22"));
         assert_eq!(snapshot.model.as_deref(), Some("glm-5.1"));
         assert_eq!(
@@ -1470,11 +1546,33 @@ mod tests {
     fn session_snapshot_nulls_launch_context_when_absent() {
         use filar_core::CommandConfirmMode;
         let app = App::new("local".into(), CommandConfirmMode::Allowlist);
-        let snapshot = session_snapshot(&app, "local");
+        let snapshot = session_snapshot(&app, "local", "123456", "2026-08-14 00:00:00");
         assert_eq!(snapshot.ssh_info, None);
         assert_eq!(snapshot.model, None);
         assert_eq!(snapshot.api_base_url, None);
         assert_eq!(snapshot.confirm_mode, Some(CommandConfirmMode::Allowlist));
         assert_eq!(snapshot.llm_profile, None);
+    }
+
+    #[test]
+    fn session_changed_detects_rev_and_tab() {
+        use filar_core::CommandConfirmMode;
+        let mut app = App::new("t0".into(), CommandConfirmMode::Allowlist);
+        let sid0 = app.active_session().id;
+        let rev0 = app.active_session().message_rev;
+
+        // Unchanged: same tab, same revision.
+        assert!(!session_changed(&app, rev0, sid0));
+
+        // Revision advanced.
+        app.push_error("hi".into());
+        assert!(session_changed(&app, rev0, sid0));
+
+        // Same revision, but a different active tab.
+        app.new_tab();
+        let sid1 = app.active_session().id;
+        let rev1 = app.active_session().message_rev;
+        assert!(session_changed(&app, rev1, sid0));
+        assert!(!session_changed(&app, rev1, sid1));
     }
 }


### PR DESCRIPTION
Closes #272

## Summary

Sessions are now saved periodically and on panic, so a crash / window close / kill loses at most ~30 seconds of history instead of the whole session.

- A single stable session id is generated once per run, so each 30s auto-save overwrites the same file (no file-per-tick churn).
- A `tokio::time::interval(30s)` branch in the `select!` loop saves the active session only when it changed (`session_changed`: `message_rev` advanced or tab switched), then prunes to `MAX_SESSIONS` (10).
- `PanicHookGuard` now takes a shared `Arc<Mutex<Option<Session>>>` snapshot, refreshed on every save; the panic hook performs a best-effort save (`try_lock`, no blocking) before restoring the terminal.
- `SessionStore::save` is now atomic (temp file + `rename`), so a crash mid-write cannot corrupt a saved session. The file write runs off the event loop via `tokio::task::spawn_blocking` and is serialised with the panic hook via the shared mutex.

## Tests

- `cargo test -p filar-core` green — 54 passed (1 new: `session_store_save_is_atomic`).
- `cargo test -p filar-tui` green — 314 passed (1 new: `session_changed_detects_rev_and_tab`, plus stable id/timestamp assertions in the `session_snapshot` tests).
- `cargo test --workspace` green.
- `cargo build --workspace` green.

## Notes

- The 30s cadence and panic path are exercised manually (TUI runtime); no `#[ignore]`/docker-sshd tests involved.
- Crash safety here targets process-level failures (kill/panic): the atomic rename guarantees the target file is always a complete JSON. Power-loss durability (`fsync` of file + directory) is out of scope.
- Window-close / kill coverage comes from the periodic save; the panic hook covers panics only.