### PR TITLE
feat(gui): auto-select SSH target and LLM profile on session click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   connection (password prompt via Ctrl+P), Esc cancels. F3 is shown in the
   bottom help bar and the F1 help overlay.
   ([#273](https://github.com/devlawey/filar/issues/273)).
+- GUI launcher: clicking a saved session now auto-selects the matching SSH
+  target (by host:port) and LLM profile (by name), and fills the Model / API
+  base URL fields from the session's launch context. The session list shows
+  the SSH host and model.
+  ([#274](https://github.com/devlawey/filar/issues/274)).
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4386,3 +4386,25 @@ session_meta_includes_launch_context). `cargo test --workspace` зелёные.
 apply_loaded_session×2). `cargo test -p filar-tui` — 321 passed.
 
 **Дальше:** #274 (GUI авто-выбор target/profile).
+
+---
+
+## Issue #274: feat(gui) — auto-select target/profile on session click
+
+**Milestone:** 0.9.0. **Ветка:** `feat/274-gui-session-autoselect`.
+
+**Что сделано:**
+- `SessionMeta` расширен полем `api_base_url` (для лаунчера).
+- GUI: `on_session_selected()` — при клике на сессию авто-выбирает SSH-слот
+  (по host:port из `ssh_info`), LLM-профиль (по имени), заполняет Model /
+  API base URL из launch-контекста. Нет совпадения SSH → Local + предупреждение.
+  Нет `ssh_info` → Local.
+- Список сессий показывает `ssh_info` (или target) и model.
+
+**Публичный API:** `SessionMeta` получил `api_base_url` (additive, serde-совместимо).
+
+**Тесты:** 4 новых (parse_ssh_host_port, session_click_autoselects_ssh_and_profile,
+session_click_without_ssh_info_stays_local, session_click_unmatched_ssh_warns_and_stays_local).
+`cargo test -p filar-gui` — 21 passed.
+
+**Дальше:** milestone 0.9.0 (session persistence) завершён.

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -105,6 +105,9 @@ pub struct SessionMeta {
     /// Model identifier used at launch.
     #[serde(default)]
     pub model: Option<String>,
+    /// API base URL used at launch.
+    #[serde(default)]
+    pub api_base_url: Option<String>,
     /// Preview of the first user message (or system message).
     pub preview: String,
 }
@@ -125,6 +128,7 @@ impl From<&Session> for SessionMeta {
             llm_profile: s.llm_profile.clone(),
             ssh_info: s.ssh_info.clone(),
             model: s.model.clone(),
+            api_base_url: s.api_base_url.clone(),
             preview,
         }
     }
@@ -797,5 +801,6 @@ mod tests {
         let meta = SessionMeta::from(&session);
         assert_eq!(meta.ssh_info.as_deref(), Some("root@10.0.0.5:22"));
         assert_eq!(meta.model.as_deref(), Some("glm-5.1"));
+        assert_eq!(meta.api_base_url.as_deref(), Some("https://example.com"));
     }
 }

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -543,6 +543,21 @@ fn parse_ssh_host_port(info: &str) -> Option<(String, u16)> {
     Some((host, port))
 }
 
+/// Fill a profile's model / API base URL fields from a session's launch
+/// context (empty session values leave the profile untouched).
+fn fill_profile_from_meta(p: &mut LlmProfileData, meta: &SessionMeta) {
+    if let Some(model) = &meta.model {
+        if !model.is_empty() {
+            p.model = model.clone();
+        }
+    }
+    if let Some(url) = &meta.api_base_url {
+        if !url.is_empty() {
+            p.api_base_url = url.clone();
+        }
+    }
+}
+
 impl LauncherApp {
     fn render_session_list(&mut self, ui: &mut egui::Ui) {
         ui.label("Recent sessions:");
@@ -597,21 +612,18 @@ impl LauncherApp {
 
         // Auto-select the LLM profile by name and fill its model / API base
         // URL from the session launch context. Only the matched profile is
-        // touched, so an unrelated profile is never overwritten.
-        if let Some(ref name) = meta.llm_profile {
-            if let Some(idx) = self.profiles.iter().position(|p| p.name == *name) {
-                self.selected_profile = idx;
-                if let Some(p) = self.profiles.get_mut(idx) {
-                    if let Some(model) = &meta.model {
-                        if !model.is_empty() {
-                            p.model = model.clone();
-                        }
-                    }
-                    if let Some(url) = &meta.api_base_url {
-                        if !url.is_empty() {
-                            p.api_base_url = url.clone();
-                        }
-                    }
+        // touched when a name is present; without a name, the flat model/URL
+        // is restored into the current selection.
+        match &meta.llm_profile {
+            Some(name) => {
+                if let Some(idx) = self.profiles.iter().position(|p| p.name == *name) {
+                    self.selected_profile = idx;
+                    fill_profile_from_meta(&mut self.profiles[idx], &meta);
+                }
+            }
+            None => {
+                if let Some(p) = self.profiles.get_mut(self.selected_profile) {
+                    fill_profile_from_meta(p, &meta);
                 }
             }
         }
@@ -620,7 +632,12 @@ impl LauncherApp {
         match meta.ssh_info.as_deref().and_then(parse_ssh_host_port) {
             Some((host, port)) => {
                 if let Some(slot_idx) = self.ssh_slots.iter().position(|s| {
-                    s.host == host && s.port.parse::<u16>().unwrap_or(22) == port
+                    let slot_port = if s.port.trim().is_empty() {
+                        Some(22)
+                    } else {
+                        s.port.parse::<u16>().ok()
+                    };
+                    s.host == host && slot_port == Some(port)
                 }) {
                     self.target_mode = slot_idx + 1;
                     self.validation_error.clear();
@@ -1483,6 +1500,25 @@ mod tests {
         app.validation_error = "stale warning".into();
         app.on_session_selected(0);
         assert!(app.validation_error.is_empty(), "Local selection must clear stale warning");
+    }
+
+    #[test]
+    fn session_click_flat_model_fills_current_profile() {
+        let meta = make_meta(None, None, Some("flat-model"), Some("https://flat.example.com"));
+        let mut app = make_app(meta);
+        app.on_session_selected(0);
+        assert_eq!(app.selected_profile, 0);
+        assert_eq!(app.profiles[0].model, "flat-model");
+        assert_eq!(app.profiles[0].api_base_url, "https://flat.example.com");
+    }
+
+    #[test]
+    fn session_click_invalid_slot_port_does_not_match() {
+        let meta = make_meta(Some("root@10.0.0.5:22"), None, None, None);
+        let mut app = make_app(meta);
+        app.ssh_slots[0].port = "22abc".into();
+        app.on_session_selected(0);
+        assert_eq!(app.target_mode, 0, "invalid non-empty port must not match 22");
     }
 }
 

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -517,6 +517,32 @@ fn configure_theme(ctx: &egui::Context) {
     ctx.set_visuals(visuals);
 }
 
+/// Parse `user@host[:port]` (the persisted `ssh_info` format) into
+/// `(host, port)`. Supports bracketed IPv6 with an optional port.
+fn parse_ssh_host_port(info: &str) -> Option<(String, u16)> {
+    let (_, host_port) = info.split_once('@')?;
+    let (host, port) = if let Some(rest) = host_port.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let host = &rest[..end];
+        let after = &rest[end + 1..];
+        let port = if after.is_empty() {
+            22
+        } else {
+            after.strip_prefix(':')?.parse().ok()?
+        };
+        (host.to_string(), port)
+    } else {
+        match host_port.rsplit_once(':') {
+            Some((h, p)) => (h.to_string(), p.parse().ok()?),
+            None => (host_port.to_string(), 22),
+        }
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some((host, port))
+}
+
 impl LauncherApp {
     fn render_session_list(&mut self, ui: &mut egui::Ui) {
         ui.label("Recent sessions:");
@@ -531,19 +557,84 @@ impl LauncherApp {
         {
             self.selected_session = None;
         }
+        let mut clicked: Option<usize> = None;
         egui::ScrollArea::vertical()
             .max_height(100.0)
             .show(ui, |ui| {
                 for (i, session) in self.sessions.iter().enumerate() {
                     let selected = self.selected_session == Some(i);
+                    let host = session
+                        .ssh_info
+                        .clone()
+                        .unwrap_or_else(|| session.target.clone());
+                    let model = session
+                        .model
+                        .clone()
+                        .or_else(|| session.llm_profile.clone())
+                        .unwrap_or_default();
                     let text = format!(
-                        "  {} | {} | {}",
-                        session.timestamp, session.target, session.preview
+                        "  {} | {} | {} | {}",
+                        session.timestamp, host, model, session.preview
                     );
                     if ui.selectable_label(selected, &text).clicked() {
-                        self.selected_session = Some(i);
+                        clicked = Some(i);
                     }
-            }});
+                }
+            });
+        if let Some(i) = clicked {
+            self.on_session_selected(i);
+        }
+    }
+
+    /// Select a saved session and auto-configure the launcher from its launch
+    /// context: SSH target (matched by `ssh_info`), LLM profile (matched by
+    /// name), and the model / API base URL fields.
+    fn on_session_selected(&mut self, i: usize) {
+        self.selected_session = Some(i);
+        let Some(meta) = self.sessions.get(i).cloned() else {
+            return;
+        };
+
+        // Auto-select the LLM profile by name.
+        if let Some(ref name) = meta.llm_profile {
+            if let Some(idx) = self.profiles.iter().position(|p| p.name == *name) {
+                self.selected_profile = idx;
+            }
+        }
+        // Fill model / API base URL into the selected profile from the session.
+        if let Some(p) = self.profiles.get_mut(self.selected_profile) {
+            if let Some(model) = &meta.model {
+                if !model.is_empty() {
+                    p.model = model.clone();
+                }
+            }
+            if let Some(url) = &meta.api_base_url {
+                if !url.is_empty() {
+                    p.api_base_url = url.clone();
+                }
+            }
+        }
+
+        // Auto-select the SSH target by ssh_info.
+        match meta.ssh_info.as_deref().and_then(parse_ssh_host_port) {
+            Some((host, port)) => {
+                if let Some(slot_idx) = self.ssh_slots.iter().position(|s| {
+                    s.host == host && s.port.parse::<u16>().unwrap_or(0) == port
+                }) {
+                    self.target_mode = slot_idx + 1;
+                    self.validation_error.clear();
+                } else {
+                    self.target_mode = 0;
+                    self.validation_error = format!(
+                        "No SSH profile matches '{}'. Select a target manually.",
+                        meta.ssh_info.as_deref().unwrap_or_default()
+                    );
+                }
+            }
+            None => {
+                self.target_mode = 0;
+            }
+        }
     }
 
     fn render_target_selector(&mut self, ui: &mut egui::Ui) {
@@ -1260,6 +1351,101 @@ mod tests {
     fn ssh_cred_name_special_chars_preserved() {
         assert_eq!(ssh_cred_name(0, "my server!"), "ssh_target:my server!");
         assert_eq!(ssh_cred_name(1, "сервер"), "ssh_target:сервер");
+    }
+
+    fn make_meta(ssh_info: Option<&str>, llm_profile: Option<&str>, model: Option<&str>, api_base_url: Option<&str>) -> SessionMeta {
+        SessionMeta {
+            id: "1".into(),
+            timestamp: "2026-08-14 00:00:00".into(),
+            target: "local".into(),
+            llm_profile: llm_profile.map(str::to_string),
+            ssh_info: ssh_info.map(str::to_string),
+            model: model.map(str::to_string),
+            api_base_url: api_base_url.map(str::to_string),
+            preview: "hi".into(),
+        }
+    }
+
+    fn make_app(meta: SessionMeta) -> LauncherApp {
+        LauncherApp {
+            sessions: vec![meta],
+            selected_session: None,
+            target_mode: 0,
+            ssh_slots: vec![SshSlot {
+                host: "10.0.0.5".into(),
+                port: "22".into(),
+                user: "root".into(),
+                alias: String::new(),
+                password: String::new(),
+                save_password: false,
+            }],
+            profiles: vec![LlmProfileData {
+                name: "glm".into(),
+                model: String::new(),
+                api_base_url: String::new(),
+                key_env: "GLM_API_KEY".into(),
+                api_key: String::new(),
+                temperature: String::new(),
+                extra_body: String::new(),
+            }],
+            selected_profile: 0,
+            validation_error: String::new(),
+            save_dir: None,
+        }
+    }
+
+    #[test]
+    fn parse_ssh_host_port_parses_user_host_port() {
+        assert_eq!(
+            parse_ssh_host_port("root@10.0.0.5:22"),
+            Some(("10.0.0.5".to_string(), 22))
+        );
+        assert_eq!(
+            parse_ssh_host_port("admin@devbox"),
+            Some(("devbox".to_string(), 22))
+        );
+        assert_eq!(
+            parse_ssh_host_port("root@[::1]:2222"),
+            Some(("::1".to_string(), 2222))
+        );
+        assert!(parse_ssh_host_port("no-at-sign").is_none());
+    }
+
+    #[test]
+    fn session_click_autoselects_ssh_and_profile() {
+        let meta = make_meta(
+            Some("root@10.0.0.5:22"),
+            Some("glm"),
+            Some("glm-5.1"),
+            Some("https://example.com"),
+        );
+        let mut app = make_app(meta);
+        app.on_session_selected(0);
+        assert_eq!(app.target_mode, 1, "matching SSH slot must be selected");
+        assert_eq!(app.selected_profile, 0);
+        assert_eq!(app.profiles[0].model, "glm-5.1");
+        assert_eq!(app.profiles[0].api_base_url, "https://example.com");
+        assert!(app.validation_error.is_empty());
+    }
+
+    #[test]
+    fn session_click_without_ssh_info_stays_local() {
+        let meta = make_meta(None, None, None, None);
+        let mut app = make_app(meta);
+        app.on_session_selected(0);
+        assert_eq!(app.target_mode, 0, "no ssh_info → Local");
+    }
+
+    #[test]
+    fn session_click_unmatched_ssh_warns_and_stays_local() {
+        let meta = make_meta(Some("root@192.168.9.9:22"), None, None, None);
+        let mut app = make_app(meta);
+        app.on_session_selected(0);
+        assert_eq!(app.target_mode, 0, "no matching slot → Local");
+        assert!(
+            app.validation_error.contains("No SSH profile matches"),
+            "must warn about unmatched ssh_info"
+        );
     }
 }
 

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -632,10 +632,11 @@ impl LauncherApp {
         match meta.ssh_info.as_deref().and_then(parse_ssh_host_port) {
             Some((host, port)) => {
                 if let Some(slot_idx) = self.ssh_slots.iter().position(|s| {
-                    let slot_port = if s.port.trim().is_empty() {
+                    let trimmed = s.port.trim();
+                    let slot_port = if trimmed.is_empty() {
                         Some(22)
                     } else {
-                        s.port.parse::<u16>().ok()
+                        trimmed.parse::<u16>().ok()
                     };
                     s.host == host && slot_port == Some(port)
                 }) {
@@ -1519,6 +1520,15 @@ mod tests {
         app.ssh_slots[0].port = "22abc".into();
         app.on_session_selected(0);
         assert_eq!(app.target_mode, 0, "invalid non-empty port must not match 22");
+    }
+
+    #[test]
+    fn session_click_slot_port_with_spaces_matches() {
+        let meta = make_meta(Some("root@10.0.0.5:22"), None, None, None);
+        let mut app = make_app(meta);
+        app.ssh_slots[0].port = " 22 ".into();
+        app.on_session_selected(0);
+        assert_eq!(app.target_mode, 1, "whitespace around port must be trimmed");
     }
 }
 

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -595,22 +595,23 @@ impl LauncherApp {
             return;
         };
 
-        // Auto-select the LLM profile by name.
+        // Auto-select the LLM profile by name and fill its model / API base
+        // URL from the session launch context. Only the matched profile is
+        // touched, so an unrelated profile is never overwritten.
         if let Some(ref name) = meta.llm_profile {
             if let Some(idx) = self.profiles.iter().position(|p| p.name == *name) {
                 self.selected_profile = idx;
-            }
-        }
-        // Fill model / API base URL into the selected profile from the session.
-        if let Some(p) = self.profiles.get_mut(self.selected_profile) {
-            if let Some(model) = &meta.model {
-                if !model.is_empty() {
-                    p.model = model.clone();
-                }
-            }
-            if let Some(url) = &meta.api_base_url {
-                if !url.is_empty() {
-                    p.api_base_url = url.clone();
+                if let Some(p) = self.profiles.get_mut(idx) {
+                    if let Some(model) = &meta.model {
+                        if !model.is_empty() {
+                            p.model = model.clone();
+                        }
+                    }
+                    if let Some(url) = &meta.api_base_url {
+                        if !url.is_empty() {
+                            p.api_base_url = url.clone();
+                        }
+                    }
                 }
             }
         }
@@ -619,7 +620,7 @@ impl LauncherApp {
         match meta.ssh_info.as_deref().and_then(parse_ssh_host_port) {
             Some((host, port)) => {
                 if let Some(slot_idx) = self.ssh_slots.iter().position(|s| {
-                    s.host == host && s.port.parse::<u16>().unwrap_or(0) == port
+                    s.host == host && s.port.parse::<u16>().unwrap_or(22) == port
                 }) {
                     self.target_mode = slot_idx + 1;
                     self.validation_error.clear();
@@ -633,6 +634,7 @@ impl LauncherApp {
             }
             None => {
                 self.target_mode = 0;
+                self.validation_error.clear();
             }
         }
     }
@@ -1446,6 +1448,41 @@ mod tests {
             app.validation_error.contains("No SSH profile matches"),
             "must warn about unmatched ssh_info"
         );
+    }
+
+    #[test]
+    fn session_click_unknown_profile_does_not_overwrite() {
+        let meta = make_meta(
+            None,
+            Some("nonexistent"),
+            Some("other-model"),
+            Some("https://other.example.com"),
+        );
+        let mut app = make_app(meta);
+        app.profiles[0].model = "keep-me".into();
+        app.profiles[0].api_base_url = "https://keep.example.com".into();
+        app.on_session_selected(0);
+        assert_eq!(app.selected_profile, 0, "no matching profile → keep current");
+        assert_eq!(app.profiles[0].model, "keep-me", "unrelated profile must not be overwritten");
+        assert_eq!(app.profiles[0].api_base_url, "https://keep.example.com");
+    }
+
+    #[test]
+    fn session_click_matches_default_port_when_slot_empty() {
+        let meta = make_meta(Some("root@10.0.0.5"), None, None, None);
+        let mut app = make_app(meta);
+        app.ssh_slots[0].port = String::new();
+        app.on_session_selected(0);
+        assert_eq!(app.target_mode, 1, "empty slot port must be treated as 22");
+    }
+
+    #[test]
+    fn session_click_clears_stale_warning_on_local() {
+        let meta = make_meta(None, None, None, None);
+        let mut app = make_app(meta);
+        app.validation_error = "stale warning".into();
+        app.on_session_selected(0);
+        assert!(app.validation_error.is_empty(), "Local selection must clear stale warning");
     }
 }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -6467,6 +6467,7 @@ mod tests {
             llm_profile: None,
             ssh_info: None,
             model: None,
+            api_base_url: None,
             preview: String::new(),
         }];
         app.session_select_visible = true;


### PR DESCRIPTION
Closes #274

## Summary

Clicking a saved session in the GUI launcher now auto-configures the target and LLM profile from the session's launch context instead of leaving the user to re-select everything manually.

- `SessionMeta` gains `api_base_url` (additive, `#[serde(default)]`) so the launcher can read the full launch context without loading the whole session.
- `on_session_selected()`:
  - SSH: matches `ssh_info` (host:port) against the 5 SSH slots and switches `target_mode` to it; if no slot matches, stays Local with a warning.
  - LLM: matches `llm_profile` by name and switches `selected_profile`.
  - Model / API base URL: fills the selected profile's fields from `model` / `api_base_url`.
  - No `ssh_info` → stays Local.
- The session list now shows the SSH host (or target) and the model.

## Tests

- `cargo test -p filar-gui` green — 21 passed (4 new: `parse_ssh_host_port`, `session_click_autoselects_ssh_and_profile`, `session_click_without_ssh_info_stays_local`, `session_click_unmatched_ssh_warns_and_stays_local`).
- `cargo test --workspace` green (core 54, tui 325).
- `cargo build --workspace` green.

## Notes

- `api_base_url` is added to `SessionMeta` in `filar-core` (additive serde-compatible field); the existing `From<&Session>` now populates it.