### PR TITLE
fix(tui): drop ⌘ from F1 help overlay on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- F1 help overlay no longer uses `⌘` on Windows (console fonts render it as
+  `?`); macOS keeps Fn+F1 / Ctrl vs ⌘ wording
+  ([#310](https://github.com/devlawey/filar/issues/310)).
+
 ### Changed
 
 - Default command timeout is now 5 minutes (`[timeouts].command_secs = 300`).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4721,3 +4721,19 @@ struct-literal без `..Default`; `Default` / `connect()` совместимы.
 **Review:** command_secs = 0 отвергается в TimeoutConfig::validate (иначе маркер/subprocess сразу таймаутятся).
 
 **Дальше:** CodeRabbit / ревью.
+
+---
+
+## Issue #310: fix(tui) — F1 help overlay without ⌘ on Windows
+
+**Milestone:** 1.0.1. **Ветка:** `fix/310-f1-help-no-cmd-glyph`.
+
+**Проблема:** Windows console font не содержит `⌘` → в F1-оверлее «?».
+
+**Решение:** `overlay_desc_macos` в `help.rs` — на macOS прежний текст
+(Fn+F1 / Ctrl vs ⌘), на остальных — ASCII `Cmd`. PLATFORM_NOTES: секция
+TUI help overlay glyphs. Markdown-доки не трогали (не рендерятся в консоли).
+
+**Публичный API:** нет.
+
+**Дальше:** CodeRabbit / ревью.

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -31,6 +31,18 @@ pub(crate) struct HelpEntry {
     pub available: fn(AppMode) -> bool,
 }
 
+/// Overlay copy that must render in Windows console fonts.
+///
+/// Windows console fonts often lack `⌘` (it shows as `?`). Keep macOS-only
+/// glyphs out of the TUI on other platforms (#310).
+fn overlay_desc_macos(macos: &'static str, other: &'static str) -> &'static str {
+    if cfg!(target_os = "macos") {
+        macos
+    } else {
+        other
+    }
+}
+
 /// Return the full command registry — all entries, all modes.
 ///
 /// The bottom help bar filters this by mode; the overlay shows everything,
@@ -40,7 +52,10 @@ pub(crate) fn help_registry() -> Vec<HelpEntry> {
         // ── Help ──────────────────────────────────────────────────────
         HelpEntry {
             key: "F1",
-            desc: "Toggle this help overlay (macOS: often Fn+F1; Ctrl, not ⌘)",
+            desc: overlay_desc_macos(
+                "Toggle this help overlay (macOS: often Fn+F1; Ctrl, not ⌘)",
+                "Toggle this help overlay (Ctrl, not Cmd)",
+            ),
             section: "Help",
             available: |_| true,
         },
@@ -344,6 +359,40 @@ mod tests {
     fn registry_is_nonempty() {
         let r = help_registry();
         assert!(!r.is_empty(), "help registry must not be empty");
+    }
+
+    #[test]
+    fn f1_desc_avoids_command_glyph_off_macos() {
+        let f1 = help_registry()
+            .into_iter()
+            .find(|e| e.key == "F1")
+            .expect("F1 entry");
+        #[cfg(target_os = "macos")]
+        {
+            assert!(
+                f1.desc.contains("Fn+F1"),
+                "macOS F1 help should mention Fn+F1: {}",
+                f1.desc
+            );
+            assert!(
+                f1.desc.contains('⌘'),
+                "macOS F1 help should mention ⌘: {}",
+                f1.desc
+            );
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(
+                !f1.desc.contains('⌘'),
+                "non-macOS overlay must not use ⌘ (Windows console renders it as ?): {}",
+                f1.desc
+            );
+            assert!(
+                f1.desc.contains("Ctrl"),
+                "non-macOS F1 help should still mention Ctrl: {}",
+                f1.desc
+            );
+        }
     }
 
     #[test]

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -9,6 +9,7 @@ Add findings here whenever a platform difference is discovered.
 |--------|---------|--------|
 | App data dirs | [Application data directory](#application-data-directory) | #291 |
 | macOS Ctrl vs ⌘, Fn+F1 | [macOS shortcuts](#macos-shortcuts) | #292 |
+| Windows console missing `⌘` glyph | [TUI help overlay glyphs](#tui-help-overlay-glyphs) | #310 |
 | Interactive PTY shell | [Local interactive shell](#local-interactive-shell-ctrlt) | #293 |
 | Release assets / packaging | [Release binaries (CI)](#release-binaries-ci) | #289, #297, #80 |
 
@@ -71,6 +72,16 @@ is intentional for 1.0.0 (#292); remapping to ⌘ is out of scope.
 **Known limitation:** if the terminal swallows Ctrl+letter or F-keys before
 crossterm sees them, filar cannot receive the shortcut — that is a terminal
 configuration issue, not a silent failure inside filar.
+
+## TUI help overlay glyphs
+
+Windows console fonts (conhost / many raster and TrueType faces) do not include
+`⌘`. Ratatui then shows `?` in the F1 overlay (#310).
+
+The help registry therefore uses `overlay_desc_macos` in
+`crates/tui/src/ui/help.rs`: macOS keeps `⌘` / Fn+F1 wording; Windows and
+Linux use ASCII (`Cmd`). Markdown docs (`USER_GUIDE`, this file) may still
+use `⌘` because they are not rendered in the Windows console.
 
 ## Async blockers
 


### PR DESCRIPTION
Closes #310

## Summary
- F1 overlay used `⌘`, which Windows console fonts render as `?`.
- `overlay_desc_macos` in `help.rs`: macOS keeps `Fn+F1` / Ctrl vs `⌘`; Windows and Linux use ASCII `Cmd`.
- `docs/PLATFORM_NOTES.md` records the font/glyph split. Markdown USER_GUIDE still uses `⌘` (not rendered in the console).

## Tests
- `cargo build --workspace` — green
- `cargo test --workspace` — green (`f1_desc_avoids_command_glyph_off_macos` on Windows)
- `#[ignore]` docker-sshd tests not run

## Manual smoke (not run here)
Open TUI on Windows, press F1: F1 line must not show `?`. On macOS: still Fn+F1 / ⌘ wording.

## Out of scope
- Changing USER_GUIDE / PLATFORM_NOTES markdown glyphs (editor fonts have ⌘).
- Interactive mouse copy (#311).