### PR TITLE
feat(tui): F3 session selection overlay with restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   session files. Session writes are now atomic (temp file + rename), so a
   crash mid-write cannot corrupt a saved session.
   ([#272](https://github.com/devlawey/filar/issues/272)).
+- F3 session selection overlay: restore a saved session from within the TUI.
+  The overlay lists saved sessions (date, host, profile, preview); Enter
+  restores messages/history/profile/tokens and re-initiates the SSH
+  connection (password prompt via Ctrl+P), Esc cancels. F3 is shown in the
+  bottom help bar and the F1 help overlay.
+  ([#273](https://github.com/devlawey/filar/issues/273)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4362,3 +4362,27 @@ session_meta_includes_launch_context). `cargo test --workspace` зелёные.
 и id/timestamp-ассерты в tui). `cargo test --workspace` зелёные (core 54, tui 314).
 
 **Дальше:** #273 (F3 overlay), #274 (GUI авто-выбор).
+
+---
+
+## Issue #273: feat(tui) — F3 session selection overlay
+
+**Milestone:** 0.9.0. **Ветка:** `feat/273-session-select-overlay`.
+
+**Что сделано:**
+- Новый модуль `crates/tui/src/ui/session_select.rs` (по образцу `host_select`) —
+  оверлей списка сохранённых сессий (дата, host/ssh_info, профиль, preview).
+- `App`: поля `session_select_visible/index/metas`; `open_session_select()`
+  (грузит `SessionStore::list()`), `select_session()` + `apply_loaded_session()`
+  (заменяют messages / input_history / llm_profile / token stats на активной вкладке).
+- SSH-восстановление: `parse_ssh_info("user@host:port")` → `pending_ssh` +
+  password flow через Ctrl+P (тот же путь, что `!ssh`).
+- F3 перехватывается до mode-specific кода (кроме PasswordInput), как F1/F2.
+- F3 в `help_registry()` (секция Modes) и `help_items(Normal)` («sessions»).
+
+**Публичный API:** нет изменений (внутренние поля `App`).
+
+**Тесты:** 7 новых (parse_ssh_info×3, f3 toggle, esc cancel,
+apply_loaded_session×2). `cargo test -p filar-tui` — 321 passed.
+
+**Дальше:** #274 (GUI авто-выбор target/profile).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -6,7 +6,7 @@
 
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
-use filar_core::{ChatBlock, CommandConfirmMode, StaticSecretProvider};
+use filar_core::{ChatBlock, CommandConfirmMode, SessionMeta, SessionStore, StaticSecretProvider};
 use ratatui::layout::Rect;
 
 use crate::event::TuiEvent;
@@ -230,6 +230,12 @@ pub struct App {
     pub save_tx: Option<tokio::sync::mpsc::UnboundedSender<SaveProgress>>,
     /// Directory where Ctrl+S session exports are written (`None` = CWD).
     pub save_dir: Option<std::path::PathBuf>,
+    /// Whether the session-selection overlay is visible (F3).
+    pub session_select_visible: bool,
+    /// Cursor position in the session-selection overlay.
+    pub session_select_index: usize,
+    /// Cached list of saved session metadata shown in the overlay.
+    pub session_select_metas: Vec<SessionMeta>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -416,6 +422,9 @@ impl App {
             save_in_flight: false,
             save_tx: None,
             save_dir: None,
+            session_select_visible: false,
+            session_select_index: 0,
+            session_select_metas: Vec::new(),
         }
     }
 
@@ -948,6 +957,110 @@ impl App {
         }
     }
 
+    /// Open the session-selection overlay (F3). Loads the list of saved
+    /// sessions from disk into [`session_select_metas`](Self::session_select_metas).
+    fn open_session_select(&mut self) {
+        self.session_select_metas = match SessionStore::with_default_dir() {
+            Ok(store) => store.list().unwrap_or_default(),
+            Err(_) => Vec::new(),
+        };
+        if self.session_select_metas.is_empty() {
+            self.push_message(ChatBlock::System(
+                "No saved sessions found. Sessions are saved automatically every \
+                 30s and on exit (Ctrl+Q)."
+                    .into(),
+            ));
+        }
+        self.session_select_index = 0;
+        self.session_select_visible = true;
+    }
+
+    /// Confirm the session selection (Enter): load the full session and apply
+    /// it to the active tab — messages, input history, LLM profile, token
+    /// stats. If the session was over SSH, re-initiate the SSH connection via
+    /// the password flow (`pending_ssh` + Ctrl+P).
+    fn select_session(&mut self) {
+        let idx = self.session_select_index;
+        self.session_select_visible = false;
+
+        let meta = match self.session_select_metas.get(idx).cloned() {
+            Some(m) => m,
+            None => return,
+        };
+        match SessionStore::with_default_dir() {
+            Ok(store) => match store.load(&meta.id) {
+                Ok(Some(session)) => self.apply_loaded_session(session),
+                Ok(None) => {
+                    self.push_error(format!("Session '{}' no longer exists.", meta.id));
+                }
+                Err(e) => {
+                    self.push_error(format!("Failed to load session: {e}"));
+                }
+            },
+            Err(e) => {
+                self.push_error(format!("Failed to init session store: {e}"));
+            }
+        }
+    }
+
+    /// Apply a loaded session to the active tab: messages, input history, LLM
+    /// profile, token stats, and — if the session was over SSH — re-initiate
+    /// the SSH connection via the password flow (`pending_ssh` + Ctrl+P).
+    fn apply_loaded_session(&mut self, session: filar_core::Session) {
+        self.messages = session.messages;
+        self.message_rev = self.message_rev.wrapping_add(1);
+        self.push_message(ChatBlock::System(
+            "Session restored — history loaded from disk".into(),
+        ));
+        self.input_history = session.input_history;
+        self.history_pos = None;
+        self.tokens_in = session.tokens_in;
+        self.tokens_out = session.tokens_out;
+        self.cost_usd = session.cost_usd;
+        self.per_profile = session.per_profile;
+        self.last_served_model = session.last_served_model;
+        self.model_per_profile = session.model_per_profile;
+        self.scroll = 0;
+
+        // Resolve LLM profile with the same validation as startup restore.
+        let default_name = if self.default_profile_name.is_empty() {
+            "default".to_string()
+        } else {
+            self.default_profile_name.clone()
+        };
+        if let Some(profile) = session.llm_profile {
+            if profile.is_empty() {
+                self.llm_profile = Some(default_name.clone());
+            } else if self.profiles.iter().any(|p| p.name == profile) {
+                self.llm_profile = Some(profile);
+            } else {
+                self.llm_profile = Some(default_name.clone());
+                self.push_message(ChatBlock::System(format!(
+                    "Profile '{}' not found — using '{}'",
+                    profile, default_name
+                )));
+            }
+        }
+
+        // SSH reconnect: parse the saved `ssh_info` and re-initiate the
+        // password flow (the same path as `!ssh user@host`).
+        if let Some((user, host, port)) = session
+            .ssh_info
+            .as_deref()
+            .and_then(parse_ssh_info)
+        {
+            self.pending_ssh = Some((user.clone(), host.clone(), port));
+            self.ssh_info = Some(format!("{user}@{host}:{port}"));
+            self.target_name = format!("{user}@{host}:{port}");
+            self.push_message(ChatBlock::System(format!(
+                "Restored SSH target {user}@{host}:{port}. Press Ctrl+P to enter the password."
+            )));
+        } else {
+            self.ssh_info = None;
+            self.target_name = session.target.clone();
+        }
+    }
+
     /// Append a message to the history and bump [`message_rev`](Self::message_rev).
     ///
     /// All mutations of `messages` must go through this method (or explicitly
@@ -1262,6 +1375,16 @@ impl App {
             return;
         }
 
+        // F3 toggles the session-selection overlay — same availability as F1/F2.
+        if key.code == KeyCode::F(3) && self.mode != AppMode::PasswordInput {
+            if self.session_select_visible {
+                self.session_select_visible = false;
+            } else {
+                self.open_session_select();
+            }
+            return;
+        }
+
         // When the help overlay is visible, only navigation and close keys
         // are processed; all other keys are consumed.
         if self.help_overlay_visible {
@@ -1349,6 +1472,30 @@ impl App {
                 }
                 KeyCode::Enter => {
                     self.select_host();
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        // When the session-selection overlay is visible, only navigation and
+        // select/cancel keys are processed; all other keys are consumed.
+        if self.session_select_visible {
+            let list_size = self.session_select_metas.len();
+            match key.code {
+                KeyCode::Esc => {
+                    self.session_select_visible = false;
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.session_select_index = self.session_select_index.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if self.session_select_index + 1 < list_size {
+                        self.session_select_index += 1;
+                    }
+                }
+                KeyCode::Enter => {
+                    self.select_session();
                 }
                 _ => {}
             }
@@ -1804,6 +1951,11 @@ impl App {
 
         // When the host-selection overlay is visible, consume all mouse events.
         if self.host_select_visible {
+            return;
+        }
+
+        // When the session-selection overlay is visible, consume all mouse events.
+        if self.session_select_visible {
             return;
         }
 
@@ -2923,6 +3075,20 @@ fn parse_ssh_command(cmd: &str) -> Option<(String, String, u16)> {
         return None;
     }
 
+    Some((user.to_string(), host.to_string(), port))
+}
+
+/// Parse `user@host[:port]` (the persisted `ssh_info` format) into
+/// `(user, host, port)`. The port defaults to 22 when omitted.
+fn parse_ssh_info(info: &str) -> Option<(String, String, u16)> {
+    let (user, host_port) = info.split_once('@')?;
+    let (host, port) = match host_port.rsplit_once(':') {
+        Some((h, p)) => (h, p.parse().ok()?),
+        None => (host_port, 22),
+    };
+    if user.is_empty() || host.is_empty() {
+        return None;
+    }
     Some((user.to_string(), host.to_string(), port))
 }
 
@@ -6160,6 +6326,129 @@ mod tests {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         assert_eq!(app.target_name, "~local");
+    }
+
+    #[test]
+    fn parse_ssh_info_parses_user_host_port() {
+        let (user, host, port) = parse_ssh_info("root@10.0.0.5:22").unwrap();
+        assert_eq!(user, "root");
+        assert_eq!(host, "10.0.0.5");
+        assert_eq!(port, 22);
+    }
+
+    #[test]
+    fn parse_ssh_info_defaults_port() {
+        let (user, host, port) = parse_ssh_info("admin@devbox").unwrap();
+        assert_eq!(user, "admin");
+        assert_eq!(host, "devbox");
+        assert_eq!(port, 22);
+    }
+
+    #[test]
+    fn parse_ssh_info_rejects_malformed() {
+        assert!(parse_ssh_info("no-at-sign").is_none());
+        assert!(parse_ssh_info("").is_none());
+    }
+
+    #[test]
+    fn f3_toggles_session_select_overlay() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        app.handle_key(KeyEvent::new(KeyCode::F(3), KeyModifiers::NONE));
+        assert!(app.session_select_visible, "F3 must open the overlay");
+        app.handle_key(KeyEvent::new(KeyCode::F(3), KeyModifiers::NONE));
+        assert!(!app.session_select_visible, "F3 must close the overlay");
+    }
+
+    #[test]
+    fn session_select_esc_cancels() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.session_select_metas = vec![filar_core::SessionMeta {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "t".into(),
+            llm_profile: None,
+            ssh_info: None,
+            model: None,
+            preview: String::new(),
+        }];
+        app.session_select_visible = true;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(!app.session_select_visible);
+    }
+
+    #[test]
+    fn apply_loaded_session_restores_messages_and_profile() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.default_profile_name = "glm".into();
+        app.profiles = vec![filar_core::LlmProfile {
+            name: "glm".into(),
+            model: "glm-5.1".into(),
+            api_base_url: String::new(),
+            max_tokens: 1024,
+            key_env: String::new(),
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        }];
+        let session = filar_core::Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "prod".into(),
+            llm_profile: Some("glm".into()),
+            messages: vec![ChatBlock::User("hello".into())],
+            input_history: vec!["ls".into()],
+            tokens_in: 11,
+            tokens_out: 22,
+            cost_usd: Some(0.5),
+            per_profile: HashMap::new(),
+            last_served_model: Some("glm-5.1".into()),
+            model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
+        };
+        app.apply_loaded_session(session);
+        assert!(app.messages.iter().any(|b| matches!(b, ChatBlock::User(s) if s == "hello")));
+        assert!(app.input_history().iter().any(|s| s == "ls"));
+        assert_eq!(app.tokens_in, 11);
+        assert_eq!(app.tokens_out, 22);
+        assert_eq!(app.llm_profile.as_deref(), Some("glm"));
+        assert_eq!(app.target_name, "prod");
+        assert!(app.ssh_info.is_none());
+        assert!(app.pending_ssh.is_none());
+    }
+
+    #[test]
+    fn apply_loaded_session_ssh_reconnects() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        let session = filar_core::Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "prod".into(),
+            llm_profile: None,
+            messages: vec![],
+            input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
+            cost_usd: None,
+            per_profile: HashMap::new(),
+            last_served_model: None,
+            model_per_profile: HashMap::new(),
+            ssh_info: Some("root@10.0.0.5:22".into()),
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
+        };
+        app.apply_loaded_session(session);
+        assert_eq!(
+            app.pending_ssh,
+            Some(("root".into(), "10.0.0.5".into(), 22))
+        );
+        assert_eq!(app.ssh_info.as_deref(), Some("root@10.0.0.5:22"));
+        assert_eq!(app.target_name, "root@10.0.0.5:22");
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -188,6 +188,10 @@ pub struct App {
     /// SessionIds of recently closed tabs — consumed by runner to teardown
     /// corresponding interactive backends.
     pub closed_ids: Vec<SessionId>,
+    /// SessionIds of tabs whose interactive backend should be torn down by the
+    /// runner without closing the tab (set by session restore when the tab was
+    /// in Interactive mode).
+    pub pending_term_teardown: Vec<SessionId>,
     /// SessionIds of new tabs awaiting a local executor from the runner.
     /// App signals the runner here; runner creates the executor asynchronously
     /// and stores it in its per-session map.
@@ -402,6 +406,7 @@ impl App {
             status_bar_area: Rect::default(),
             help_bar_area: Rect::default(),
             closed_ids: Vec::new(),
+            pending_term_teardown: Vec::new(),
             pending_local_executors: Vec::new(),
             help_overlay_visible: false,
             help_scroll: 0,
@@ -531,6 +536,11 @@ impl App {
     /// Take and clear the list of closed session IDs (for runner to process).
     pub fn take_closed_ids(&mut self) -> Vec<SessionId> {
         std::mem::take(&mut self.closed_ids)
+    }
+
+    /// Take and clear the list of tabs awaiting interactive-backend teardown.
+    pub fn take_pending_term_teardown(&mut self) -> Vec<SessionId> {
+        std::mem::take(&mut self.pending_term_teardown)
     }
 
     /// Take and clear the list of sessions awaiting a local executor (for runner to process).
@@ -960,16 +970,28 @@ impl App {
     /// Open the session-selection overlay (F3). Loads the list of saved
     /// sessions from disk into [`session_select_metas`](Self::session_select_metas).
     fn open_session_select(&mut self) {
-        self.session_select_metas = match SessionStore::with_default_dir() {
-            Ok(store) => store.list().unwrap_or_default(),
-            Err(_) => Vec::new(),
-        };
-        if self.session_select_metas.is_empty() {
-            self.push_message(ChatBlock::System(
-                "No saved sessions found. Sessions are saved automatically every \
-                 30s and on exit (Ctrl+Q)."
-                    .into(),
-            ));
+        match SessionStore::with_default_dir() {
+            Ok(store) => match store.list() {
+                Ok(metas) if metas.is_empty() => {
+                    self.session_select_metas = Vec::new();
+                    self.push_message(ChatBlock::System(
+                        "No saved sessions found. Sessions are saved automatically every \
+                         30s and on exit (Ctrl+Q)."
+                            .into(),
+                    ));
+                }
+                Ok(metas) => {
+                    self.session_select_metas = metas;
+                }
+                Err(e) => {
+                    self.session_select_metas = Vec::new();
+                    self.push_error(format!("Failed to list saved sessions: {e}"));
+                }
+            },
+            Err(e) => {
+                self.session_select_metas = Vec::new();
+                self.push_error(format!("Failed to init session store: {e}"));
+            }
         }
         self.session_select_index = 0;
         self.session_select_visible = true;
@@ -1007,6 +1029,37 @@ impl App {
     /// profile, token stats, and — if the session was over SSH — re-initiate
     /// the SSH connection via the password flow (`pending_ssh` + Ctrl+P).
     fn apply_loaded_session(&mut self, session: filar_core::Session) {
+        // Reset active runtime state before replacing history so stale events
+        // from the previous session don't leak into the restored one.
+        if let Some(token) = self.cancellation.take() {
+            token.cancel();
+        }
+        self.cancellation = None;
+        if let Some(confirm) = self.pending_confirm.take() {
+            let _ = confirm.respond_to.send(false);
+        }
+        if self.terminal.is_some() {
+            let sid = self.active_session().id;
+            self.pending_term_teardown.push(sid);
+        }
+        self.mode = AppMode::Normal;
+        self.agent_running = false;
+        self.awaiting_confirmation = false;
+        self.background_activity = false;
+        self.streaming = false;
+        self.pending_proposal = None;
+        self.pending_input = None;
+        self.pending_term_input = None;
+        self.toggle_interactive = false;
+        self.terminal = None;
+        self.pending_ssh_password = None;
+        self.ctrl_o_pending_target = None;
+        self.ctrl_o_pending_session_id = None;
+        self.confirm_button_areas.clear();
+        self.hovered_button = None;
+        self.collapsed_overrides.clear();
+        self.selection = None;
+
         self.messages = session.messages;
         self.message_rev = self.message_rev.wrapping_add(1);
         self.push_message(ChatBlock::System(
@@ -1022,23 +1075,28 @@ impl App {
         self.model_per_profile = session.model_per_profile;
         self.scroll = 0;
 
-        // Resolve LLM profile with the same validation as startup restore.
+        // Resolve LLM profile. Reset to the default when the saved session has
+        // no profile, so we don't reuse the replaced tab's profile.
         let default_name = if self.default_profile_name.is_empty() {
             "default".to_string()
         } else {
             self.default_profile_name.clone()
         };
-        if let Some(profile) = session.llm_profile {
-            if profile.is_empty() {
-                self.llm_profile = Some(default_name.clone());
-            } else if self.profiles.iter().any(|p| p.name == profile) {
+        match session.llm_profile {
+            Some(profile) if self.profiles.iter().any(|p| p.name == profile) => {
                 self.llm_profile = Some(profile);
-            } else {
+            }
+            Some(profile) => {
                 self.llm_profile = Some(default_name.clone());
-                self.push_message(ChatBlock::System(format!(
-                    "Profile '{}' not found — using '{}'",
-                    profile, default_name
-                )));
+                if !profile.is_empty() {
+                    self.push_message(ChatBlock::System(format!(
+                        "Profile '{}' not found — using '{}'",
+                        profile, default_name
+                    )));
+                }
+            }
+            None => {
+                self.llm_profile = Some(default_name.clone());
             }
         }
 
@@ -3079,12 +3137,19 @@ fn parse_ssh_command(cmd: &str) -> Option<(String, String, u16)> {
 }
 
 /// Parse `user@host[:port]` (the persisted `ssh_info` format) into
-/// `(user, host, port)`. The port defaults to 22 when omitted.
+/// `(user, host, port)`. The port defaults to 22 when omitted, and IPv6
+/// addresses in square brackets are supported (`user@[::1]:22`).
 fn parse_ssh_info(info: &str) -> Option<(String, String, u16)> {
     let (user, host_port) = info.split_once('@')?;
     let (host, port) = match host_port.rsplit_once(':') {
         Some((h, p)) => (h, p.parse().ok()?),
         None => (host_port, 22),
+    };
+    // Strip IPv6 brackets: `[::1]` → `::1`.
+    let host = if host.starts_with('[') && host.ends_with(']') {
+        &host[1..host.len() - 1]
+    } else {
+        host
     };
     if user.is_empty() || host.is_empty() {
         return None;
@@ -6351,6 +6416,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_ssh_info_handles_ipv6_brackets() {
+        let (user, host, port) = parse_ssh_info("root@[::1]:22").unwrap();
+        assert_eq!(user, "root");
+        assert_eq!(host, "::1");
+        assert_eq!(port, 22);
+    }
+
+    #[test]
     fn f3_toggles_session_select_overlay() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -6449,6 +6522,43 @@ mod tests {
         );
         assert_eq!(app.ssh_info.as_deref(), Some("root@10.0.0.5:22"));
         assert_eq!(app.target_name, "root@10.0.0.5:22");
+    }
+
+    #[test]
+    fn apply_loaded_session_resets_profile_when_none() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.default_profile_name = "glm".into();
+        app.profiles = vec![filar_core::LlmProfile {
+            name: "glm".into(),
+            model: "glm-5.1".into(),
+            api_base_url: String::new(),
+            max_tokens: 1024,
+            key_env: String::new(),
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        }];
+        app.llm_profile = Some("other".into());
+        let session = filar_core::Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "local".into(),
+            llm_profile: None,
+            messages: vec![],
+            input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
+            cost_usd: None,
+            per_profile: HashMap::new(),
+            last_served_model: None,
+            model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
+        };
+        app.apply_loaded_session(session);
+        assert_eq!(app.llm_profile.as_deref(), Some("glm"));
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -3149,9 +3149,10 @@ fn parse_ssh_info(info: &str) -> Option<(String, String, u16)> {
         let end = rest.find(']')?;
         let host = &rest[..end];
         let after = &rest[end + 1..];
-        let port = match after.strip_prefix(':') {
-            Some(p) => p.parse().ok()?,
-            None => 22,
+        let port = if after.is_empty() {
+            22
+        } else {
+            after.strip_prefix(':')?.parse().ok()?
         };
         (host.to_string(), port)
     } else {
@@ -6438,6 +6439,12 @@ mod tests {
         assert_eq!(user, "root");
         assert_eq!(host, "::1");
         assert_eq!(port, 22);
+    }
+
+    #[test]
+    fn parse_ssh_info_rejects_garbage_after_bracket() {
+        assert!(parse_ssh_info("root@[::1]oops").is_none());
+        assert!(parse_ssh_info("root@[::1]:22oops").is_none());
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1030,7 +1030,9 @@ impl App {
     /// the SSH connection via the password flow (`pending_ssh` + Ctrl+P).
     fn apply_loaded_session(&mut self, session: filar_core::Session) {
         // Reset active runtime state before replacing history so stale events
-        // from the previous session don't leak into the restored one.
+        // from the previous session don't leak into the restored one. This
+        // runs on the single-threaded event loop (from `handle_key`), so the
+        // read-then-write of `terminal`/`pending_*` below cannot race.
         if let Some(token) = self.cancellation.take() {
             token.cancel();
         }
@@ -3137,24 +3139,31 @@ fn parse_ssh_command(cmd: &str) -> Option<(String, String, u16)> {
 }
 
 /// Parse `user@host[:port]` (the persisted `ssh_info` format) into
-/// `(user, host, port)`. The port defaults to 22 when omitted, and IPv6
-/// addresses in square brackets are supported (`user@[::1]:22`).
+/// `(user, host, port)`. The port defaults to 22 when omitted. IPv6 addresses
+/// in square brackets are supported, with or without a port
+/// (`user@[::1]`, `user@[::1]:22`).
 fn parse_ssh_info(info: &str) -> Option<(String, String, u16)> {
     let (user, host_port) = info.split_once('@')?;
-    let (host, port) = match host_port.rsplit_once(':') {
-        Some((h, p)) => (h, p.parse().ok()?),
-        None => (host_port, 22),
-    };
-    // Strip IPv6 brackets: `[::1]` → `::1`.
-    let host = if host.starts_with('[') && host.ends_with(']') {
-        &host[1..host.len() - 1]
+    let (host, port) = if let Some(rest) = host_port.strip_prefix('[') {
+        // Bracketed IPv6: the port, if present, follows the closing bracket.
+        let end = rest.find(']')?;
+        let host = &rest[..end];
+        let after = &rest[end + 1..];
+        let port = match after.strip_prefix(':') {
+            Some(p) => p.parse().ok()?,
+            None => 22,
+        };
+        (host.to_string(), port)
     } else {
-        host
+        match host_port.rsplit_once(':') {
+            Some((h, p)) => (h.to_string(), p.parse().ok()?),
+            None => (host_port.to_string(), 22),
+        }
     };
     if user.is_empty() || host.is_empty() {
         return None;
     }
-    Some((user.to_string(), host.to_string(), port))
+    Some((user.to_string(), host, port))
 }
 
 /// Check if a command is interactive (would hang the executor waiting for input).
@@ -6418,6 +6427,14 @@ mod tests {
     #[test]
     fn parse_ssh_info_handles_ipv6_brackets() {
         let (user, host, port) = parse_ssh_info("root@[::1]:22").unwrap();
+        assert_eq!(user, "root");
+        assert_eq!(host, "::1");
+        assert_eq!(port, 22);
+    }
+
+    #[test]
+    fn parse_ssh_info_handles_ipv6_without_port() {
+        let (user, host, port) = parse_ssh_info("root@[::1]").unwrap();
         assert_eq!(user, "root");
         assert_eq!(host, "::1");
         assert_eq!(port, 22);

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1007,6 +1007,15 @@ async fn run_app(
             executors.remove(&sid);
         }
 
+        // Teardown interactive backends for tabs reset by session restore
+        // (F3) — the tab stays open, but its PTY/SSH reader must stop.
+        for sid in app.take_pending_term_teardown() {
+            if let Some((term, handle)) = interactive_backends.remove(&sid) {
+                let _ = term.close().await;
+                handle.abort();
+            }
+        }
+
         // Create local executors for new tabs signalled via new_tab().
         for sid in app.take_pending_local_executors() {
             match filar_transport::LocalExecutor::new().await {

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -24,6 +24,7 @@ fn help_items(mode: AppMode) -> Vec<HelpItem> {
             HelpItem { key: "enter", desc: "send", action: Some(HelpAction::Send) },
             HelpItem { key: "F1", desc: "help", action: None },
             HelpItem { key: "F2", desc: "safe", action: None },
+            HelpItem { key: "F3", desc: "sessions", action: None },
             HelpItem { key: "!", desc: "shell", action: Some(HelpAction::Shell) },
             HelpItem { key: "^T", desc: "terminal", action: Some(HelpAction::Terminal) },
             HelpItem { key: "^O", desc: "hosts", action: None },

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -58,6 +58,12 @@ pub(crate) fn help_registry() -> Vec<HelpEntry> {
             available: |m| m != AppMode::PasswordInput,
         },
         HelpEntry {
+            key: "F3",
+            desc: "Open session selection overlay (restore a saved session)",
+            section: "Modes",
+            available: |m| m != AppMode::PasswordInput,
+        },
+        HelpEntry {
             key: "^P",
             desc: "Enter password input mode",
             section: "Modes",

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -35,6 +35,7 @@ mod help;
 mod host_select;
 mod input;
 mod save_overlay;
+mod session_select;
 #[allow(unused_imports)]
 pub(crate) use chat::scrollbar_content_len;
 pub mod layout_cache;
@@ -128,6 +129,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
         host_select::render_host_select(f, app, full);
     }
 
+    // Render session-selection overlay on top of everything if active.
+    if app.session_select_visible {
+        let full = f.area();
+        session_select::render_session_select(f, app, full);
+    }
+
     // Render session-save progress overlay on top of everything if active.
     if app.save_overlay_visible {
         let full = f.area();
@@ -199,6 +206,12 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
     if app.host_select_visible {
         let full = f.area();
         host_select::render_host_select(f, app, full);
+    }
+
+    // Render session-selection overlay on top of everything if active.
+    if app.session_select_visible {
+        let full = f.area();
+        session_select::render_session_select(f, app, full);
     }
 
     // Render session-save progress overlay on top of everything if active.

--- a/crates/tui/src/ui/session_select.rs
+++ b/crates/tui/src/ui/session_select.rs
@@ -1,0 +1,118 @@
+//! Session-selection overlay — modal window for restoring a saved session.
+//!
+//! Opened via `F3`. Shows the list of saved sessions (`SessionMeta`) with
+//! date, target/SSH host, LLM profile, and a message preview. Enter restores
+//! the selected session; Esc cancels.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::app::App;
+
+const OVERLAY_MAX_WIDTH: u16 = 76;
+const OVERLAY_H_MARGIN: u16 = 4;
+const OVERLAY_V_MARGIN: u16 = 3;
+
+/// Render the session-selection overlay on top of the current frame.
+pub(crate) fn render_session_select(f: &mut Frame, app: &App, area: Rect) {
+    let width = OVERLAY_MAX_WIDTH.min(area.width.saturating_sub(2 * OVERLAY_H_MARGIN));
+    let list_size = app.session_select_metas.len() as u16;
+    // Height: border (2) + title (1) + items + footer (1) + padding.
+    let content_height = list_size.saturating_add(4);
+    let height = content_height.min(area.height.saturating_sub(2 * OVERLAY_V_MARGIN));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+
+    let overlay_area = Rect::new(x, y, width, height);
+
+    f.render_widget(Clear, overlay_area);
+
+    let mut items: Vec<ListItem> = Vec::new();
+
+    if app.session_select_metas.is_empty() {
+        items.push(ListItem::new(Line::from(vec![
+            Span::styled("  No saved sessions found.", app.theme.warning_fg()),
+        ])));
+        items.push(ListItem::new(Line::from(vec![
+            Span::styled(
+                "  Sessions are saved every 30s and on exit (Ctrl+Q).",
+                app.theme.muted(),
+            ),
+        ])));
+    }
+
+    let preview_budget = (width.saturating_sub(48)) as usize;
+    for (i, meta) in app.session_select_metas.iter().enumerate() {
+        let cursor = if app.session_select_index == i { "\u{25b6}" } else { " " };
+        let host = meta
+            .ssh_info
+            .clone()
+            .unwrap_or_else(|| meta.target.clone());
+        let profile = meta.llm_profile.clone().unwrap_or_default();
+
+        items.push(ListItem::new(Line::from(vec![
+            Span::raw(format!(" {cursor} ")),
+            Span::styled(
+                &meta.timestamp,
+                Style::default()
+                    .fg(app.theme.fg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(host, Style::default().fg(app.theme.accent)),
+            Span::raw("  "),
+            Span::styled(profile, app.theme.muted()),
+            Span::raw("  "),
+            Span::styled(truncate(&meta.preview, preview_budget), app.theme.dim()),
+        ])));
+    }
+
+    let title = " Select session (F3) ";
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.accent))
+        .style(Style::default().bg(app.theme.bg))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ));
+
+    let mut state = ListState::default();
+    if !app.session_select_metas.is_empty() {
+        state.select(Some(app.session_select_index));
+    }
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().bg(app.theme.selection_bg));
+
+    f.render_stateful_widget(list, overlay_area, &mut state);
+
+    // Footer hint.
+    let footer = " \u{2191}\u{2193} navigate   Enter restore   Esc cancel ";
+    let footer_area = Rect::new(
+        overlay_area.x,
+        overlay_area.y + overlay_area.height.saturating_sub(1),
+        overlay_area.width,
+        1,
+    );
+    f.render_widget(
+        ratatui::widgets::Paragraph::new(Span::styled(footer, app.theme.muted())),
+        footer_area,
+    );
+}
+
+/// Truncate `s` to at most `max` characters, appending an ellipsis.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let keep = max.saturating_sub(1).max(1);
+        s.chars().take(keep).collect::<String>() + "\u{2026}"
+    } else {
+        s.to_string()
+    }
+}


### PR DESCRIPTION
Closes #273

## Summary

F3 now opens a session-selection overlay so the user can switch to a saved session without leaving the TUI.

- New `crates/tui/src/ui/session_select.rs` overlay (modeled on `host_select`), listing saved sessions with date, host/`ssh_info`, LLM profile, and a message preview.
- `App` gains `session_select_visible/index/metas`; `open_session_select()` loads `SessionStore::list()`, and `select_session()` + `apply_loaded_session()` replace the active tab's `messages`, `input_history`, `llm_profile`, and token stats.
- SSH restore: `parse_ssh_info("user@host:port")` re-initiates the SSH connection via the existing password flow (`pending_ssh` + Ctrl+P), the same path as `!ssh user@host`.
- F3 is intercepted before mode-specific handling (like F1/F2), so it works in every mode except `PasswordInput`.
- F3 is registered in `help_registry()` (Modes) and shown in the bottom help bar (`F3 sessions`).

## Tests

- `cargo test -p filar-tui` green — 321 passed (7 new: `parse_ssh_info` ×3, F3 toggle, Esc cancel, `apply_loaded_session` ×2).
- `cargo test --workspace` green.
- `cargo build --workspace` green.

## Notes

- SSH reconnect requires re-authentication (secrets are never persisted), so restoring an SSH session surfaces the Ctrl+P password prompt rather than silently reconnecting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an F3 session-selection overlay for browsing and restoring saved sessions.
  * Session entries show date, host, profile, and message previews, with keyboard navigation and cancel options.
  * Restored sessions include messages, input history, model settings, usage statistics, and target details.
  * SSH sessions can reconnect using the existing password prompt flow.
  * Added F3 guidance to the help bar and help overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->