### PR TITLE
feat(tui): show SSH alias, host and pwd in the status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,20 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
 - SSH status bar shows **alias** (or host-only when there is no alias),
   **host**, and last-known **pwd**. Local tabs still show `local` plus the
   process cwd. Interactive OSC 7 updates pwd; agent↔PTY sync is #313
   ([#309](https://github.com/devlawey/filar/issues/309)).
+- Default command timeout is now 5 minutes (`[timeouts].command_secs = 300`).
+  The value is applied to SSH marker wait and local subprocess execution, so
+  long jobs such as `du`/`find` are no longer killed at 120s (SSH) or 60s
+  (local) under default settings
+  ([#308](https://github.com/devlawey/filar/issues/308)).
+
+### Fixed
+
 - GUI launcher: paste into API key / SSH password no longer keeps a trailing
   newline (or the space egui 0.29 substituted for it). Show-password /
   show-API-key toggles were added
@@ -28,14 +36,6 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - F1 help overlay no longer uses `⌘` on Windows (console fonts render it as
   `?`); macOS keeps Fn+F1 / Ctrl vs ⌘ wording
   ([#310](https://github.com/devlawey/filar/issues/310)).
-
-### Changed
-
-- Default command timeout is now 5 minutes (`[timeouts].command_secs = 300`).
-  The value is applied to SSH marker wait and local subprocess execution, so
-  long jobs such as `du`/`find` are no longer killed at 120s (SSH) or 60s
-  (local) under default settings
-  ([#308](https://github.com/devlawey/filar/issues/308)).
 
 ## [1.0.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- SSH status bar shows **alias** (or host-only when there is no alias),
+  **host**, and last-known **pwd**. Local tabs still show `local` plus the
+  process cwd. Interactive OSC 7 updates pwd; agent↔PTY sync is #313
+  ([#309](https://github.com/devlawey/filar/issues/309)).
 - GUI launcher: paste into API key / SSH password no longer keeps a trailing
   newline (or the space egui 0.29 substituted for it). Show-password /
   show-API-key toggles were added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4782,16 +4782,19 @@ NSPasteboard; egui 0.29 `TextEdit::singleline` заменяет `\n`/`\r` на �
 
 ## Issue #309: feat(tui) — SSH status bar alias + host + pwd
 
-**Milestone:** 1.0.1. **Ветка:** `feat/309-ssh-status-alias-host-pwd`.
+**Milestone:** 1.0.1. **Ветка:** `feat/309-ssh-status-alias-host-pwd`. **PR:** #318.
 
 **Проблема:** в статус-баре при SSH был только `target_name`, без host и pwd.
 
 **Решение:**
 - `Session::status_target()`: SSH `alias host pwd`, local `name pwd`.
 - Нет alias → только host + pwd (если `target_name` = raw `user@host`).
-- `Session.cwd`: local — process cwd; SSH — `pwd` после connect; interactive — OSC 7.
+- `Session.cwd`: local — process cwd; SSH — OSC 7 из interactive PTY. Автоматический `pwd` после connect убран: это обход confirm-гейта (AGENTS.md).
 - Синхронизация cwd агент↔PTY — **#313** (здесь только отображение).
 
 **Публичный API:** `Session::status_target`, `TuiEvent::CwdChanged`. Breaking для exhaustiveness match `TuiEvent`.
 
-**Дальше:** CodeRabbit / ревью.
+**Review (#318):**
+- Убран `spawn_remote_cwd_probe` (`exec.run("pwd")` без approve).
+- `CwdChanged` пишет в сессию по `session_id` явно; тест на фоновую вкладку.
+- CHANGELOG: запись #309 в `### Changed`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4779,3 +4779,19 @@ NSPasteboard; egui 0.29 `TextEdit::singleline` заменяет `\n`/`\r` на �
 **Дальше:** CodeRabbit / ревью.
 
 **Review:** убран `.trim()` (пробелы в SSH-пароле валидны; newline/BOM/ZWSP остаются). Show-чекбокс рисуется до поля, чтобы маска менялась в том же кадре.
+
+## Issue #309: feat(tui) — SSH status bar alias + host + pwd
+
+**Milestone:** 1.0.1. **Ветка:** `feat/309-ssh-status-alias-host-pwd`.
+
+**Проблема:** в статус-баре при SSH был только `target_name`, без host и pwd.
+
+**Решение:**
+- `Session::status_target()`: SSH `alias host pwd`, local `name pwd`.
+- Нет alias → только host + pwd (если `target_name` = raw `user@host`).
+- `Session.cwd`: local — process cwd; SSH — `pwd` после connect; interactive — OSC 7.
+- Синхронизация cwd агент↔PTY — **#313** (здесь только отображение).
+
+**Публичный API:** `Session::status_target`, `TuiEvent::CwdChanged`. Breaking для exhaustiveness match `TuiEvent`.
+
+**Дальше:** CodeRabbit / ревью.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -361,6 +361,10 @@ pub struct Session {
     /// SSH connection info for this tab (e.g. "user@host:port"). None = local.
     /// Set when `!ssh` succeeds for this tab. Used for display and system prompt.
     pub ssh_info: Option<String>,
+    /// Last known working directory for the status bar (`None` = unknown).
+    /// Local tabs start from the process cwd; SSH is filled after `pwd` / OSC 7.
+    /// Agent↔interactive sync of this value is #313.
+    pub cwd: Option<String>,
     /// LLM profile selected via Ctrl+L. None = use App default.
     pub llm_profile: Option<String>,
     /// Cumulative input tokens consumed by this session.
@@ -664,6 +668,7 @@ impl Session {
             has_new: false,
             awaiting_confirmation: false,
             ssh_info: None,
+            cwd: local_cwd(),
             llm_profile: None,
             tokens_in: 0,
             tokens_out: 0,
@@ -678,6 +683,55 @@ impl Session {
             transcript_saving: false,
             transcript_error_shown: false,
         }
+    }
+
+    /// Status-bar location: local `name pwd`; SSH `alias host pwd`.
+    ///
+    /// Alias falls back to empty (host + pwd only) when `target_name` is just
+    /// the raw `user@host` ssh_info. Missing cwd omits the path.
+    pub fn status_target(&self) -> String {
+        let pwd = self.cwd.as_deref().map(|p| truncate_pwd(p, 24)).unwrap_or_default();
+        match self.ssh_info.as_deref().and_then(parse_ssh_info) {
+            Some((_, host, _)) => {
+                let alias = self.alias_for_status();
+                match (alias.is_empty(), pwd.is_empty()) {
+                    (true, true) => host,
+                    (true, false) => format!("{host} {pwd}"),
+                    (false, true) => format!("{alias} {host}"),
+                    (false, false) => format!("{alias} {host} {pwd}"),
+                }
+            }
+            None => {
+                if pwd.is_empty() {
+                    self.target_name.clone()
+                } else {
+                    format!("{} {pwd}", self.target_name)
+                }
+            }
+        }
+    }
+
+    /// Distinct alias for the status bar, or empty if `target_name` duplicates ssh_info.
+    fn alias_for_status(&self) -> String {
+        let name = self.target_name.trim();
+        if name.is_empty() {
+            return String::new();
+        }
+        if let Some(info) = &self.ssh_info {
+            if name == info {
+                return String::new();
+            }
+            if let Some(no_port) = info.strip_suffix(":22") {
+                if name == no_port {
+                    return String::new();
+                }
+            }
+            // Raw user@host is not an alias.
+            if name.contains('@') && !name.starts_with('~') {
+                return String::new();
+            }
+        }
+        name.to_string()
     }
 
     /// Format the tab label: `local-N` for local sessions, `user@host` for
@@ -2907,7 +2961,8 @@ impl App {
             TuiEvent::Agent { session_id, .. } => *session_id,
             TuiEvent::Thinking => self.sessions[self.active].id,
             TuiEvent::ConfirmationRequest { .. } => self.sessions[self.active].id,
-            TuiEvent::TransportChanged { .. } => self.sessions[self.active].id,
+            TuiEvent::TransportChanged { session_id, .. } => *session_id,
+            TuiEvent::CwdChanged { session_id, .. } => *session_id,
             TuiEvent::PasswordNeeded { session_id, .. } => *session_id,
         };
 
@@ -3070,6 +3125,9 @@ impl App {
             }
             TuiEvent::TransportChanged { .. } => {
                 // Handled by the runner before reaching here — no-op.
+            }
+            TuiEvent::CwdChanged { cwd, .. } => {
+                self.cwd = Some(cwd);
             }
             TuiEvent::PasswordNeeded { session_id, target } => {
                 self.ctrl_o_pending_target = Some(target);
@@ -3256,6 +3314,22 @@ fn parse_ssh_command(cmd: &str) -> Option<(String, String, u16)> {
     }
 
     Some((user.to_string(), host.to_string(), port))
+}
+
+fn local_cwd() -> Option<String> {
+    std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string())
+}
+
+/// Truncate a path from the left so the status bar stays compact.
+fn truncate_pwd(pwd: &str, max: usize) -> String {
+    let chars: Vec<char> = pwd.chars().collect();
+    if chars.len() <= max {
+        pwd.to_string()
+    } else {
+        format!("…{}", chars[chars.len() - (max.saturating_sub(1))..].iter().collect::<String>())
+    }
 }
 
 /// Parse `user@host[:port]` (the persisted `ssh_info` format) into
@@ -6641,6 +6715,58 @@ mod tests {
     fn parse_ssh_info_rejects_garbage_after_bracket() {
         assert!(parse_ssh_info("root@[::1]oops").is_none());
         assert!(parse_ssh_info("root@[::1]:22oops").is_none());
+    }
+
+    #[test]
+    fn status_target_ssh_shows_alias_host_pwd() {
+        let mut app = App::new("prod".into(), CommandConfirmMode::Always);
+        app.ssh_info = Some("root@10.0.0.5:22".into());
+        app.cwd = Some("/home/deploy".into());
+        assert_eq!(app.status_target(), "prod 10.0.0.5 /home/deploy");
+    }
+
+    #[test]
+    fn status_target_ssh_without_alias_shows_host_pwd() {
+        let mut app = App::new("root@10.0.0.5:22".into(), CommandConfirmMode::Always);
+        app.ssh_info = Some("root@10.0.0.5:22".into());
+        app.cwd = Some("/root".into());
+        assert_eq!(app.status_target(), "10.0.0.5 /root");
+    }
+
+    #[test]
+    fn status_target_local_shows_name_and_pwd() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.cwd = Some("/tmp/proj".into());
+        assert_eq!(app.status_target(), "local /tmp/proj");
+    }
+
+    #[test]
+    fn status_target_omits_pwd_when_unknown() {
+        let mut app = App::new("prod".into(), CommandConfirmMode::Always);
+        app.ssh_info = Some("root@10.0.0.5:22".into());
+        app.cwd = None;
+        assert_eq!(app.status_target(), "prod 10.0.0.5");
+    }
+
+    #[test]
+    fn cwd_changed_event_sets_session_cwd() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        let sid = app.sessions[0].id;
+        app.handle_agent_event(TuiEvent::CwdChanged {
+            session_id: sid,
+            cwd: "/var/log".into(),
+        });
+        assert_eq!(app.cwd.as_deref(), Some("/var/log"));
+    }
+
+    #[test]
+    fn truncate_pwd_keeps_tail() {
+        assert_eq!(truncate_pwd("/a", 24), "/a");
+        let long = "/very/long/path/that/exceeds/limit";
+        let t = truncate_pwd(long, 24);
+        assert!(t.starts_with('…'), "{t}");
+        assert!(t.ends_with("exceeds/limit") || t.ends_with(long.rsplit('/').next().unwrap()), "{t}");
+        assert!(t.chars().count() <= 24, "{t}");
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -362,8 +362,8 @@ pub struct Session {
     /// Set when `!ssh` succeeds for this tab. Used for display and system prompt.
     pub ssh_info: Option<String>,
     /// Last known working directory for the status bar (`None` = unknown).
-    /// Local tabs start from the process cwd; SSH is filled after `pwd` / OSC 7.
-    /// Agent↔interactive sync of this value is #313.
+    /// Local tabs start from the process cwd; SSH is filled from OSC 7
+    /// (interactive PTY). Agent↔interactive sync of this value is #313.
     pub cwd: Option<String>,
     /// LLM profile selected via Ctrl+L. None = use App default.
     pub llm_profile: Option<String>,
@@ -3126,8 +3126,10 @@ impl App {
             TuiEvent::TransportChanged { .. } => {
                 // Handled by the runner before reaching here — no-op.
             }
-            TuiEvent::CwdChanged { cwd, .. } => {
-                self.cwd = Some(cwd);
+            TuiEvent::CwdChanged { session_id, cwd } => {
+                if let Some(idx) = self.find_session_idx(session_id) {
+                    self.sessions[idx].cwd = Some(cwd);
+                }
             }
             TuiEvent::PasswordNeeded { session_id, target } => {
                 self.ctrl_o_pending_target = Some(target);
@@ -6757,6 +6759,23 @@ mod tests {
             cwd: "/var/log".into(),
         });
         assert_eq!(app.cwd.as_deref(), Some("/var/log"));
+    }
+
+    #[test]
+    fn cwd_changed_routes_to_named_session_not_active() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.new_tab();
+        let inactive_id = app.sessions[0].id;
+        let active_id = app.sessions[1].id;
+        assert_eq!(app.sessions[app.active].id, active_id);
+        let active_cwd = app.sessions[1].cwd.clone();
+        app.handle_agent_event(TuiEvent::CwdChanged {
+            session_id: inactive_id,
+            cwd: "/opt/bg".into(),
+        });
+        assert_eq!(app.sessions[0].cwd.as_deref(), Some("/opt/bg"));
+        assert_eq!(app.sessions[1].cwd, active_cwd);
+        assert_eq!(app.active, 1, "active tab must not change");
     }
 
     #[test]

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -49,6 +49,12 @@ pub enum TuiEvent {
         alias: Option<String>,
     },
 
+    /// Working directory for a tab (from remote `pwd` or OSC 7). Status bar only.
+    CwdChanged {
+        session_id: SessionId,
+        cwd: String,
+    },
+
     /// Ctrl+O encountered a password target with no cached password.
     /// The UI must switch to password entry mode.
     PasswordNeeded {

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -49,7 +49,7 @@ pub enum TuiEvent {
         alias: Option<String>,
     },
 
-    /// Working directory for a tab (from remote `pwd` or OSC 7). Status bar only.
+    /// Working directory for a tab (OSC 7 / later sync). Status bar only.
     CwdChanged {
         session_id: SessionId,
         cwd: String,

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -77,6 +77,9 @@ fn route_term_chunk(app: &mut App, sid: SessionId, chunk: TermChunk) -> RouteOut
         TermChunk::Bytes(bytes) => {
             if let Some(ref mut model) = session.terminal {
                 model.feed(&bytes);
+                if let Some(cwd) = model.take_osc7_cwd() {
+                    session.cwd = Some(cwd);
+                }
             }
             if is_background {
                 session.has_new = true;
@@ -87,6 +90,32 @@ fn route_term_chunk(app: &mut App, sid: SessionId, chunk: TermChunk) -> RouteOut
         TermChunk::Err(e) => RouteOutcome::Error(e),
     }
 }
+
+fn spawn_remote_cwd_probe(
+    exec: Arc<TuiExecutor>,
+    session_id: crate::app::SessionId,
+    tx: mpsc::UnboundedSender<TuiEvent>,
+) {
+    tokio::spawn(async move {
+        if let Ok(result) = exec.run("pwd").await {
+            if let Some(cwd) = sanitize_pwd_output(&result.stdout) {
+                let _ = tx.send(TuiEvent::CwdChanged { session_id, cwd });
+            }
+        }
+    });
+}
+
+fn sanitize_pwd_output(stdout: &str) -> Option<String> {
+    let line = stdout
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.eq_ignore_ascii_case("path") && *l != "----")?;
+    if line.len() > 1024 {
+        return None;
+    }
+    Some(line.to_string())
+}
+
 use filar_core::ChatBlock;
 
 // ---------------------------------------------------------------------------
@@ -411,11 +440,16 @@ async fn run_app(
     if let Some(ref target) = config.ssh_target {
         app.sessions[0].ssh_info =
             Some(format!("{}@{}:{}", target.user, target.host, target.port));
+        app.sessions[0].cwd = None;
+        if let Some(entry) = executors.get(&initial_sid) {
+            spawn_remote_cwd_probe(entry.executor.clone(), initial_sid, agent_tx.clone());
+        }
     } else if let Some(ref info) = config.initial_ssh_info {
         // Restored session was over SSH but no live ssh_target was provided
         // (e.g. `--session` restore without `--target`). Surface the saved
         // host in the tab label; reconnecting is handled by the overlay.
         app.sessions[0].ssh_info = Some(info.clone());
+        app.sessions[0].cwd = None;
     }
 
     // Crossterm event stream for async keyboard input.
@@ -1118,7 +1152,7 @@ async fn run_app(
             } => {
                 if let Some(event) = maybe_agent_event {
                     // Intercept TransportChanged to update per-session info.
-                    if let TuiEvent::TransportChanged { session_id, ref ssh_info, ref alias, .. } = &event {
+                    if let TuiEvent::TransportChanged { session_id, is_local, ref ssh_info, ref alias, .. } = &event {
                         if let Some(idx) = app.find_session_idx(*session_id) {
                             app.sessions[idx].ssh_info = ssh_info.clone();
                             app.sessions[idx].target_name =
@@ -1127,6 +1161,20 @@ async fn run_app(
                                         format!("local-{}", idx + 1)
                                     })
                                 });
+                            if *is_local {
+                                app.sessions[idx].cwd = std::env::current_dir()
+                                    .ok()
+                                    .map(|p| p.display().to_string());
+                            } else {
+                                app.sessions[idx].cwd = None;
+                                if let Some(entry) = executors.get(session_id) {
+                                    spawn_remote_cwd_probe(
+                                        entry.executor.clone(),
+                                        *session_id,
+                                        agent_tx.clone(),
+                                    );
+                                }
+                            }
                         }
                     }
                     // All agent events just need a redraw — the borderless
@@ -1526,6 +1574,21 @@ mod tests {
         );
         assert!(matches!(outcome, RouteOutcome::Fed));
         assert!(app.sessions[0].has_new, "background tab must be marked");
+    }
+
+    #[test]
+    fn route_osc7_updates_session_cwd() {
+        use filar_core::CommandConfirmMode;
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        let sid = app.sessions[0].id;
+        app.sessions[0].terminal = Some(crate::terminal::TerminalModel::new(80, 24));
+        let outcome = route_term_chunk(
+            &mut app,
+            sid,
+            TermChunk::Bytes(b"\x1b]7;file://host/opt/app\x07".to_vec()),
+        );
+        assert!(matches!(outcome, RouteOutcome::Fed));
+        assert_eq!(app.sessions[0].cwd.as_deref(), Some("/opt/app"));
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -91,31 +91,6 @@ fn route_term_chunk(app: &mut App, sid: SessionId, chunk: TermChunk) -> RouteOut
     }
 }
 
-fn spawn_remote_cwd_probe(
-    exec: Arc<TuiExecutor>,
-    session_id: crate::app::SessionId,
-    tx: mpsc::UnboundedSender<TuiEvent>,
-) {
-    tokio::spawn(async move {
-        if let Ok(result) = exec.run("pwd").await {
-            if let Some(cwd) = sanitize_pwd_output(&result.stdout) {
-                let _ = tx.send(TuiEvent::CwdChanged { session_id, cwd });
-            }
-        }
-    });
-}
-
-fn sanitize_pwd_output(stdout: &str) -> Option<String> {
-    let line = stdout
-        .lines()
-        .map(str::trim)
-        .find(|l| !l.is_empty() && !l.eq_ignore_ascii_case("path") && *l != "----")?;
-    if line.len() > 1024 {
-        return None;
-    }
-    Some(line.to_string())
-}
-
 use filar_core::ChatBlock;
 
 // ---------------------------------------------------------------------------
@@ -440,10 +415,9 @@ async fn run_app(
     if let Some(ref target) = config.ssh_target {
         app.sessions[0].ssh_info =
             Some(format!("{}@{}:{}", target.user, target.host, target.port));
+        // Do not run unconfirmed `pwd` here (AGENTS.md confirm gate).
+        // Pwd appears once OSC 7 reports it (interactive) or #313 syncs it.
         app.sessions[0].cwd = None;
-        if let Some(entry) = executors.get(&initial_sid) {
-            spawn_remote_cwd_probe(entry.executor.clone(), initial_sid, agent_tx.clone());
-        }
     } else if let Some(ref info) = config.initial_ssh_info {
         // Restored session was over SSH but no live ssh_target was provided
         // (e.g. `--session` restore without `--target`). Surface the saved
@@ -1166,14 +1140,8 @@ async fn run_app(
                                     .ok()
                                     .map(|p| p.display().to_string());
                             } else {
+                                // Unknown until OSC 7 / #313 — no unconfirmed remote `pwd`.
                                 app.sessions[idx].cwd = None;
-                                if let Some(entry) = executors.get(session_id) {
-                                    spawn_remote_cwd_probe(
-                                        entry.executor.clone(),
-                                        *session_id,
-                                        agent_tx.clone(),
-                                    );
-                                }
                             }
                         }
                     }

--- a/crates/tui/src/terminal.rs
+++ b/crates/tui/src/terminal.rs
@@ -54,6 +54,10 @@ impl Dimensions for TermDimensions {
 pub struct TerminalModel {
     term: Term<VoidListener>,
     processor: alacritty_terminal::vte::ansi::Processor,
+    /// Last OSC 7 working directory parsed from PTY output.
+    osc7_cwd: Option<String>,
+    /// Carry buffer so OSC 7 split across reads is still recognized.
+    osc_scan: Vec<u8>,
 }
 
 impl TerminalModel {
@@ -69,12 +73,30 @@ impl TerminalModel {
         };
         let term = Term::new(config, &dims, VoidListener);
         let processor = <_>::default();
-        Self { term, processor }
+        Self {
+            term,
+            processor,
+            osc7_cwd: None,
+            osc_scan: Vec::new(),
+        }
     }
 
     /// Feed output bytes (from PTY/SSH) into the terminal model.
     pub fn feed(&mut self, bytes: &[u8]) {
+        self.osc_scan.extend_from_slice(bytes);
+        if self.osc_scan.len() > 4096 {
+            let drop = self.osc_scan.len() - 4096;
+            self.osc_scan.drain(..drop);
+        }
+        if let Some(cwd) = drain_osc7_cwd(&mut self.osc_scan) {
+            self.osc7_cwd = Some(cwd);
+        }
         self.processor.advance(&mut self.term, bytes);
+    }
+
+    /// Take the latest OSC 7 cwd, if the PTY reported one since the last take.
+    pub fn take_osc7_cwd(&mut self) -> Option<String> {
+        self.osc7_cwd.take()
     }
 
     /// Resize the terminal to the given dimensions.
@@ -592,6 +614,110 @@ fn ctrl_char_to_bytes(c: char) -> Vec<u8> {
     vec![byte]
 }
 
+/// Pull complete OSC 7 sequences out of `buf`, leaving a possible incomplete
+/// suffix. Returns the last decoded path.
+fn drain_osc7_cwd(buf: &mut Vec<u8>) -> Option<String> {
+    let mut last = None;
+    loop {
+        let Some(start) = find_osc7_start(buf) else {
+            // Keep a short tail in case ESC is at the end.
+            if buf.len() > 8 {
+                let keep = 8;
+                let drop = buf.len() - keep;
+                buf.drain(..drop);
+            }
+            break;
+        };
+        if start > 0 {
+            buf.drain(..start);
+        }
+        // buf now starts with ESC ] 7 ;
+        let Some(end) = find_osc_end(buf) else {
+            break;
+        };
+        let payload = buf[4..end].to_vec();
+        let skip = osc_end_skip(buf, end);
+        buf.drain(..end + skip);
+        if let Ok(s) = std::str::from_utf8(&payload) {
+            if let Some(path) = parse_osc7_payload(s) {
+                last = Some(path);
+            }
+        }
+    }
+    last
+}
+
+fn find_osc7_start(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == [0x1b, b']', b'7', b';'])
+}
+
+fn find_osc_end(buf: &[u8]) -> Option<usize> {
+    for i in 4..buf.len() {
+        if buf[i] == 0x07 {
+            return Some(i);
+        }
+        if buf[i] == 0x1b && i + 1 < buf.len() && buf[i + 1] == b'\\' {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn osc_end_skip(buf: &[u8], end: usize) -> usize {
+    if buf[end] == 0x07 {
+        1
+    } else {
+        2 // ESC \
+    }
+}
+
+fn parse_osc7_payload(payload: &str) -> Option<String> {
+    let uri = payload.trim();
+    let rest = uri.strip_prefix("file://")?;
+    let path = if let Some(stripped) = rest.strip_prefix("//") {
+        // file:////path (unusual) — treat as path
+        format!("/{stripped}")
+    } else if rest.starts_with('/') {
+        rest.to_string()
+    } else {
+        let slash = rest.find('/')?;
+        rest[slash..].to_string()
+    };
+    let decoded = percent_decode(&path);
+    let chars: Vec<char> = decoded.chars().collect();
+    if chars.len() >= 3 && chars[0] == '/' && chars[1].is_ascii_alphabetic() && chars[2] == ':' {
+        return Some(decoded.chars().skip(1).collect());
+    }
+    Some(decoded)
+}
+
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (from_hex(bytes[i + 1]), from_hex(bytes[i + 2])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn from_hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -605,6 +731,38 @@ mod tests {
         let model = TerminalModel::new(80, 24);
         assert_eq!(model.cols(), 80);
         assert_eq!(model.rows(), 24);
+    }
+
+    #[test]
+    fn osc7_bel_unix_path() {
+        let mut model = TerminalModel::new(80, 24);
+        model.feed(b"\x1b]7;file://host/tmp/work\x07");
+        assert_eq!(model.take_osc7_cwd().as_deref(), Some("/tmp/work"));
+        assert!(model.take_osc7_cwd().is_none());
+    }
+
+    #[test]
+    fn osc7_st_and_percent_decode() {
+        let mut model = TerminalModel::new(80, 24);
+        model.feed(b"\x1b]7;file:///home/user/my%20dir\x1b\\");
+        assert_eq!(model.take_osc7_cwd().as_deref(), Some("/home/user/my dir"));
+    }
+
+    #[test]
+    fn osc7_split_across_chunks() {
+        let mut model = TerminalModel::new(80, 24);
+        model.feed(b"\x1b]7;file://h");
+        assert!(model.take_osc7_cwd().is_none());
+        model.feed(b"ost/var/log\x07");
+        assert_eq!(model.take_osc7_cwd().as_deref(), Some("/var/log"));
+    }
+
+    #[test]
+    fn osc7_windows_drive_path() {
+        assert_eq!(
+            parse_osc7_payload("file://localhost/C:/Users/me"),
+            Some("C:/Users/me".into())
+        );
     }
 
     #[test]

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -65,8 +65,8 @@ fn help_items(mode: AppMode) -> Vec<HelpItem> {
 
 /// Render the status bar (top line).
 ///
-/// Layout: `filar ▸ {target}` on the left (accent on target name),
-/// mode indicator in the center (only for non-Normal modes),
+/// Layout: `filar ▸ {alias host pwd}` on the left for SSH (`name pwd` when
+/// local), mode indicator in the center (only for non-Normal modes),
 /// `confirm_mode` on the right (muted).
 pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
     let glyphs = app.theme.glyphs();
@@ -79,7 +79,7 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
         Span::styled(glyphs.target_sep, app.theme.muted()),
         Span::raw(" "),
         Span::styled(
-            app.target_name.clone(),
+            app.status_target(),
             app.theme.user_style(),
         ),
     ];
@@ -416,6 +416,26 @@ mod tests {
         app.active_session_mut().llm_profile = Some("glm".into());
         let row = render_status_row(&mut app, 120);
         assert!(row.contains("toks: —"), "zero tokens must show dash, got: {row}");
+    }
+
+    #[test]
+    fn status_bar_ssh_shows_alias_host_and_pwd() {
+        let mut app = App::new("prod".into(), CommandConfirmMode::Always);
+        app.ssh_info = Some("root@10.0.0.5:22".into());
+        app.cwd = Some("/srv".into());
+        let row = render_status_row(&mut app, 120);
+        assert!(row.contains("prod"), "alias, got: {row}");
+        assert!(row.contains("10.0.0.5"), "host, got: {row}");
+        assert!(row.contains("/srv"), "pwd, got: {row}");
+    }
+
+    #[test]
+    fn status_bar_local_still_shows_name() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.cwd = Some("/tmp".into());
+        let row = render_status_row(&mut app, 120);
+        assert!(row.contains("local"), "local name, got: {row}");
+        assert!(row.contains("/tmp"), "local pwd, got: {row}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #309

## Summary
- SSH status bar is now `alias host pwd` (example: `prod 10.0.0.5 /home/deploy`). If there is no alias, only `host pwd`.
- Local tabs stay `local` (or `local-N`) plus the process cwd.
- `Session.cwd` is filled from: process cwd (local), remote `pwd` after SSH connect (`Ctrl+O` / `!ssh` / launcher / `--target`), OSC 7 from the interactive PTY.

## Tests
- `cargo build --workspace` / `cargo test --workspace` — green
- New: `status_target_*`, OSC 7 parse (incl. split chunks), `route_osc7_updates_session_cwd`
- `#[ignore]` docker-sshd not run

## Manual smoke
1. Launch SSH from GUI — status shows alias + host; pwd appears after connect.
2. `Ctrl+O` / `!ssh` / `--target` — same.
3. Local tab — `local` + local path; not broken.
4. Optional: shell with OSC 7 (`cd` in bash/zsh that emits it) — pwd in the bar updates.

## Out of scope (#313)
- Syncing agent executor cwd with interactive `cd` (and the reverse). This PR only **displays** cwd.