### PR TITLE
fix(timeouts): raise default command timeout to 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Default command timeout is now 5 minutes (`[timeouts].command_secs = 300`).
+  The value is applied to SSH marker wait and local subprocess execution, so
+  long jobs such as `du`/`find` are no longer killed at 120s (SSH) or 60s
+  (local) under default settings
+  ([#308](https://github.com/devlawey/filar/issues/308)).
+
 ## [1.0.0] - 2026-08-17
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4695,3 +4695,27 @@ prepare-release dual (#296).
 **Открыто:** #80 code-sign / SmartScreen.
 
 **Теги:** `v1.0.0` + `engine-v1.0.0` (core/transport/agent менялись).
+
+---
+
+## Issue #308: fix(timeouts) — default command timeout 300s
+
+**Milestone:** 1.0.1. **Ветка:** `fix/308-command-timeout-300s`.
+
+**Проблема:** `[timeouts].command_secs` жил только в конфиге. SSH ждал маркер
+фиксированные **120s** (`recv_until_marker`); local subprocess — **60s**.
+`du`/`find` на больших деревьях падали с `timeout waiting for command marker`.
+
+**Решение:**
+- Дефолт `command_secs` = **300** (`DEFAULT_COMMAND_TIMEOUT_SECS`).
+- Значение пробрасывается в `SshTransportConfig.command_timeout` (маркер SSH)
+  и `LocalExecutor::with_timeout` (локальный subprocess).
+- Пользователь по-прежнему меняет `[timeouts].command_secs` в `config.toml`.
+- GUI таймаут не пробрасывает (поля нет) — только `config.toml`.
+- Confirm-gate / zero-install не трогались.
+
+**Публичный API:** новое поле `SshTransportConfig.command_timeout` (default
+300s) и `LocalExecutor::with_timeout`. Добавление поля — breaking для
+struct-literal без `..Default`; `Default` / `connect()` совместимы.
+
+**Дальше:** CodeRabbit / ревью.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4718,4 +4718,6 @@ prepare-release dual (#296).
 300s) и `LocalExecutor::with_timeout`. Добавление поля — breaking для
 struct-literal без `..Default`; `Default` / `connect()` совместимы.
 
+**Review:** command_secs = 0 отвергается в TimeoutConfig::validate (иначе маркер/subprocess сразу таймаутятся).
+
 **Дальше:** CodeRabbit / ревью.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ key_env = "DEEPSEEK_API_KEY"
 
 # ── Timeouts (seconds) ─────────────────────────────────────
 [timeouts]
-command_secs = 120   # single command execution
+command_secs = 300   # single command execution
 llm_secs = 60        # single LLM API call
 connect_secs = 15    # SSH connection establishment
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -131,7 +131,7 @@ key_env = "DEEPSEEK_API_KEY"
 
 # ── Таймауты (в секундах) ──────────────────────────────────
 [timeouts]
-command_secs = 120   # выполнение одной команды
+command_secs = 300   # выполнение одной команды
 llm_secs = 60        # один вызов LLM API
 connect_secs = 15    # установка SSH-соединения
 

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 max_tokens = 4096
 
 [timeouts]
-command_secs = 120
+command_secs = 300
 llm_secs = 60
 connect_secs = 15
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -17,7 +17,7 @@ use tracing_subscriber::EnvFilter;
 use filar_agent::OpenAiCompatClient;
 use filar_agent::LlmClient;
 use filar_core::{secrets, default_base_dir, ChatBlock, Config, CoreError, SecretProvider, SessionStore, StaticSecretProvider};
-use filar_transport::{LocalExecutor, SshExecutor};
+use filar_transport::{LocalExecutor, SshExecutor, SshTransportConfig};
 use filar_tui::TuiConfig;
 
 // ---------------------------------------------------------------------------
@@ -449,15 +449,21 @@ async fn run() -> anyhow::Result<()> {
     info!(model = %llm_config.model, "LLM client initialised");
 
     // ── Create executor (local or SSH) ─────────────────────────────────
+    let command_timeout = Duration::from_secs(config.timeouts.command_secs);
     let executor: Arc<dyn filar_transport::CommandExecutor> = if target_name == "local" {
         info!("initialising local command executor");
-        Arc::new(LocalExecutor::new().await.map_err(|e| {
+        Arc::new(LocalExecutor::with_timeout(command_timeout).await.map_err(|e| {
             warn!(error = %e, "failed to create local executor");
             anyhow::anyhow!(e)
         })?)
     } else if let Some(ref target) = ssh_target {
         info!(host = %target.host, port = target.port, user = %target.user, "connecting via SSH");
-        let ssh = SshExecutor::connect(target).await.map_err(|e| {
+        let ssh = SshExecutor::connect_with_config(
+            target,
+            SshTransportConfig::default().with_command_timeout(command_timeout),
+        )
+        .await
+        .map_err(|e| {
             warn!(error = %e, "SSH connection failed");
             anyhow::anyhow!(e)
         })?;
@@ -570,6 +576,7 @@ async fn run() -> anyhow::Result<()> {
         }),
         ssh_targets: launch_ssh_targets,
         save_dir: launch_save_dir,
+        command_timeout,
     };
 
     info!("launching TUI");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -293,6 +293,18 @@ fn default_connect_timeout() -> u64 {
     15
 }
 
+impl TimeoutConfig {
+    /// Reject values that would make every command fail immediately.
+    pub fn validate(&self) -> Result<()> {
+        if self.command_secs == 0 {
+            return Err(CoreError::Config(
+                "timeouts.command_secs must be greater than 0".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Confirmation mode
 // ---------------------------------------------------------------------------
@@ -340,6 +352,7 @@ impl Config {
         for p in &cfg.llm_profiles {
             LlmConfig::from(p).validate()?;
         }
+        cfg.timeouts.validate()?;
         Ok(cfg)
     }
 
@@ -484,6 +497,26 @@ api_base_url = "https://open.bigmodel.cn/api/paas/v4"
         )
         .unwrap();
         assert_eq!(cfg.timeouts.command_secs, 300);
+    }
+
+    #[test]
+    fn reject_zero_command_timeout() {
+        let cfg: Config = toml::from_str(
+            r#"
+[llm]
+model = "glm-5.1"
+api_base_url = "https://open.bigmodel.cn/api/paas/v4"
+
+[timeouts]
+command_secs = 0
+"#,
+        )
+        .unwrap();
+        let err = cfg.timeouts.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("command_secs"),
+            "error should mention command_secs: {err}"
+        );
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -253,6 +253,12 @@ impl From<&LlmProfile> for LlmConfig {
 // Timeouts
 // ---------------------------------------------------------------------------
 
+/// Default `[timeouts].command_secs` — 5 minutes.
+///
+/// Applied to SSH marker wait and local subprocess execution. Long jobs such as
+/// `du`/`find` on large trees need more than the previous 120s cap.
+pub const DEFAULT_COMMAND_TIMEOUT_SECS: u64 = 300;
+
 /// Timeout configuration (all values in seconds).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimeoutConfig {
@@ -278,7 +284,7 @@ impl Default for TimeoutConfig {
 }
 
 fn default_command_timeout() -> u64 {
-    120
+    DEFAULT_COMMAND_TIMEOUT_SECS
 }
 fn default_llm_timeout() -> u64 {
     60
@@ -461,6 +467,23 @@ user = "testuser"
         assert_eq!(cfg.ssh_targets.len(), 1);
         assert_eq!(cfg.ssh_targets[0].port, 2222);
         assert_eq!(cfg.confirm_mode, CommandConfirmMode::Allowlist);
+        assert_eq!(cfg.timeouts.command_secs, DEFAULT_COMMAND_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn default_command_timeout_is_five_minutes() {
+        assert_eq!(DEFAULT_COMMAND_TIMEOUT_SECS, 300);
+        assert_eq!(TimeoutConfig::default().command_secs, 300);
+        // Omitted `[timeouts]` still deserialises to the 300s default.
+        let cfg: Config = toml::from_str(
+            r#"
+[llm]
+model = "glm-5.1"
+api_base_url = "https://open.bigmodel.cn/api/paas/v4"
+"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.timeouts.command_secs, 300);
     }
 
     #[test]
@@ -474,7 +497,7 @@ api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 max_tokens = 8192
 
 [timeouts]
-command_secs = 300
+command_secs = 90
 llm_secs = 90
 connect_secs = 10
 
@@ -497,7 +520,7 @@ type = "agent"
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
         assert_eq!(cfg.llm.max_tokens, 8192);
-        assert_eq!(cfg.timeouts.command_secs, 300);
+        assert_eq!(cfg.timeouts.command_secs, 90);
         assert_eq!(cfg.confirm_mode, CommandConfirmMode::Allowlist);
         assert_eq!(cfg.ssh_targets.len(), 2);
         assert_eq!(cfg.ssh_target("staging").unwrap().host, "10.0.0.6");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -501,18 +501,26 @@ api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 
     #[test]
     fn reject_zero_command_timeout() {
-        let cfg: Config = toml::from_str(
-            r#"
+        let toml = r#"
 [llm]
 model = "glm-5.1"
 api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 
 [timeouts]
 command_secs = 0
-"#,
-        )
-        .unwrap();
-        let err = cfg.timeouts.validate().unwrap_err();
+"#;
+        let tmp = std::env::temp_dir().join(format!(
+            "filar_config_timeout_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::write(&tmp, toml).unwrap();
+        let result = Config::load(&tmp);
+        let _ = std::fs::remove_file(&tmp);
+        let err = result.expect_err("Config::load should reject command_secs = 0");
         assert!(
             err.to_string().contains("command_secs"),
             "error should mention command_secs: {err}"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,7 +12,10 @@ pub mod secrets;
 pub mod session;
 
 pub use chat::ChatBlock;
-pub use config::{Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig, HostKeyPolicy};
+pub use config::{
+    Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig,
+    HostKeyPolicy, DEFAULT_COMMAND_TIMEOUT_SECS,
+};
 pub use error::{CoreError, Result};
 pub use secrets::{
     ssh_cred_name, ssh_target_display_name, EnvSecretProvider, KeyringSecretProvider,

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -13,12 +13,12 @@ use std::time::{Duration, Instant};
 use tokio::sync::Notify;
 use tracing::info;
 
-use filar_core::{CoreError, Result};
+use filar_core::{CoreError, Result, DEFAULT_COMMAND_TIMEOUT_SECS};
 
 use crate::{CommandResult, StreamEvent};
 
-/// Default timeout for command execution (60 seconds).
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default timeout for command execution (5 minutes).
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS);
 
 // ---------------------------------------------------------------------------
 // LocalExecutor
@@ -28,15 +28,26 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 ///
 /// On Windows, uses PowerShell. On Unix, uses `sh`.
 /// Each command runs in a separate process — no persistent shell session.
-/// Commands have a 60-second timeout to prevent hanging on interactive prompts.
+/// Commands have a 5-minute timeout by default to prevent hanging on
+/// interactive prompts; override with [`LocalExecutor::with_timeout`].
 pub struct LocalExecutor {
     cancel_notify: Arc<Notify>,
+    timeout: Duration,
 }
 
 impl LocalExecutor {
-    /// Create a new local executor.
+    /// Create a new local executor with the default command timeout.
     pub async fn new() -> Result<Self> {
-        Self::with_shell(None).await
+        Self::with_timeout(DEFAULT_TIMEOUT).await
+    }
+
+    /// Create a local executor with an explicit command timeout.
+    pub async fn with_timeout(timeout: Duration) -> Result<Self> {
+        info!(timeout_secs = timeout.as_secs(), "local subprocess executor ready");
+        Ok(Self {
+            cancel_notify: Arc::new(Notify::new()),
+            timeout,
+        })
     }
 
     /// Create a local executor with a specific shell program.
@@ -44,10 +55,7 @@ impl LocalExecutor {
     /// The `shell` parameter is accepted for API compatibility but ignored —
     /// the shell is determined automatically by platform.
     pub async fn with_shell(_shell: Option<&str>) -> Result<Self> {
-        info!("local subprocess executor ready");
-        Ok(Self {
-            cancel_notify: Arc::new(Notify::new()),
-        })
+        Self::with_timeout(DEFAULT_TIMEOUT).await
     }
 }
 
@@ -87,10 +95,10 @@ impl crate::CommandExecutor for LocalExecutor {
             _ = self.cancel_notify.notified() => {
                 return Err(CoreError::Other("command cancelled by user".into()));
             }
-            _ = tokio::time::sleep(DEFAULT_TIMEOUT) => {
+            _ = tokio::time::sleep(self.timeout) => {
                 return Err(CoreError::Other(format!(
                     "command timed out after {} seconds",
-                    DEFAULT_TIMEOUT.as_secs()
+                    self.timeout.as_secs()
                 )));
             }
         };
@@ -152,6 +160,11 @@ fn build_shell_command(command: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_timeout_is_five_minutes() {
+        assert_eq!(DEFAULT_TIMEOUT, Duration::from_secs(300));
+    }
 
     #[test]
     fn build_shell_command_contains_user_command() {

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 
 use filar_core::{
     CoreError, EnvSecretProvider, HostKeyPolicy, Result, SecretProvider, SshAuth, SshTarget,
+    DEFAULT_COMMAND_TIMEOUT_SECS,
 };
 
 use crate::CommandResult;
@@ -61,6 +62,10 @@ pub struct SshTransportConfig {
     /// *before dispatch* triggers one silent reconnect and a single retry.
     /// A command that may already have executed is never auto-retried.
     pub auto_reconnect: bool,
+    /// How long to wait for a command's end-of-output marker before sending
+    /// Ctrl-C and failing with `timeout waiting for command marker`.
+    /// Default: [`DEFAULT_COMMAND_TIMEOUT_SECS`] (5 minutes).
+    pub command_timeout: Duration,
 }
 
 impl Default for SshTransportConfig {
@@ -69,7 +74,16 @@ impl Default for SshTransportConfig {
             keepalive_interval: Some(DEFAULT_KEEPALIVE_INTERVAL),
             keepalive_max: DEFAULT_KEEPALIVE_MAX,
             auto_reconnect: true,
+            command_timeout: Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
         }
+    }
+}
+
+impl SshTransportConfig {
+    /// Override the per-command marker-wait timeout.
+    pub fn with_command_timeout(mut self, timeout: Duration) -> Self {
+        self.command_timeout = timeout;
+        self
     }
 }
 
@@ -225,6 +239,8 @@ pub struct SshSession {
     /// on reconnect). The reader task reads this to decide whether a channel
     /// closure is expected (INFO) or unexpected (WARN).
     shutdown: Arc<AtomicBool>,
+    /// Per-command marker-wait timeout from [`SshTransportConfig`].
+    command_timeout: Duration,
 }
 
 impl SshSession {
@@ -379,6 +395,7 @@ impl SshSession {
             session: Mutex::new(session),
             req_counter: AtomicU64::new(0),
             shutdown,
+            command_timeout: cfg.command_timeout,
         })
     }
 
@@ -438,7 +455,7 @@ impl SshSession {
 
         // Read events until we find the marker — without holding any lock
         // that `cancel()` needs.
-        match recv_until_marker(&mut event_rx, &marker_tag, Duration::from_secs(120)).await {
+        match recv_until_marker(&mut event_rx, &marker_tag, self.command_timeout).await {
             Ok((stdout, stderr, exit_code)) => {
                 let duration = start.elapsed();
                 Ok(CommandResult {
@@ -1296,6 +1313,11 @@ mod tests {
         assert_eq!(cfg.keepalive_interval, Some(Duration::from_secs(20)));
         assert_eq!(cfg.keepalive_max, 3);
         assert!(cfg.auto_reconnect);
+        assert_eq!(
+            cfg.command_timeout,
+            Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS)
+        );
+        assert_eq!(cfg.command_timeout, Duration::from_secs(300));
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -20,7 +20,8 @@ use tracing::{error, info, warn};
 use filar_agent::{AgentBuilder, CommandConfirmer, LlmClient};
 use filar_core::{CommandConfirmMode, CoreError, Result, SecretProvider, StaticSecretProvider};
 use filar_transport::{
-    CommandExecutor, InteractiveTerminal, LocalInteractive, SecretSubstitutingExecutor, SshInteractive,
+    CommandExecutor, InteractiveTerminal, LocalInteractive, SecretSubstitutingExecutor,
+    SshExecutor, SshInteractive, SshTransportConfig,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -262,6 +263,14 @@ pub struct TuiConfig {
     pub log_rx: Option<mpsc::UnboundedReceiver<String>>,
     /// Directory where Ctrl+S session exports are written (`None` = CWD).
     pub save_dir: Option<std::path::PathBuf>,
+    /// Per-command execution timeout from `[timeouts].command_secs`.
+    /// Applied to SSH marker wait and local subprocess execution.
+    pub command_timeout: Duration,
+}
+
+/// SSH transport tunables with the app-configured command timeout.
+fn ssh_transport_config(command_timeout: Duration) -> SshTransportConfig {
+    SshTransportConfig::default().with_command_timeout(command_timeout)
 }
 
 /// Run the TUI with the given LLM client, executor, and configuration.
@@ -321,6 +330,7 @@ async fn run_app(
     mut config: TuiConfig,
     snapshot: SessionSnapshot,
 ) -> Result<()> {
+    let command_timeout = config.command_timeout;
     let profiles_for_restore = std::mem::take(&mut config.profiles);
     let default_for_restore = std::mem::take(&mut config.default_profile_name);
     let has_history = !config.initial_messages.is_empty()
@@ -838,7 +848,11 @@ async fn run_app(
                                 host_key_policy: filar_core::HostKeyPolicy::Tofu,
                             };
                             let new_ssh_info = format!("{user}@{host}:{port}");
-                            match filar_transport::SshExecutor::connect(&target).await {
+                            match SshExecutor::connect_with_config(
+                                &target,
+                                ssh_transport_config(command_timeout),
+                            )
+                            .await {
                                 Ok(ssh_exec) => {
                                     // A newer attempt superseded this one while
                                     // we were connecting — drop the result.
@@ -913,7 +927,11 @@ async fn run_app(
                         _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {}
                     }
                     let new_info = format!("{}@{}:{}", target.user, target.host, target.port);
-                    match filar_transport::SshExecutor::connect(&target).await {
+                    match SshExecutor::connect_with_config(
+                        &target,
+                        ssh_transport_config(command_timeout),
+                    )
+                    .await {
                         Ok(ssh_exec) => {
                             if let Some((ref exec, ref st)) = exec_entry {
                                 exec.swap_executor(Arc::new(ssh_exec) as Arc<dyn CommandExecutor>).await;
@@ -960,7 +978,10 @@ async fn run_app(
                 if let Some(idx) = selection {
                     if idx == 0 {
                         // Switch to local.
-                        let local_exec = match filar_transport::LocalExecutor::new().await {
+                        let local_exec = match filar_transport::LocalExecutor::with_timeout(
+                            command_timeout,
+                        )
+                        .await {
                             Ok(exec) => exec,
                             Err(e) => {
                                 let _ = tx.send(TuiEvent::Agent {
@@ -1003,7 +1024,11 @@ async fn run_app(
                             }
                         }
                         let new_info = format!("{}@{}:{}", target.user, target.host, target.port);
-                        match filar_transport::SshExecutor::connect(&target).await {
+                        match SshExecutor::connect_with_config(
+                            &target,
+                            ssh_transport_config(command_timeout),
+                        )
+                        .await {
                             Ok(ssh_exec) => {
                                 if let Some((ref exec, ref st)) = exec_entry {
                                     exec.swap_executor(Arc::new(ssh_exec) as Arc<dyn CommandExecutor>).await;
@@ -1053,7 +1078,7 @@ async fn run_app(
 
         // Create local executors for new tabs signalled via new_tab().
         for sid in app.take_pending_local_executors() {
-            match filar_transport::LocalExecutor::new().await {
+            match filar_transport::LocalExecutor::with_timeout(command_timeout).await {
                 Ok(local) => {
                     executors.insert(
                         sid,

--- a/docs/ENGINE_API.md
+++ b/docs/ENGINE_API.md
@@ -133,6 +133,13 @@ The transport itself **never reads environment variables** for the password. The
 reading `SSH_PASSWORD` from the environment, while external consumers whose env is
 not a secret source are not trapped by it.
 
+`SshTransportConfig::command_timeout` (default 300s,
+`filar_core::DEFAULT_COMMAND_TIMEOUT_SECS`) is how long `SshSession::run` waits
+for the command marker. Override with
+`SshTransportConfig::default().with_command_timeout(duration)`. Locally,
+`LocalExecutor::with_timeout` is the equivalent (`LocalExecutor::new` uses the
+same 300s default).
+
 ```rust,no_run
 use std::sync::Arc;
 use filar_core::{SshTarget, SshAuth, HostKeyPolicy, StaticSecretProvider};


### PR DESCRIPTION
Closes #308

## Summary
- Default `[timeouts].command_secs` is now **300** (`DEFAULT_COMMAND_TIMEOUT_SECS`).
- The value is actually applied: SSH marker wait (`SshTransportConfig.command_timeout`) and local subprocess (`LocalExecutor::with_timeout`). Previously SSH was hardcoded at 120s and local at 60s, so `du`/`find` died at 2 minutes regardless of config.
- Users can still raise/lower the value in `config.toml`. Sample config, README, and USER_GUIDE updated.
- GUI has no timeout field — override remains `config.toml` only.
- Confirm-gate and zero-install unchanged.

## Tests
- `cargo build --workspace` — green
- `cargo test --workspace` — green
- New unit tests: default = 300 (config omit + `TimeoutConfig::default` + SSH/local defaults); explicit TOML override still works (`command_secs = 90`)
- `#[ignore]` docker-sshd tests not run (no Docker here)

## Manual smoke (not run in this environment)
TUI/GUI cannot be driven here. After merge, confirm a long `du`/`find` on a large tree over SSH completes past 2 minutes with default settings, and that a lower `command_secs` in `config.toml` still cuts it short.

## Out of scope
- Agent-level `AgentBuilder::command_timeout` still defaults to `None` (transport timeout is the source of truth).
- GUI timeout control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased the default command execution timeout from 120 seconds to 5 minutes.
  - Applied the configurable timeout consistently to local and SSH command execution.
  - Added support for overriding the timeout through the existing configuration setting.
  - Preserved separate GUI configuration behavior.

- **Documentation**
  - Updated the README, user guide, changelog, and API documentation to reflect the new default and available configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->