### PR TITLE
ci(release): dual-platform Windows + macOS aarch64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,22 @@ jobs:
           files: filar-*-windows-x86_64.exe
 
   # Decision for #289: one macOS arch for now — aarch64 (Apple Silicon).
-  # `macos-latest` is arm64; Intel (x86_64) / universal binary left for a
-  # follow-up (see packaging issue #297) if demand appears.
+  # Pin `macos-14` (arm64), not the floating `macos-latest` alias, so the
+  # asset name `*-macos-aarch64` cannot drift if GitHub retargets the alias.
+  # Intel (x86_64) / universal binary left for follow-up (#297).
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 45
     steps:
       - name: Checkout code (at the release tag)
         uses: actions/checkout@v4
+
+      - name: Assert Apple Silicon runner
+        run: |
+          test "$(uname -m)" = "arm64" || {
+            echo "Expected arm64 runner for *-macos-aarch64 asset, got $(uname -m)"
+            exit 1
+          }
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,22 @@
-name: Release build (Windows)
+name: Release build
 
-# Триггер — ПУБЛИКАЦИЯ релиза через интерфейс GitHub.
-# Флоу: Releases → "Draft a new release" → выбираешь/создаёшь тег (например v0.1.1)
-#       → жмёшь "Generate release notes" (GitHub сам соберёт список из PR)
-#       → "Publish release".
-# Публикация запускает этот workflow: он собирает Windows-бинарник и прикладывает
-# его к тому же релизу как файл для скачивания.
+# Trigger — publishing a GitHub Release.
+# Flow: Releases → "Draft a new release" → create/select tag (e.g. v1.0.0)
+#       → "Generate release notes" → "Publish release".
+# Publishing runs this workflow: it builds Windows + macOS binaries and
+# attaches them to the same release as downloadable assets.
 on:
   release:
     types: [published]
 
-# Нужно право записи в содержимое репозитория, чтобы загрузить файл в релиз.
+# Write access is required to upload assets to the release.
 permissions:
   contents: write
 
 jobs:
   build-windows:
     runs-on: windows-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout code (at the release tag)
         uses: actions/checkout@v4
@@ -40,3 +40,35 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: filar-*-windows-x86_64.exe
+
+  # Decision for #289: one macOS arch for now — aarch64 (Apple Silicon).
+  # `macos-latest` is arm64; Intel (x86_64) / universal binary left for a
+  # follow-up (see packaging issue #297) if demand appears.
+  build-macos:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code (at the release tag)
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --package filar-app
+
+      - name: Package binary with version in the name
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          cp target/release/filar "filar-${tag}-macos-aarch64"
+          chmod +x "filar-${tag}-macos-aarch64"
+          file "filar-${tag}-macos-aarch64"
+          rustc -vV | grep host
+
+      - name: Attach binary to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: filar-*-macos-aarch64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Release CI now builds and attaches both Windows (`*-windows-x86_64.exe`)
+  and macOS (`*-macos-aarch64`) binaries to the same GitHub Release
+  ([#289](https://github.com/devlawey/filar/issues/289)).
+
 ## [0.9.0] - 2026-08-15
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4499,10 +4499,13 @@ session_click_without_ssh_info_stays_local, session_click_unmatched_ssh_warns_an
 **Что сделано:**
 - `.github/workflows/release.yml` переименован в «Release build» (не Windows-only).
 - Job `build-windows` сохранён (asset `filar-{tag}-windows-x86_64.exe`).
-- Добавлен job `build-macos` на `macos-latest` → asset
-  `filar-{tag}-macos-aarch64` (оба аттачатся к одному GitHub Release).
+- Добавлен job `build-macos` → asset `filar-{tag}-macos-aarch64`
+  (оба аттачатся к одному GitHub Release).
 - **Решение по аркам:** одна — `aarch64` (Apple Silicon). Intel / universal —
   follow-up (#297), не в этом PR.
+- **Review fix:** runner закреплён на `macos-14` (не `macos-latest`) +
+  assert `uname -m == arm64` перед упаковкой — имя ассета не может уехать
+  при смене floating alias.
 - `docs/PLATFORM_NOTES.md` — секция Release binaries + quarantine note.
 - CHANGELOG `[Unreleased]` — строка про dual-platform CI.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4506,6 +4506,9 @@ session_click_without_ssh_info_stays_local, session_click_unmatched_ssh_warns_an
 - **Review fix:** runner закреплён на `macos-14` (не `macos-latest`) +
   assert `uname -m == arm64` перед упаковкой — имя ассета не может уехать
   при смене floating alias.
+- **Review fix (2):** в PLATFORM_NOTES добавлен `chmod +x` вместе с
+  `xattr -d com.apple.quarantine` — raw asset с Releases без +x даёт
+  permission denied.
 - `docs/PLATFORM_NOTES.md` — секция Release binaries + quarantine note.
 - CHANGELOG `[Unreleased]` — строка про dual-platform CI.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4489,3 +4489,27 @@ session_click_without_ssh_info_stays_local, session_click_unmatched_ssh_warns_an
 
 **Дальше:** SMOKE-чекап (`docs/SMOKE.md`, включая новые F3-кейсы) → тег
 `v0.9.0` + GitHub Release → тег движка `engine-v0.9.0`.
+
+---
+
+## Issue #289: ci(release) — dual-platform Windows + macOS
+
+**Milestone:** Filar v1.0.0. **Ветка:** `feat/289-dual-platform-release`.
+
+**Что сделано:**
+- `.github/workflows/release.yml` переименован в «Release build» (не Windows-only).
+- Job `build-windows` сохранён (asset `filar-{tag}-windows-x86_64.exe`).
+- Добавлен job `build-macos` на `macos-latest` → asset
+  `filar-{tag}-macos-aarch64` (оба аттачатся к одному GitHub Release).
+- **Решение по аркам:** одна — `aarch64` (Apple Silicon). Intel / universal —
+  follow-up (#297), не в этом PR.
+- `docs/PLATFORM_NOTES.md` — секция Release binaries + quarantine note.
+- CHANGELOG `[Unreleased]` — строка про dual-platform CI.
+
+**Публичный API:** нет (только CI/docs).
+
+**Тесты:** локально `cargo build --workspace` / `cargo test --workspace`
+(юнит); macOS job проверяется только на publish release (нет dry-run в этом PR).
+
+**Дальше:** #296 (prepare-release skill под dual assets), packaging #297,
+smoke #294.

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -82,10 +82,12 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 | Platform | Runner | Asset name |
 |----------|--------|------------|
 | Windows  | `windows-latest` | `filar-{tag}-windows-x86_64.exe` |
-| macOS    | `macos-latest`   | `filar-{tag}-macos-aarch64` |
+| macOS    | `macos-14` (arm64) | `filar-{tag}-macos-aarch64` |
 
 > **Arch decision (#289):** macOS ships **one** architecture — `aarch64`
-> (Apple Silicon). Intel (`x86_64`) and universal binaries are out of scope for
-> this workflow until packaging follow-up (#297). Unsigned OSS downloads on
-> macOS may need `xattr -d com.apple.quarantine <path>` before first run.
+> (Apple Silicon). The job pins `macos-14` (not floating `macos-latest`) and
+> asserts `uname -m == arm64` before packaging so the asset name cannot drift.
+> Intel (`x86_64`) and universal binaries are out of scope until packaging
+> follow-up (#297). Unsigned OSS downloads on macOS may need
+> `xattr -d com.apple.quarantine <path>` before first run.
 

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -88,6 +88,10 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 > (Apple Silicon). The job pins `macos-14` (not floating `macos-latest`) and
 > asserts `uname -m == arm64` before packaging so the asset name cannot drift.
 > Intel (`x86_64`) and universal binaries are out of scope until packaging
-> follow-up (#297). Unsigned OSS downloads on macOS may need
-> `xattr -d com.apple.quarantine <path>` before first run.
+> follow-up (#297). After downloading the raw asset from GitHub Releases,
+> restore the executable bit and clear Gatekeeper quarantine if needed:
+>
+> ```bash
+> chmod +x filar-*-macos-aarch64 && xattr -d com.apple.quarantine filar-*-macos-aarch64
+> ```
 

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -75,4 +75,17 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 > bytes to the pipe in the OEM code page may still be mis-decoded; that is a
 > separate, harder problem and is not handled here.
 
+## Release binaries (CI)
+
+`.github/workflows/release.yml` builds and attaches assets on release publish:
+
+| Platform | Runner | Asset name |
+|----------|--------|------------|
+| Windows  | `windows-latest` | `filar-{tag}-windows-x86_64.exe` |
+| macOS    | `macos-latest`   | `filar-{tag}-macos-aarch64` |
+
+> **Arch decision (#289):** macOS ships **one** architecture — `aarch64`
+> (Apple Silicon). Intel (`x86_64`) and universal binaries are out of scope for
+> this workflow until packaging follow-up (#297). Unsigned OSS downloads on
+> macOS may need `xattr -d com.apple.quarantine <path>` before first run.
 


### PR DESCRIPTION
Closes #289

## Summary
- Rename workflow to **Release build** and keep `build-windows` (`filar-{tag}-windows-x86_64.exe`).
- Add `build-macos` on `macos-latest` → asset `filar-{tag}-macos-aarch64` attached to the same release.
- **Arch decision:** one macOS arch (`aarch64` / Apple Silicon). Intel / universal deferred to #297.
- Document assets + Gatekeeper quarantine note in `docs/PLATFORM_NOTES.md`; CHANGELOG / PROGRESS updated.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (0 failed; 7 `#[ignore]` docker-sshd — not run)
- [ ] Manual: publish a test/draft release (or wait for next `v*`) and confirm both assets upload

## Out of scope
- `prepare-release` skill dual-asset checks (#296)
- macOS packaging / `.app` / notarization (#297)
- Intel macOS (`x86_64`) binary