### PR TITLE
fix(app,gui): SSH password keyring key mismatch on GUI→TUI handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- GUI→TUI SSH password handoff now reads the OS keyring under
+  `ssh_target:{alias|SSHn}` (same key the launcher writes), instead of the
+  legacy `ssh{slot}` name that never matched
+  ([#290](https://github.com/devlawey/filar/issues/290)).
+
 ### Changed
 
 - Release CI now builds and attaches both Windows (`*-windows-x86_64.exe`)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4535,6 +4535,8 @@ smoke #294.
 - `resolve_gui_ssh_target` в `main.rs`: keyring lookup + `SshTarget.name` = display name
   (больше не `"gui-ssh"` / `ssh{N}`).
 - GUI wrapper и `build_ssh_targets_from_profiles` используют те же helpers.
+- **Review:** sync keyring задокументирован как one-shot startup (до TUI loop);
+  `spawn_blocking` для всех keyring-чтений на старте — вне скоупа #290.
 
 **Публичный API:** additive — `ssh_cred_name` / `ssh_target_display_name` в core;
 `SshConnection.alias` (default `""`).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4519,3 +4519,27 @@ session_click_without_ssh_info_stays_local, session_click_unmatched_ssh_warns_an
 
 **Дальше:** #296 (prepare-release skill под dual assets), packaging #297,
 smoke #294.
+
+---
+
+## Issue #290: fix(app,gui) — SSH password keyring key mismatch on GUI→TUI handoff
+
+**Milestone:** Filar v1.0.0. **Ветка:** `fix/290-ssh-keyring-handoff`.
+
+**Проблема:** GUI писал пароль как `ssh_target:{alias|SSHn}`, а `main.rs`
+после subprocess читал `ssh{slot}` — handoff Save password → Launch ломался.
+
+**Решение:**
+- `filar_core::{ssh_cred_name, ssh_target_display_name}` — единый контракт имён.
+- `SshConnection.alias` сериализуется в `pending_launch.json` (не секрет).
+- `resolve_gui_ssh_target` в `main.rs`: keyring lookup + `SshTarget.name` = display name
+  (больше не `"gui-ssh"` / `ssh{N}`).
+- GUI wrapper и `build_ssh_targets_from_profiles` используют те же helpers.
+
+**Публичный API:** additive — `ssh_cred_name` / `ssh_target_display_name` в core;
+`SshConnection.alias` (default `""`).
+
+**Тесты:** core naming; gui round-trip alias; app `resolve_gui_ssh_*`.
+**DoD smoke:** Save password → Launch → SSH без повторного ввода (Win/Mac) — вручную.
+
+**Дальше:** CodeRabbit / ревью.

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -117,6 +117,13 @@ pub fn resolve_startup_profile(
 /// [`filar_core::ssh_cred_name`] — the same key the launcher writes.
 /// Target `name` uses [`filar_core::ssh_target_display_name`] so later TUI
 /// reconnects (`ssh_target:{name}`) hit the same entry.
+///
+/// # Sync keyring
+///
+/// `KeyringSecretProvider::get` is synchronous. Callers must invoke this
+/// **once during startup**, before the TUI event loop is running (same
+/// pattern as the GUI API-key lookup a few lines below). Do not call it from
+/// a hot async path without `spawn_blocking`.
 fn resolve_gui_ssh_target(s: &filar_gui::SshConnection) -> filar_core::SshTarget {
     let name = filar_core::ssh_target_display_name(s.slot, &s.alias);
     let password = if s.password.is_empty() {

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -110,6 +110,34 @@ pub fn resolve_startup_profile(
     }
 }
 
+/// Build an [`SshTarget`](filar_core::SshTarget) from a GUI [`SshConnection`](filar_gui::SshConnection).
+///
+/// When the password is empty (normal after `pending_launch.json` deserialize —
+/// it is `#[serde(skip)]`), reads it from the OS keyring under
+/// [`filar_core::ssh_cred_name`] — the same key the launcher writes.
+/// Target `name` uses [`filar_core::ssh_target_display_name`] so later TUI
+/// reconnects (`ssh_target:{name}`) hit the same entry.
+fn resolve_gui_ssh_target(s: &filar_gui::SshConnection) -> filar_core::SshTarget {
+    let name = filar_core::ssh_target_display_name(s.slot, &s.alias);
+    let password = if s.password.is_empty() {
+        let cred = filar_core::KeyringSecretProvider::new();
+        let key = filar_core::ssh_cred_name(s.slot, &s.alias);
+        cred.get(&key)
+            .inspect_err(|e| tracing::debug!(error = %e, %key, "no saved SSH password in keyring"))
+            .ok()
+    } else {
+        Some(s.password.clone())
+    };
+    filar_core::SshTarget {
+        name,
+        host: s.host.clone(),
+        port: s.port,
+        user: s.user.clone(),
+        auth: filar_core::SshAuth::Password { password },
+        host_key_policy: filar_core::HostKeyPolicy::Tofu,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LLM client factory
 // ---------------------------------------------------------------------------
@@ -334,26 +362,9 @@ async fn run() -> anyhow::Result<()> {
                 // Build SshTarget if the user selected SSH in the GUI.
                 // Read password from OS credential store if not passed in
                 // (since the struct now excludes secrets from serialization).
+                // Keyring key MUST match GUI/`ssh_cred_name` (#290), not legacy `ssh{slot}`.
                 let ssh_target = launch.ssh.map(|s| {
-                    let password = if s.password.is_empty() {
-                        let cred = filar_core::KeyringSecretProvider::new();
-                        let name = format!("ssh{}", s.slot);
-                        cred.get(&name)
-                            .inspect_err(|e| tracing::debug!(error = %e, %name, "no saved SSH password in keyring"))
-                            .ok()
-                    } else {
-                        Some(s.password)
-                    };
-                    filar_core::SshTarget {
-                        name: "gui-ssh".to_string(),
-                        host: s.host,
-                        port: s.port,
-                        user: s.user,
-                        auth: filar_core::SshAuth::Password {
-                            password,
-                        },
-                        host_key_policy: filar_core::HostKeyPolicy::Tofu,
-                    }
+                    resolve_gui_ssh_target(&s)
                 });
 
                 // Read API key from OS credential store using the profile's key_env.
@@ -570,7 +581,61 @@ async fn run() -> anyhow::Result<()> {
 mod tests {
     use filar_core::{LlmProfile, SecretProvider, StaticSecretProvider};
 
-    use super::build_llm_client_from_profile;
+    use super::{build_llm_client_from_profile, resolve_gui_ssh_target};
+
+    // ── GUI→TUI SSH keyring handoff (#290) ──────────────────────────────
+
+    #[test]
+    fn resolve_gui_ssh_uses_cred_name_not_legacy_ssh_slot() {
+        // Empty password → keyring lookup uses ssh_target:…, never ssh{N}.
+        let conn = filar_gui::SshConnection {
+            host: "10.0.0.1".into(),
+            port: 22,
+            user: "root".into(),
+            password: String::new(),
+            slot: 0,
+            alias: String::new(),
+        };
+        let target = resolve_gui_ssh_target(&conn);
+        assert_eq!(target.name, "SSH1", "empty alias → SSH{{slot+1}}");
+        assert_eq!(
+            filar_core::ssh_cred_name(conn.slot, &conn.alias),
+            "ssh_target:SSH1",
+            "keyring key must match GUI save contract"
+        );
+        // Legacy key `ssh0` must NOT be what we document/use.
+        assert_ne!(
+            filar_core::ssh_cred_name(conn.slot, &conn.alias),
+            format!("ssh{}", conn.slot)
+        );
+    }
+
+    #[test]
+    fn resolve_gui_ssh_alias_sets_target_name_and_cred_key() {
+        let conn = filar_gui::SshConnection {
+            host: "example.com".into(),
+            port: 2222,
+            user: "admin".into(),
+            password: "in-memory".into(),
+            slot: 2,
+            alias: "prod-web".into(),
+        };
+        let target = resolve_gui_ssh_target(&conn);
+        assert_eq!(target.name, "prod-web");
+        assert_eq!(target.host, "example.com");
+        assert_eq!(target.port, 2222);
+        assert_eq!(target.user, "admin");
+        assert_eq!(
+            filar_core::ssh_cred_name(conn.slot, &conn.alias),
+            "ssh_target:prod-web"
+        );
+        match target.auth {
+            filar_core::SshAuth::Password { password: Some(p) } => {
+                assert_eq!(p, "in-memory", "in-memory password must win over keyring");
+            }
+            other => panic!("expected Password auth, got {other:?}"),
+        }
+    }
 
     // ── Key resolution tests ────────────────────────────────────────────
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,5 +14,8 @@ pub mod session;
 pub use chat::ChatBlock;
 pub use config::{Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig, HostKeyPolicy};
 pub use error::{CoreError, Result};
-pub use secrets::{EnvSecretProvider, KeyringSecretProvider, SecretProvider, StaticSecretProvider, redact};
+pub use secrets::{
+    ssh_cred_name, ssh_target_display_name, EnvSecretProvider, KeyringSecretProvider,
+    SecretProvider, StaticSecretProvider, redact,
+};
 pub use session::{default_base_dir, ProfileUsage, Session, SessionMeta, SessionStore};

--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -237,6 +237,31 @@ pub fn api_key(env_var: &str) -> Result<String> {
 }
 
 // ---------------------------------------------------------------------------
+// SSH keyring key naming (GUI ↔ TUI contract)
+// ---------------------------------------------------------------------------
+
+/// Display / config name for an SSH launcher slot.
+///
+/// Empty `alias` → `SSH{slot+1}` (e.g. slot 0 → `"SSH1"`). Non-empty alias is
+/// returned as-is. Must stay in sync with the GUI launcher and TUI runner.
+pub fn ssh_target_display_name(slot: usize, alias: &str) -> String {
+    if alias.is_empty() {
+        format!("SSH{}", slot + 1)
+    } else {
+        alias.to_string()
+    }
+}
+
+/// OS credential-store username for an SSH launcher slot password.
+///
+/// Format: `ssh_target:{name}` where `name` is [`ssh_target_display_name`].
+/// Used by the GUI when saving, `main` on GUI→TUI handoff, and the TUI runner
+/// on reconnect (`format!("ssh_target:{}", target.name)`).
+pub fn ssh_cred_name(slot: usize, alias: &str) -> String {
+    format!("ssh_target:{}", ssh_target_display_name(slot, alias))
+}
+
+// ---------------------------------------------------------------------------
 // KeyringSecretProvider
 // ---------------------------------------------------------------------------
 
@@ -488,5 +513,27 @@ mod tests {
         let expected_prefix = redact(name);
         assert!(!msg.contains(name));
         assert!(msg.contains(&expected_prefix));
+    }
+
+    // ── SSH keyring naming (#290) ─────────────────────────────────────
+
+    #[test]
+    fn ssh_cred_name_empty_alias_uses_slot() {
+        assert_eq!(ssh_cred_name(0, ""), "ssh_target:SSH1");
+        assert_eq!(ssh_cred_name(4, ""), "ssh_target:SSH5");
+        assert_eq!(ssh_target_display_name(0, ""), "SSH1");
+    }
+
+    #[test]
+    fn ssh_cred_name_nonempty_alias_uses_alias() {
+        assert_eq!(ssh_cred_name(0, "VPS DE"), "ssh_target:VPS DE");
+        assert_eq!(ssh_cred_name(2, "prod-web"), "ssh_target:prod-web");
+        assert_eq!(ssh_target_display_name(2, "prod-web"), "prod-web");
+    }
+
+    #[test]
+    fn ssh_cred_name_special_chars_preserved() {
+        assert_eq!(ssh_cred_name(0, "my server!"), "ssh_target:my server!");
+        assert_eq!(ssh_cred_name(1, "сервер"), "ssh_target:сервер");
     }
 }

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -94,12 +94,7 @@ fn unique_profile_name(existing: &[LlmProfileData], prefix: &str) -> String {
 /// up the password under `format!("ssh_target:{}", target.name)`.
 /// Both functions use `SSH{slot+1}` as the fallback for empty alias.
 fn ssh_cred_name(slot: usize, alias: &str) -> String {
-    let name = if alias.is_empty() {
-        format!("SSH{}", slot + 1)
-    } else {
-        alias.to_string()
-    };
-    format!("ssh_target:{name}")
+    filar_core::ssh_cred_name(slot, alias)
 }
 
 /// Migration: fix duplicate profile names and key_env entries in a loaded list.
@@ -196,6 +191,11 @@ pub struct SshConnection {
     /// Not a secret — must be persisted so resume picks the correct keyring entry.
     #[serde(default)]
     pub slot: usize,
+    /// Optional alias for the slot (empty → `SSH{slot+1}`). Not a secret —
+    /// persisted so GUI→TUI handoff can rebuild the keyring key via
+    /// [`filar_core::ssh_cred_name`].
+    #[serde(default)]
+    pub alias: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -338,11 +338,7 @@ fn build_ssh_targets_from_profiles(profiles: &[SshProfile]) -> Vec<filar_core::S
     let mut targets: Vec<filar_core::SshTarget> = Vec::new();
     for (i, profile) in profiles.iter().enumerate() {
         if profile.host.is_empty() { continue; }
-        let name = if profile.alias.is_empty() {
-            format!("SSH{}", i + 1)
-        } else {
-            profile.alias.clone()
-        };
+        let name = filar_core::ssh_target_display_name(i, &profile.alias);
         if seen.contains(&name) { continue; }
         seen.insert(name.clone());
         let port: u16 = profile.port.parse().unwrap_or_else(|_| {
@@ -862,7 +858,14 @@ impl LauncherApp {
         let target = if self.target_mode == 0 { "local" } else { "ssh" };
         let ssh = if self.target_mode > 0 {
             let slot = &self.ssh_slots[self.target_mode - 1];
-            Some(SshConnection { host: slot.host.clone(), port: slot.port.parse().unwrap_or(22), user: slot.user.clone(), password: slot.password.clone(), slot: self.target_mode.saturating_sub(1) })
+            Some(SshConnection {
+                host: slot.host.clone(),
+                port: slot.port.parse().unwrap_or(22),
+                user: slot.user.clone(),
+                password: slot.password.clone(),
+                slot: self.target_mode.saturating_sub(1),
+                alias: slot.alias.clone(),
+            })
         } else { None };
 
         let settings = Settings {
@@ -1113,6 +1116,7 @@ mod tests {
                 user: "root".into(),
                 password: "supersecret".into(),
                 slot: 0,
+                alias: "prod".into(),
             }),
             model: "glm".into(),
             api_base_url: "https://api.example.com".into(),
@@ -1137,6 +1141,7 @@ mod tests {
         assert_eq!(loaded.model, "glm");
         assert!(loaded.ssh.is_some());
         assert_eq!(loaded.ssh.as_ref().unwrap().slot, 0);
+        assert_eq!(loaded.ssh.as_ref().unwrap().alias, "prod");
         // Secrets must be absent after deserialization (serde(skip) → default).
         assert!(loaded.api_key.is_empty());
         assert!(loaded.ssh.as_ref().unwrap().password.is_empty());
@@ -1150,6 +1155,7 @@ mod tests {
             user: "admin".into(),
             password: "p@ssw0rd".into(),
             slot: 2,
+            alias: String::new(),
         };
         let json = serde_json::to_string(&conn).unwrap();
         assert!(!json.contains("p@ssw0rd"));
@@ -1159,6 +1165,27 @@ mod tests {
         assert_eq!(loaded.host, "host");
         assert_eq!(loaded.slot, 2);
         assert!(loaded.password.is_empty());
+    }
+
+    #[test]
+    fn ssh_connection_alias_survives_round_trip() {
+        let conn = SshConnection {
+            host: "h".into(),
+            port: 22,
+            user: "u".into(),
+            password: "secret".into(),
+            slot: 1,
+            alias: "VPS DE".into(),
+        };
+        let json = serde_json::to_string(&conn).unwrap();
+        assert!(json.contains("VPS DE"));
+        assert!(!json.contains("secret"));
+        let loaded: SshConnection = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.alias, "VPS DE");
+        assert_eq!(
+            filar_core::ssh_cred_name(loaded.slot, &loaded.alias),
+            "ssh_target:VPS DE"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #290

## Summary
- Shared `filar_core::{ssh_cred_name, ssh_target_display_name}` — one naming contract for GUI, app handoff, and TUI.
- `SshConnection.alias` is persisted in `pending_launch.json` (non-secret) so the parent process can rebuild the keyring key after subprocess.
- `main::resolve_gui_ssh_target` reads `ssh_target:{alias|SSHn}` (never legacy `ssh{slot}`) and sets `SshTarget.name` to the same display name (no more `"gui-ssh"`).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (0 failed; 7 `#[ignore]` docker-sshd — not run)
- [ ] Manual smoke: Save password → Launch → SSH connect without re-entering password (Win / Mac)

## Out of scope
- Password entered in GUI **without** "Save password" still cannot cross the subprocess boundary (never written to keyring; skipped in JSON). Separate follow-up if needed.