### PR TITLE
fix(tui): copy on mouse drag-select in interactive terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- Interactive terminal (Ctrl+T): drag-select copies to the clipboard like
+  agent mode when the PTY has not requested mouse tracking. Apps that enable
+  SGR/legacy mouse still receive events; Ctrl+C is unchanged
+  ([#311](https://github.com/devlawey/filar/issues/311)).
 - F1 help overlay no longer uses `⌘` on Windows (console fonts render it as
   `?`); macOS keeps Fn+F1 / Ctrl vs ⌘ wording
   ([#310](https://github.com/devlawey/filar/issues/310)).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4737,3 +4737,22 @@ TUI help overlay glyphs. Markdown-доки не трогали (не ренде�
 **Публичный API:** нет.
 
 **Дальше:** CodeRabbit / ревью.
+
+---
+
+## Issue #311: fix(tui) — mouse drag-select copy in interactive mode
+
+**Milestone:** 1.0.1. **Ветка:** `fix/311-interactive-mouse-copy`.
+
+**Проблема:** В Ctrl+T drag-select не копировал (только wheel/scrollbar / SGR
+в PTY).
+
+**Решение:** Если приложение не запросило mouse tracking — filar drag-select
+по сетке `TerminalModel`, copy on release (как в agent). Если mouse mode
+включён (vim/less) — события по-прежнему в PTY, своей селекции нет.
+Ctrl+C не трогали. Help: `drag` доступен и в Interactive.
+
+**Публичный API:** `TerminalModel::visible_line_text`,
+`render_with_selection`.
+
+**Дальше:** CodeRabbit / ревью.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -2258,11 +2258,10 @@ impl App {
 
     /// Handle a mouse event in Interactive terminal mode.
     ///
-    /// If the terminal application has requested mouse events (SGR mode),
-    /// all mouse events are encoded as SGR sequences and forwarded to the
-    /// terminal input.  Otherwise, the scroll wheel either scrolls the
-    /// scrollback history (primary screen) or translates to arrow keys
-    /// (alternate screen, e.g. `less`, `man`).
+    /// If the terminal application has requested mouse events (SGR/legacy mode),
+    /// all mouse events are encoded and forwarded to the PTY. Otherwise filar
+    /// owns the mouse: scroll wheel (scrollback or arrow keys on the alt
+    /// screen) and drag-select copy, without sending bytes to the remote.
     fn handle_interactive_mouse(&mut self, m: crossterm::event::MouseEvent) {
         use crossterm::event::MouseEventKind;
 
@@ -2322,7 +2321,10 @@ impl App {
         let alt_screen = self.terminal.as_ref().is_some_and(|t| t.is_alt_screen());
 
         if mouse_mode {
-            // Forward mouse events to the terminal.
+            // Forward mouse events to the terminal (vim/less/etc. requested them).
+            // Filar drag-select is disabled in this path so PTY apps keep the mouse.
+            self.selection = None;
+            self.mouse_drag = None;
             if sgr_mouse {
                 // SGR encoding: \x1b[<{button};{x};{y}M/m
                 if let Some(seq) = encode_sgr_mouse(&m, x, y) {
@@ -2338,7 +2340,10 @@ impl App {
             return;
         }
 
-        // No mouse mode — handle scroll wheel only.
+        // No mouse mode — filar owns the mouse: scroll wheel + drag-select copy.
+        use crossterm::event::MouseButton;
+        let vis_col = (m.column - area.x) as usize;
+        let vis_row = (m.row - area.y) as usize;
         match m.kind {
             MouseEventKind::ScrollUp => {
                 if alt_screen {
@@ -2356,6 +2361,33 @@ impl App {
                 } else if let Some(t) = self.terminal.as_mut() {
                     t.scroll_display(-3);
                 }
+            }
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.selection = Some(Selection {
+                    anchor_line: vis_row,
+                    anchor_col: vis_col,
+                    head_line: vis_row,
+                    head_col: vis_col,
+                });
+                self.mouse_drag = Some(DragKind::Selection);
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if self.mouse_drag == Some(DragKind::Selection) {
+                    if let Some(sel) = &mut self.selection {
+                        sel.head_line = vis_row;
+                        sel.head_col = vis_col;
+                    }
+                }
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if self.mouse_drag == Some(DragKind::Selection) {
+                    if self.selection.as_ref().is_some_and(|s| s.is_empty()) {
+                        self.selection = None;
+                    } else {
+                        self.copy_selection_to_clipboard();
+                    }
+                }
+                self.mouse_drag = None;
             }
             _ => {}
         }
@@ -2664,11 +2696,14 @@ impl App {
             .unwrap_or_default()
     }
 
-    /// Extract the selected text from `layout_cache.lines`.
+    /// Extract the selected text from the chat layout or the interactive grid.
     ///
     /// For the start and end lines, only the portion within the selection
     /// column range is included.  Middle lines are included in full.
     fn selected_text(&self) -> Option<String> {
+        if self.mode == AppMode::Interactive {
+            return self.term_selected_text();
+        }
         let sel = self.selection.as_ref()?;
         if sel.is_empty() {
             return None;
@@ -2692,6 +2727,37 @@ impl App {
                 result.push_str(&text);
             }
             if line_idx < end_line {
+                result.push('\n');
+            }
+        }
+        if result.is_empty() { None } else { Some(result) }
+    }
+
+    /// Extract selected text from the interactive terminal grid.
+    fn term_selected_text(&self) -> Option<String> {
+        let sel = self.selection.as_ref()?;
+        if sel.is_empty() {
+            return None;
+        }
+        let term = self.terminal.as_ref()?;
+        let ((start_line, start_col), (end_line, end_col)) = sel.normalised();
+        let mut result = String::new();
+        for row in start_line..=end_line {
+            let text = term.visible_line_text(row);
+            if row == start_line && row == end_line {
+                let s = start_col.min(text.chars().count());
+                let e = end_col.min(text.chars().count());
+                result.push_str(&text.chars().skip(s).take(e.saturating_sub(s)).collect::<String>());
+            } else if row == start_line {
+                let s = start_col.min(text.chars().count());
+                result.push_str(&text.chars().skip(s).collect::<String>());
+            } else if row == end_line {
+                let e = end_col.min(text.chars().count());
+                result.push_str(&text.chars().take(e).collect::<String>());
+            } else {
+                result.push_str(&text);
+            }
+            if row < end_line {
                 result.push('\n');
             }
         }
@@ -3071,6 +3137,8 @@ impl App {
     pub fn hide_interactive_view(&mut self) {
         if self.mode == AppMode::Interactive {
             self.mode = AppMode::Normal;
+            self.selection = None;
+            self.mouse_drag = None;
         }
     }
 
@@ -3078,6 +3146,8 @@ impl App {
     pub fn show_interactive_view(&mut self) {
         if self.terminal.is_some() {
             self.mode = AppMode::Interactive;
+            self.selection = None;
+            self.mouse_drag = None;
         }
     }
 
@@ -5328,6 +5398,67 @@ mod tests {
         let input = app.take_term_input().unwrap();
         // x=16, y=6.
         assert_eq!(input, b"\x1b[<64;16;6M");
+    }
+
+    #[test]
+    fn interactive_drag_select_sets_selection_without_pty_bytes() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"hello world\r\n");
+        }
+        // Down at vis (10, 3) → screen col=10, row=5 (area.y=2).
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        assert!(app.pending_term_input.is_none(), "select must not write to PTY");
+        assert_eq!(app.mouse_drag, Some(DragKind::Selection));
+        let sel = app.selection.expect("selection started");
+        assert_eq!(sel.anchor_line, 3);
+        assert_eq!(sel.anchor_col, 10);
+
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left),
+            column: 15,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        let sel = app.selection.expect("selection after drag");
+        assert_eq!(sel.head_col, 15);
+        assert!(app.pending_term_input.is_none());
+    }
+
+    #[test]
+    fn interactive_drag_select_extracts_grid_text() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"hello world\r\n");
+        }
+        app.selection = Some(Selection {
+            anchor_line: 0,
+            anchor_col: 0,
+            head_line: 0,
+            head_col: 5,
+        });
+        assert_eq!(app.selected_text().as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn interactive_sgr_mouse_does_not_start_filar_selection() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed(b"\x1b[?1006h\x1b[?1002h");
+        }
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        });
+        assert!(app.selection.is_none());
+        assert!(app.take_term_input().is_some());
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -2342,8 +2342,8 @@ impl App {
 
         // No mouse mode — filar owns the mouse: scroll wheel + drag-select copy.
         use crossterm::event::MouseButton;
-        let vis_col = (m.column - area.x) as usize;
-        let vis_row = (m.row - area.y) as usize;
+        let vis_col = m.column.saturating_sub(area.x) as usize;
+        let vis_row = m.row.saturating_sub(area.y) as usize;
         match m.kind {
             MouseEventKind::ScrollUp => {
                 if alt_screen {
@@ -2743,20 +2743,16 @@ impl App {
         let ((start_line, start_col), (end_line, end_col)) = sel.normalised();
         let mut result = String::new();
         for row in start_line..=end_line {
-            let text = term.visible_line_text(row);
-            if row == start_line && row == end_line {
-                let s = start_col.min(text.chars().count());
-                let e = end_col.min(text.chars().count());
-                result.push_str(&text.chars().skip(s).take(e.saturating_sub(s)).collect::<String>());
+            let (sc, ec) = if row == start_line && row == end_line {
+                (start_col, end_col)
             } else if row == start_line {
-                let s = start_col.min(text.chars().count());
-                result.push_str(&text.chars().skip(s).collect::<String>());
+                (start_col, usize::MAX)
             } else if row == end_line {
-                let e = end_col.min(text.chars().count());
-                result.push_str(&text.chars().take(e).collect::<String>());
+                (0, end_col)
             } else {
-                result.push_str(&text);
-            }
+                (0, usize::MAX)
+            };
+            result.push_str(&term.visible_range_text(row, sc, ec));
             if row < end_line {
                 result.push('\n');
             }
@@ -5443,6 +5439,21 @@ mod tests {
             head_col: 5,
         });
         assert_eq!(app.selected_text().as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn interactive_drag_select_wide_glyph_uses_grid_columns() {
+        let mut app = make_interactive_app();
+        if let Some(t) = app.terminal.as_mut() {
+            t.feed("界abc\r\n".as_bytes());
+        }
+        app.selection = Some(Selection {
+            anchor_line: 0,
+            anchor_col: 2,
+            head_line: 0,
+            head_col: 4,
+        });
+        assert_eq!(app.selected_text().as_deref(), Some("ab"));
     }
 
     #[test]

--- a/crates/tui/src/terminal.rs
+++ b/crates/tui/src/terminal.rs
@@ -166,14 +166,28 @@ impl TerminalModel {
 
     /// Characters on a visible row (display_offset applied), trailing spaces trimmed.
     pub fn visible_line_text(&self, vis_row: usize) -> String {
+        self.visible_range_text(vis_row, 0, usize::MAX)
+    }
+
+    /// Text on a visible row for grid columns `[start_col, end_col)`.
+    ///
+    /// Indices are **screen columns**, not UTF-8/char indexes, so a wide glyph
+    /// (CJK/emoji + `WIDE_CHAR_SPACER`) does not shift later Latin letters.
+    pub fn visible_range_text(&self, vis_row: usize, start_col: usize, end_col: usize) -> String {
         let grid = self.term.grid();
         if vis_row >= grid.screen_lines() {
             return String::new();
         }
         let offset = grid.display_offset() as i32;
         let grid_row = &grid[Line(vis_row as i32 - offset)];
+        let cols = grid.columns();
+        let start = start_col.min(cols);
+        let end = end_col.min(cols);
+        if start >= end {
+            return String::new();
+        }
         let mut s = String::new();
-        for col in 0..grid.columns() {
+        for col in start..end {
             let cell = &grid_row[Column(col)];
             if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                 continue;
@@ -622,6 +636,16 @@ mod tests {
         model.feed(b"hello");
         let pos = model.cursor_position();
         assert_eq!(pos, Some((5, 0)));
+    }
+
+    #[test]
+    fn visible_range_text_uses_grid_columns_not_char_indexes() {
+        // `界` occupies two columns (glyph + WIDE_CHAR_SPACER); `abc` follows.
+        // Screen columns 2..4 must be `ab`, not `bc`.
+        let mut model = TerminalModel::new(20, 4);
+        model.feed("界abc\r\n".as_bytes());
+        assert_eq!(model.visible_line_text(0), "界abc");
+        assert_eq!(model.visible_range_text(0, 2, 4), "ab");
     }
 
     #[test]

--- a/crates/tui/src/terminal.rs
+++ b/crates/tui/src/terminal.rs
@@ -164,12 +164,45 @@ impl TerminalModel {
         self.term.grid().total_lines()
     }
 
+    /// Characters on a visible row (display_offset applied), trailing spaces trimmed.
+    pub fn visible_line_text(&self, vis_row: usize) -> String {
+        let grid = self.term.grid();
+        if vis_row >= grid.screen_lines() {
+            return String::new();
+        }
+        let offset = grid.display_offset() as i32;
+        let grid_row = &grid[Line(vis_row as i32 - offset)];
+        let mut s = String::new();
+        for col in 0..grid.columns() {
+            let cell = &grid_row[Column(col)];
+            if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                continue;
+            }
+            s.push(cell.c);
+        }
+        s.trim_end().to_string()
+    }
+
     /// Render the terminal grid to a ratatui frame.
     ///
     /// Each cell is rendered as a character with its foreground/background
     /// colors and text attributes (bold, italic, underline, etc.). The cursor
     /// cell is rendered with inverted colors when visible.
     pub fn render(&self, frame: &mut Frame, area: Rect) {
+        self.render_with_selection(frame, area, None, Color::DarkGray);
+    }
+
+    /// Like [`render`](Self::render), with an optional drag-select highlight.
+    ///
+    /// `selection` is a normalised `((start_row, start_col), (end_row, end_col))`
+    /// in visible-grid coordinates (0-based, display_offset already applied).
+    pub fn render_with_selection(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        selection: Option<((usize, usize), (usize, usize))>,
+        selection_bg: Color,
+    ) {
         let grid = self.term.grid();
         let num_cols = grid.columns();
         let num_lines = grid.screen_lines();
@@ -210,7 +243,10 @@ impl TerminalModel {
                 // Determine if this is the cursor cell.
                 let is_cursor = cursor.is_some_and(|(c, r)| c as usize == col && r as usize == row);
 
-                let (fg, bg) = cell_colors(cell, is_cursor);
+                let (fg, mut bg) = cell_colors(cell, is_cursor);
+                if selection.is_some_and(|range| visible_cell_selected(range, row, col)) {
+                    bg = selection_bg;
+                }
                 let style = build_style(cell.flags, fg, bg);
 
                 // If style changed, flush the current span.
@@ -251,6 +287,28 @@ impl TerminalModel {
             }
         }
     }
+}
+
+/// Whether `(row, col)` sits inside a normalised visible-grid selection.
+fn visible_cell_selected(
+    range: ((usize, usize), (usize, usize)),
+    row: usize,
+    col: usize,
+) -> bool {
+    let ((sr, sc), (er, ec)) = range;
+    if row < sr || row > er {
+        return false;
+    }
+    if sr == er {
+        return col >= sc && col < ec;
+    }
+    if row == sr {
+        return col >= sc;
+    }
+    if row == er {
+        return col < ec;
+    }
+    true
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -195,7 +195,7 @@ pub(crate) fn help_registry() -> Vec<HelpEntry> {
             key: "drag",
             desc: "Select text (copies on release)",
             section: "Copy",
-            available: |m| m != AppMode::Interactive,
+            available: |m| m != AppMode::PasswordInput,
         },
         // ── Input ─────────────────────────────────────────────────────
         HelpEntry {
@@ -447,6 +447,7 @@ mod tests {
         assert!(always_available.contains(&"^T")); // toggles out of interactive
         assert!(always_available.contains(&"wheel"));
         assert!(always_available.contains(&"^Q"));
+        assert!(always_available.contains(&"drag"));
         // Tabs/agent/input entries should be dimmed.
         assert!(!always_available.contains(&"^N"));
         assert!(!always_available.contains(&"Enter"));

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -193,7 +193,7 @@ pub(crate) fn help_registry() -> Vec<HelpEntry> {
         // ── Copy ──────────────────────────────────────────────────────
         HelpEntry {
             key: "drag",
-            desc: "Select text (copies on release)",
+            desc: "Select text, copies on release (not if the app captured the mouse)",
             section: "Copy",
             available: |m| m != AppMode::PasswordInput,
         },

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -163,7 +163,12 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
 
     // Render the terminal model grid.
     if let Some(ref term) = app.terminal {
-        term.render(f, chunks[2]);
+        term.render_with_selection(
+            f,
+            chunks[2],
+            app.selection.filter(|s| !s.is_empty()).map(|s| s.normalised()),
+            app.theme.selection_bg,
+        );
 
         // Scrollbar for scrollback — shown on the right edge of the
         // terminal area when there's history to scroll through.


### PR DESCRIPTION
Closes #311

## Summary
- In Ctrl+T interactive mode, drag-select now copies to the system clipboard (same copy-on-release as agent/chat).
- When the PTY app has **not** requested mouse tracking, filar owns the mouse: selection on the `TerminalModel` grid, highlight, copy. Scroll wheel and scrollbar are unchanged.
- When the app **has** requested SGR/legacy mouse (vim, less, …), events still go to the PTY; filar does not steal the drag.
- Ctrl+C / other keys still go to the remote. Help overlay lists drag-select in Interactive.

## Tests
- `cargo build --workspace` — green
- `cargo test -p filar-tui --lib` — 333 passed (new: `interactive_drag_select_*`, SGR still does not start filar selection)
- `#[ignore]` docker-sshd not run

## Manual smoke (not run here)
Windows + macOS: Ctrl+T, drag over shell output, release → clipboard has the text. In `vim` with mouse, drag still moves vim cursor / selects in vim, not filar. Ctrl+C still interrupts the remote.

## Out of scope
- Shift+click to force filar-select while an app has mouse mode.
- Double/triple-click word/line in interactive.