### PR TITLE
feat(core): OS-appropriate data directory for Win + Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,23 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Desktop data directory now uses `dirs::data_dir()`:
+  Windows `%APPDATA%\filar\`, macOS `~/Library/Application Support/filar/`,
+  Linux `~/.local/share/filar/` (or `$XDG_DATA_HOME`). Legacy Unix
+  `$HOME/filar` is migrated once on startup when the new path is empty
+  ([#291](https://github.com/devlawey/filar/issues/291)).
+- Release CI now builds and attaches both Windows (`*-windows-x86_64.exe`)
+  and macOS (`*-macos-aarch64`) binaries to the same GitHub Release
+  ([#289](https://github.com/devlawey/filar/issues/289)).
+
 ### Fixed
 
 - GUI→TUI SSH password handoff now reads the OS keyring under
   `ssh_target:{alias|SSHn}` (same key the launcher writes), instead of the
   legacy `ssh{slot}` name that never matched
   ([#290](https://github.com/devlawey/filar/issues/290)).
-
-### Changed
-
-- Release CI now builds and attaches both Windows (`*-windows-x86_64.exe`)
-  and macOS (`*-macos-aarch64`) binaries to the same GitHub Release
-  ([#289](https://github.com/devlawey/filar/issues/289)).
 
 ## [0.9.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   `ssh_target:{alias|SSHn}` (same key the launcher writes), instead of the
   legacy `ssh{slot}` name that never matched
   ([#290](https://github.com/devlawey/filar/issues/290)).
+- Docs: log file path documented as `{app data}/filar/logs/filar.log`
+  (the `logs/` segment was missing in README)
+  ([#291](https://github.com/devlawey/filar/issues/291)).
 
 ## [0.9.0] - 2026-08-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1529,7 @@ dependencies = [
 name = "filar-core"
 version = "0.9.0"
 dependencies = [
+ "dirs",
  "keyring",
  "serde",
  "serde_json",
@@ -3092,6 +3114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,6 +3718,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ rfd = "0.15"
 # OS credential storage (Windows Credential Manager, macOS Keychain, Linux Secret Service)
 keyring = { version = "3", default-features = false, features = ["apple-native", "windows-native", "sync-secret-service"] }
 
+# Platform data directories (APPDATA / Application Support / XDG)
+dirs = "6"
+
 # Clipboard
 arboard = "3"
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4545,3 +4545,24 @@ smoke #294.
 **DoD smoke:** Save password → Launch → SSH без повторного ввода (Win/Mac) — вручную.
 
 **Дальше:** CodeRabbit / ревью.
+
+---
+
+## Issue #291: core — OS-appropriate data directory (Win + Mac)
+
+**Milestone:** Filar v1.0.0. **Ветка:** `feat/291-os-data-dir`.
+
+**Решение (option 2):** `dirs::data_dir()` как parent; app root = `{base}/filar/`.
+- Windows: `%APPDATA%\filar\` (без изменений)
+- macOS: `~/Library/Application Support/filar/`
+- Linux: `~/.local/share/filar/` (или `$XDG_DATA_HOME`)
+
+**Миграция:** на Unix, если есть legacy `$HOME/filar` и нет нового пути —
+`rename` один раз (best-effort + warn).
+
+**Документы:** PLATFORM_NOTES, README, USER_GUIDE, ENGINE_API.
+
+**Публичный API:** поведение `default_base_dir()` на macOS/Linux меняется
+(Windows тот же Roaming APPDATA).
+
+**Дальше:** CodeRabbit / ревью.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4558,7 +4558,13 @@ smoke #294.
 - Linux: `~/.local/share/filar/` (или `$XDG_DATA_HOME`)
 
 **Миграция:** на Unix, если есть legacy `$HOME/filar` и нет нового пути —
-`rename` один раз (best-effort + warn).
+`rename` один раз через `std::sync::Once` (best-effort + warn).
+
+**Review fixes:**
+- Уточнён контракт: `default_base_dir()` = OS parent (не `…/filar`); callers
+  join `"filar"` (как `SessionStore::new`).
+- Миграция — `Once`, не на каждый вызов.
+- Тест переименован под реальное поведение; docs log path `logs/` в CHANGELOG.
 
 **Документы:** PLATFORM_NOTES, README, USER_GUIDE, ENGINE_API.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ think about this — the GUI launcher handles everything automatically.
 #### 1. GUI Launcher settings (`settings.json`)
 
 Location: `%APPDATA%\filar\settings.json` (Windows),
-`~/.local/share/filar/settings.json` (Linux).
+`~/Library/Application Support/filar/settings.json` (macOS),
+`~/.local/share/filar/settings.json` (Linux; or `$XDG_DATA_HOME/filar/`).
 
 The launcher saves non-sensitive UI state here: SSH profiles (host, port,
 user, alias), model name, API base URL, temperature, extra body JSON, save
@@ -85,7 +86,8 @@ Launch.
 
 #### 2. Handoff file (`pending_launch.json`)
 
-Location: `%APPDATA%\filar\pending_launch.json`.
+Location: `{OS data dir}/filar/pending_launch.json` (same directory as
+`settings.json` — see above).
 
 A **transient** file written by the launcher on "Launch" and read+deleted by
 the TUI subprocess. It carries the launch-specific settings (model, API URL,
@@ -100,11 +102,11 @@ not exist — the TUI falls back to `config.toml`.
 Location (search order):
 1. `FILAR_CONFIG` env var (explicit path)
 2. `./config.toml` in the current working directory
-3. `%APPDATA%\filar\config.toml` (app-data dir — **the launcher writes here**)
+3. `{OS data dir}/filar/config.toml` (app-data dir — **the launcher writes here**)
 4. `config.toml` next to the executable
 
 **When is `config.toml` created?** The launcher writes the `[llm]` section
-(model, api_base_url, temperature, extra_body) to `%APPDATA%\filar\config.toml`
+(model, api_base_url, temperature, extra_body) to `{OS data dir}/filar/config.toml`
 on every Launch, as a fallback for CLI usage. It merges into the existing
 file — it does not overwrite `[[ssh_targets]]`, `[[llm_profiles]]`, or
 other sections you may have added manually.
@@ -114,7 +116,7 @@ other sections you may have added manually.
 - **CLI users** (`filar --target ...`): the TUI reads `config.toml` because
   there is no `pending_launch.json`. This is where you define SSH targets,
 LLM profiles, timeouts, and the default confirm mode.
-- **Power users**: edit `%APPDATA%\filar\config.toml` manually to add
+- **Power users**: edit `{OS data dir}/filar/config.toml` manually to add
   `[[llm_profiles]]`, tweak `[timeouts]`, or set `confirm_mode`. The
   launcher will preserve these sections on next Launch.
 
@@ -450,8 +452,9 @@ SSH integration tests require a Docker `sshd` container (skipped if Docker is no
 ## Logging
 
 Application logs are written to:
-- `%APPDATA%\filar\filar.log` (Windows)
-- `~/.local/share/filar/filar.log` (Linux)
+- `%APPDATA%\filar\logs\filar.log` (Windows)
+- `~/Library/Application Support/filar/logs/filar.log` (macOS)
+- `~/.local/share/filar/logs/filar.log` (Linux)
 
 For verbose logging:
 ```powershell

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -65,10 +65,15 @@ cargo build --release
 
 | Файл | Где | Кто пишет | Зачем |
 |------|-----|-----------|-------|
-| `settings.json` | `%APPDATA%\filar\` | GUI-лаунчер | Сохраняет состояние UI (SSH-профили, модель, URL, выбор) |
-| `pending_launch.json` | `%APPDATA%\filar\` | GUI-лаунчер → TUI | Транзитный: передаёт настройки запуска от GUI к TUI, удаляется после чтения |
-| `config.toml` | `%APPDATA%\filar\` | GUI-лаунчер (частично) + пользователь | Фолбэк для CLI-режима; полный набор настроек |
+| `settings.json` | `{OS data dir}/filar/` | GUI-лаунчер | Сохраняет состояние UI (SSH-профили, модель, URL, выбор) |
+| `pending_launch.json` | `{OS data dir}/filar/` | GUI-лаунчер → TUI | Транзитный: передаёт настройки запуска от GUI к TUI, удаляется после чтения |
+| `config.toml` | `{OS data dir}/filar/` | GUI-лаунчер (частично) + пользователь | Фолбэк для CLI-режима; полный набор настроек |
 | OS Credential Manager | Системное хранилище | GUI / TUI | API-ключи и SSH-пароли — **только здесь**, нигде в файлах |
+
+Пути `{OS data dir}/filar/`:
+- Windows: `%APPDATA%\filar\`
+- macOS: `~/Library/Application Support/filar/`
+- Linux: `~/.local/share/filar/` (или `$XDG_DATA_HOME/filar/`)
 
 **Поток при запуске через GUI:**
 1. Пользователь редактирует поля в лаунчере → сохраняются в `settings.json`
@@ -168,7 +173,7 @@ $env:SSH_PASSWORD = "пароль-ssh"    # SSH auth type = "password"
 Поиск в порядке приоритета:
 1. `FILAR_CONFIG` env (явный путь)
 2. `./config.toml` (текущая директория)
-3. `%APPDATA%\filar\config.toml` (сюда пишет лаунчер)
+3. `{OS data dir}/filar/config.toml` (сюда пишет лаунчер; см. §2.1)
 4. `config.toml` рядом с `.exe`
 
 Если ни одного файла нет — используются встроенные значения по умолчанию.
@@ -343,7 +348,8 @@ Explanation:         Updating package lists to check available versions
 ### 6.2. Хранилище
 
 - **Windows:** `%APPDATA%\filar\sessions\`
-- **Unix:** `~/.local/share/filar/sessions/`
+- **macOS:** `~/Library/Application Support/filar/sessions/`
+- **Linux:** `~/.local/share/filar/sessions/`
 
 Формат: JSON-файлы (`<id>.json`). Хранится не более **10 последних** сессий
 (старые удаляются автоматически).
@@ -372,7 +378,8 @@ filar.exe --target local --session 1718900000
 ### 7.1. Где лежит файл
 
 - **Windows:** `%APPDATA%\filar\logs\filar.log`
-- **Unix:** `~/.local/share/filar/logs/filar.log`
+- **macOS:** `~/Library/Application Support/filar/logs/filar.log`
+- **Linux:** `~/.local/share/filar/logs/filar.log`
 
 Файл ротируется посуточно (`filar.log.YYYY-MM-DD`). В нём — полная запись
 с временными метками, включая уровни ниже WARN.
@@ -455,7 +462,7 @@ filar
 
 ### "failed to load config"
 - Filar работает и без `config.toml` — используются значения по умолчанию
-- Для CLI-режима создайте `%APPDATA%\filar\config.toml` (см. раздел 2)
+- Для CLI-режима создайте `{OS data dir}/filar/config.toml` (см. раздел 2)
 - Или укажите путь: `$env:FILAR_CONFIG = "C:\path\to\config.toml"`
 
 ### "API key is required"
@@ -476,7 +483,7 @@ filar
 - Минимальный размер окна: ~80×24
 
 ### Сессии не сохраняются
-- Проверьте права на запись в `%APPDATA%\filar\sessions\`
+- Проверьте права на запись в `{OS data dir}/filar/sessions/`
 - Создайте директорию вручную при необходимости
 
 ---
@@ -515,5 +522,5 @@ filar
 - [ ] CLI: `--target local` — локальный executor
 - [ ] CLI: `--llm <profile>` — выбор LLM-профиля
 - [ ] SSH: подключение к тестовому серверу (если доступен)
-- [ ] Сессии: сохранение в `%APPDATA%\filar\sessions\`
+- [ ] Сессии: сохранение в `{OS data dir}/filar/sessions/`
 - [ ] Сессии: не более 10 файлов (prune работает)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,3 +12,4 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 zeroize = { workspace = true }
 keyring = "3"
+dirs = { workspace = true }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -342,7 +342,7 @@ impl Config {
     /// Search order:
     /// 1. `FILAR_CONFIG` environment variable (explicit path)
     /// 2. `config.toml` in the current working directory (override for development)
-    /// 3. `%APPDATA%\filar\config.toml` (shared system-wide config)
+    /// 3. `{OS data dir}/filar/config.toml` (shared system-wide config)
     /// 4. `config.toml` next to the executable
     ///
     /// Falls back to built-in defaults if no file is found anywhere.

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -638,20 +638,10 @@ mod tests {
     fn default_base_dir_returns_os_data_parent_without_creating_filar() {
         if let Ok(base) = default_base_dir() {
             assert!(base.exists(), "OS data dir parent should already exist");
-            if let Some(expected) = dirs::data_dir() {
-                assert_eq!(base, expected, "default_base_dir must use dirs::data_dir()");
-            }
-            // Contract: returns the parent; callers join "filar". This call must
-            // not create `{base}/filar` by itself (SessionStore::new does that).
-            let app_root = base.join("filar");
-            // We cannot assert !exists in general (user may already have data),
-            // but we can assert the returned path is NOT the app root.
-            assert_ne!(
-                base.file_name().and_then(|s| s.to_str()),
-                Some("filar"),
-                "default_base_dir must return the OS parent, not …/filar"
-            );
-            let _ = app_root; // documented join target for callers
+            // Contract: equals dirs::data_dir() (the OS parent). Callers join
+            // "filar"; SessionStore::new creates `{base}/filar/sessions`.
+            let expected = dirs::data_dir().expect("dirs::data_dir available in test env");
+            assert_eq!(base, expected, "default_base_dir must use dirs::data_dir()");
         }
     }
 

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,8 +1,9 @@
 ﻿//! Session persistence: save and restore chat histories.
 //!
-//! Sessions are stored as JSON files in a per-user directory:
+//! Sessions are stored as JSON files under the platform data directory:
 //! - Windows: `%APPDATA%/filar/sessions/<id>.json`
-//! - Unix:    `$HOME/.filar/sessions/<id>.json`
+//! - macOS:   `~/Library/Application Support/filar/sessions/<id>.json`
+//! - Linux:   `$XDG_DATA_HOME/filar/sessions/` or `~/.local/share/filar/sessions/`
 //!
 //! At most [`MAX_SESSIONS`] sessions are kept; older ones are pruned.
 
@@ -178,9 +179,9 @@ impl SessionStore {
 
     /// Create a store using the platform-default base directory.
     ///
-    /// On Windows this is `%APPDATA%`; on Unix it is `$HOME`.
-    /// For cross-compilation targets (Android, iOS) where these variables
-    /// may not be set, use [`new`](Self::new) with an explicit path.
+    /// See [`default_base_dir`]. For cross-compilation targets (Android, iOS)
+    /// where an OS data dir is unavailable, use [`new`](Self::new) with an
+    /// explicit path.
     pub fn with_default_dir() -> Result<Self> {
         Self::new(default_base_dir()?)
     }
@@ -272,23 +273,82 @@ impl SessionStore {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Determine the platform-default base directory for filar data.
+/// Determine the platform-default **parent** directory for filar data.
 ///
-/// Returns `%APPDATA%` on Windows, `$HOME` on Unix.
-/// The sessions directory is `base/filar/sessions`.
+/// Returns the OS user data directory (`dirs::data_dir`):
+/// - Windows → `%APPDATA%` (Roaming)
+/// - macOS → `~/Library/Application Support`
+/// - Linux → `$XDG_DATA_HOME` or `~/.local/share`
 ///
-/// This function does **not** create any directories — use it when you only
-/// need the base path (e.g. for `settings.json`, `pending_launch.json`).
-/// For session storage, use [`SessionStore::with_default_dir`] instead.
+/// App files live under `{base}/filar/` (`settings.json`, `pending_launch.json`,
+/// `config.toml`, `sessions/`, `logs/`). This function does **not** create
+/// directories — use it when you only need the base path. For session storage,
+/// use [`SessionStore::with_default_dir`].
+///
+/// On Unix, if a legacy `$HOME/filar` directory exists and the new
+/// `{data_dir}/filar` does not, it is renamed once (best-effort; failures are
+/// logged and ignored so startup still proceeds).
 pub fn default_base_dir() -> Result<PathBuf> {
-    if cfg!(windows) {
-        std::env::var("APPDATA")
-            .map(PathBuf::from)
-            .map_err(|_| CoreError::Other("APPDATA environment variable not set".into()))
-    } else {
-        std::env::var("HOME")
-            .map(PathBuf::from)
-            .map_err(|_| CoreError::Other("HOME environment variable not set".into()))
+    let base = dirs::data_dir().ok_or_else(|| {
+        CoreError::Other(
+            "could not determine OS data directory (dirs::data_dir returned None)".into(),
+        )
+    })?;
+
+    #[cfg(unix)]
+    try_migrate_legacy_home_filar(&base);
+
+    Ok(base)
+}
+
+/// Best-effort one-shot migration from legacy `$HOME/filar` to
+/// `{data_dir}/filar` (macOS Application Support / Linux XDG).
+///
+/// No-op when the legacy path is missing, the destination already exists, or
+/// `HOME` is unset. Exposed for unit tests.
+#[cfg(any(unix, test))]
+pub(crate) fn migrate_legacy_filar_dir(
+    legacy_filar: &std::path::Path,
+    new_filar: &std::path::Path,
+) -> std::io::Result<bool> {
+    if !legacy_filar.is_dir() || new_filar.exists() {
+        return Ok(false);
+    }
+    if let Some(parent) = new_filar.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::rename(legacy_filar, new_filar)?;
+    Ok(true)
+}
+
+#[cfg(unix)]
+fn try_migrate_legacy_home_filar(data_dir: &std::path::Path) {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return;
+    };
+    let legacy = home.join("filar");
+    let dest = data_dir.join("filar");
+    // Skip when legacy path is already the destination (e.g. unusual HOME).
+    if legacy == dest {
+        return;
+    }
+    match migrate_legacy_filar_dir(&legacy, &dest) {
+        Ok(true) => {
+            tracing::info!(
+                from = %legacy.display(),
+                to = %dest.display(),
+                "migrated legacy filar data directory"
+            );
+        }
+        Ok(false) => {}
+        Err(e) => {
+            tracing::warn!(
+                from = %legacy.display(),
+                to = %dest.display(),
+                error = %e,
+                "failed to migrate legacy filar data directory; continuing with new path"
+            );
+        }
     }
 }
 
@@ -550,10 +610,9 @@ mod tests {
 
     #[test]
     fn session_store_with_default_dir_resolves_platform_path() {
-        // with_default_dir() should succeed when APPDATA (Windows) or HOME (Unix)
-        // is set, and the resulting directory should be base/filar/sessions.
+        // with_default_dir() should succeed when the OS data dir is available,
+        // and the resulting directory should be base/filar/sessions.
         let store = SessionStore::with_default_dir();
-        // In CI / test environments the env var is usually set.
         if let Ok(s) = store {
             assert!(
                 s.dir().ends_with(std::path::Path::new("filar/sessions")),
@@ -562,18 +621,56 @@ mod tests {
             );
             assert!(s.dir().exists(), "directory should exist after creation");
         }
-        // If env var is not set, that's also acceptable in exotic environments.
     }
 
     #[test]
     fn default_base_dir_does_not_create_directories() {
-        // default_base_dir() should return a path but NOT create any directories.
-        // We can't easily verify "no directory created" in general, but we can
-        // check that the function returns a path that makes sense.
         if let Ok(base) = default_base_dir() {
-            // The base dir itself (APPDATA or HOME) should already exist.
+            // The OS data dir itself should already exist.
             assert!(base.exists(), "base directory should already exist");
+            // Must match dirs::data_dir() (Windows APPDATA / macOS Application Support / XDG).
+            if let Some(expected) = dirs::data_dir() {
+                assert_eq!(base, expected, "default_base_dir must use dirs::data_dir()");
+            }
         }
+    }
+
+    #[test]
+    fn migrate_legacy_filar_renames_when_dest_missing() {
+        let tmp = std::env::temp_dir().join(format!("filar_migrate_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let legacy = tmp.join("home").join("filar");
+        let dest = tmp.join("data").join("filar");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("settings.json"), "{}").unwrap();
+
+        let migrated = migrate_legacy_filar_dir(&legacy, &dest).unwrap();
+        assert!(migrated);
+        assert!(!legacy.exists());
+        assert!(dest.join("settings.json").exists());
+
+        // Second call is a no-op.
+        assert!(!migrate_legacy_filar_dir(&legacy, &dest).unwrap());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn migrate_legacy_filar_skips_when_dest_exists() {
+        let tmp = std::env::temp_dir().join(format!("filar_migrate_skip_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let legacy = tmp.join("home").join("filar");
+        let dest = tmp.join("data").join("filar");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(legacy.join("old.json"), "legacy").unwrap();
+        std::fs::write(dest.join("new.json"), "fresh").unwrap();
+
+        assert!(!migrate_legacy_filar_dir(&legacy, &dest).unwrap());
+        assert!(legacy.join("old.json").exists());
+        assert!(dest.join("new.json").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -275,19 +275,21 @@ impl SessionStore {
 
 /// Determine the platform-default **parent** directory for filar data.
 ///
-/// Returns the OS user data directory (`dirs::data_dir`):
+/// Returns the OS user data directory (`dirs::data_dir`) — **without** the
+/// `filar/` segment:
 /// - Windows → `%APPDATA%` (Roaming)
 /// - macOS → `~/Library/Application Support`
 /// - Linux → `$XDG_DATA_HOME` or `~/.local/share`
 ///
-/// App files live under `{base}/filar/` (`settings.json`, `pending_launch.json`,
-/// `config.toml`, `sessions/`, `logs/`). This function does **not** create
-/// directories — use it when you only need the base path. For session storage,
-/// use [`SessionStore::with_default_dir`].
+/// Callers join `"filar"` themselves (e.g. `base.join("filar").join("settings.json")`).
+/// [`SessionStore::new`] also joins `filar/sessions` onto this parent. Returning
+/// `base/filar` from this function would double the segment.
 ///
-/// On Unix, if a legacy `$HOME/filar` directory exists and the new
-/// `{data_dir}/filar` does not, it is renamed once (best-effort; failures are
-/// logged and ignored so startup still proceeds).
+/// This function does **not** create directories. For session storage, use
+/// [`SessionStore::with_default_dir`].
+///
+/// On Unix, a legacy `$HOME/filar` directory is migrated once (via [`std::sync::Once`])
+/// into `{data_dir}/filar` when the destination is missing (best-effort).
 pub fn default_base_dir() -> Result<PathBuf> {
     let base = dirs::data_dir().ok_or_else(|| {
         CoreError::Other(
@@ -305,7 +307,8 @@ pub fn default_base_dir() -> Result<PathBuf> {
 /// `{data_dir}/filar` (macOS Application Support / Linux XDG).
 ///
 /// No-op when the legacy path is missing, the destination already exists, or
-/// `HOME` is unset. Exposed for unit tests.
+/// `HOME` is unset. Available under `cfg(test)` on all platforms so unit tests
+/// can exercise the rename logic without a Unix host.
 #[cfg(any(unix, test))]
 pub(crate) fn migrate_legacy_filar_dir(
     legacy_filar: &std::path::Path,
@@ -314,6 +317,8 @@ pub(crate) fn migrate_legacy_filar_dir(
     if !legacy_filar.is_dir() || new_filar.exists() {
         return Ok(false);
     }
+    // Ensure the parent of `new_filar` exists; `rename` then moves the whole
+    // legacy directory into place (it does not require `new_filar` to exist).
     if let Some(parent) = new_filar.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -323,33 +328,39 @@ pub(crate) fn migrate_legacy_filar_dir(
 
 #[cfg(unix)]
 fn try_migrate_legacy_home_filar(data_dir: &std::path::Path) {
-    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
-        return;
-    };
-    let legacy = home.join("filar");
-    let dest = data_dir.join("filar");
-    // Skip when legacy path is already the destination (e.g. unusual HOME).
-    if legacy == dest {
-        return;
-    }
-    match migrate_legacy_filar_dir(&legacy, &dest) {
-        Ok(true) => {
-            tracing::info!(
-                from = %legacy.display(),
-                to = %dest.display(),
-                "migrated legacy filar data directory"
-            );
+    use std::sync::Once;
+    static MIGRATE_ONCE: Once = Once::new();
+    let data_dir = data_dir.to_path_buf();
+    MIGRATE_ONCE.call_once(move || {
+        let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+            return;
+        };
+        let legacy = home.join("filar");
+        let dest = data_dir.join("filar");
+        // Guard odd setups where HOME == data_dir (e.g. XDG_DATA_HOME=$HOME),
+        // which would make legacy and dest the same path.
+        if legacy == dest {
+            return;
         }
-        Ok(false) => {}
-        Err(e) => {
-            tracing::warn!(
-                from = %legacy.display(),
-                to = %dest.display(),
-                error = %e,
-                "failed to migrate legacy filar data directory; continuing with new path"
-            );
+        match migrate_legacy_filar_dir(&legacy, &dest) {
+            Ok(true) => {
+                tracing::info!(
+                    from = %legacy.display(),
+                    to = %dest.display(),
+                    "migrated legacy filar data directory"
+                );
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    from = %legacy.display(),
+                    to = %dest.display(),
+                    error = %e,
+                    "failed to migrate legacy filar data directory; continuing with new path"
+                );
+            }
         }
-    }
+    });
 }
 
 /// Generate a session ID and human-readable timestamp from the current time.
@@ -624,14 +635,23 @@ mod tests {
     }
 
     #[test]
-    fn default_base_dir_does_not_create_directories() {
+    fn default_base_dir_returns_os_data_parent_without_creating_filar() {
         if let Ok(base) = default_base_dir() {
-            // The OS data dir itself should already exist.
-            assert!(base.exists(), "base directory should already exist");
-            // Must match dirs::data_dir() (Windows APPDATA / macOS Application Support / XDG).
+            assert!(base.exists(), "OS data dir parent should already exist");
             if let Some(expected) = dirs::data_dir() {
                 assert_eq!(base, expected, "default_base_dir must use dirs::data_dir()");
             }
+            // Contract: returns the parent; callers join "filar". This call must
+            // not create `{base}/filar` by itself (SessionStore::new does that).
+            let app_root = base.join("filar");
+            // We cannot assert !exists in general (user may already have data),
+            // but we can assert the returned path is NOT the app root.
+            assert_ne!(
+                base.file_name().and_then(|s| s.to_str()),
+                Some("filar"),
+                "default_base_dir must return the OS parent, not …/filar"
+            );
+            let _ = app_root; // documented join target for callers
         }
     }
 

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -361,9 +361,8 @@ fn build_ssh_targets_from_profiles(profiles: &[SshProfile]) -> Vec<filar_core::S
     targets
 }
 
-/// Write `[llm]` and `[[ssh_targets]]` settings to `config.toml` in
-/// `%APPDATA%\filar\` so `filar-tui` invoked without the GUI launcher picks
-/// them up.
+/// Write `[llm]` settings to `{OS data dir}/filar/config.toml` so `filar`
+/// invoked without the GUI launcher still picks them up.
 ///
 /// If a `config.toml` already exists, the `[llm]` and `[[ssh_targets]]`
 /// sections are merged; unrelated sections are preserved.

--- a/docs/ENGINE_API.md
+++ b/docs/ENGINE_API.md
@@ -167,8 +167,8 @@ use filar_core::SessionStore;
 let store = SessionStore::new(std::path::PathBuf::from("/data/data/com.example.app"))?;
 ```
 
-For desktop platforms, use `SessionStore::with_default_dir()` which reads
-`APPDATA` (Windows) or `HOME` (Unix).
+For desktop platforms, use `SessionStore::with_default_dir()` which uses
+`dirs::data_dir()` (Windows `%APPDATA%`, macOS Application Support, Linux XDG).
 
 ## LLM request parameters
 

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -95,3 +95,20 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 > chmod +x filar-*-macos-aarch64 && xattr -d com.apple.quarantine filar-*-macos-aarch64
 > ```
 
+## Application data directory
+
+Decision for [#291](https://github.com/devlawey/filar/issues/291): use the OS
+user **data** directory via `dirs::data_dir()`, then `filar/` underneath.
+`settings.json`, `pending_launch.json`, `config.toml`, `sessions/`, and
+`logs/` all share this single base.
+
+| Platform | Base (`default_base_dir()`) | App root |
+|----------|------------------------------|----------|
+| Windows  | `%APPDATA%` (Roaming) | `%APPDATA%\filar\` |
+| macOS    | `~/Library/Application Support` | `~/Library/Application Support/filar/` |
+| Linux    | `$XDG_DATA_HOME` or `~/.local/share` | `~/.local/share/filar/` |
+
+> **Legacy Unix path:** before 1.0.0, non-Windows builds used `$HOME/filar/`.
+> On first run, if `$HOME/filar` exists and the new app root does not, filar
+> renames it into the new location (best-effort). Windows paths are unchanged.
+

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -98,9 +98,10 @@ Mapped via `ctrl_key(en, ru)` helper in `crates/tui/src/app.rs`.
 ## Application data directory
 
 Decision for [#291](https://github.com/devlawey/filar/issues/291): use the OS
-user **data** directory via `dirs::data_dir()`, then `filar/` underneath.
-`settings.json`, `pending_launch.json`, `config.toml`, `sessions/`, and
-`logs/` all share this single base.
+user **data** directory via `dirs::data_dir()` as the **parent** returned by
+`default_base_dir()`, then join `filar/` in callers (`SessionStore::new` does
+the same). `settings.json`, `pending_launch.json`, `config.toml`, `sessions/`,
+and `logs/` all share this single app root.
 
 | Platform | Base (`default_base_dir()`) | App root |
 |----------|------------------------------|----------|


### PR DESCRIPTION
Closes #291

## Summary
- **Decision (option 2):** `default_base_dir()` → `dirs::data_dir()`; app root remains `{base}/filar/` for `settings.json`, `pending_launch.json`, `config.toml`, `sessions/`, `logs/`.
- **Paths:** Windows `%APPDATA%\filar\` (unchanged); macOS `~/Library/Application Support/filar/`; Linux `~/.local/share/filar/` (or `$XDG_DATA_HOME`).
- **Migration:** one-shot rename `$HOME/filar` → new app root on Unix when dest missing (best-effort).
- Docs: `PLATFORM_NOTES`, README, USER_GUIDE, ENGINE_API; CHANGELOG upgrade note.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (0 failed; 7 `#[ignore]` — not run)
- [ ] Manual macOS: with legacy `~/filar`, confirm migrate into Application Support

## Out of scope
- Platform badge / broader dual-platform docs polish (#295)