### PR TITLE
fix(tui): sync cwd between interactive PTY and agent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - F1 help overlay no longer uses `⌘` on Windows (console fonts render it as
   `?`); macOS keeps Fn+F1 / Ctrl vs ⌘ wording
   ([#310](https://github.com/devlawey/filar/issues/310)).
+- Interactive `cd` (Ctrl+T) is applied to the agent executor on return, and
+  entering interactive starts the PTY in the tab cwd (local spawn cwd; SSH
+  sends `cd`). Status-bar pwd tracks OSC 7, a POSIX leave-probe, and SSH
+  `$PWD` in the command marker
+  ([#313](https://github.com/devlawey/filar/issues/313)).
 
 ## [1.0.0] - 2026-08-17
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4813,3 +4813,5 @@ NSPasteboard; egui 0.29 `TextEdit::singleline` заменяет `\n`/`\r` на �
 - Windows local `cmd.exe` без OSC 7 — см. PLATFORM_NOTES.
 
 **Публичный API:** `CommandExecutor::set_cwd`/`current_cwd`; `CommandResult.cwd`; `posix_cd_*` / `OSC7_PWD_PROBE`.
+
+**Review (#319):** SSH `set_cwd` больше не вызывает `run("cd")`. `cd` префиксируется к следующей **подтверждённой** команде агента (`cd … &&`). Парсер маркера требует `__` после pwd.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4798,3 +4798,18 @@ NSPasteboard; egui 0.29 `TextEdit::singleline` заменяет `\n`/`\r` на �
 - Убран `spawn_remote_cwd_probe` (`exec.run("pwd")` без approve).
 - `CwdChanged` пишет в сессию по `session_id` явно; тест на фоновую вкладку.
 - CHANGELOG: запись #309 в `### Changed`.
+
+## Issue #313: fix(tui) — sync cwd between interactive and agent
+
+**Milestone:** 1.0.1. **Ветка:** `fix/313-sync-cwd-agent-interactive`.
+
+**Проблема:** `cd` в Ctrl+T не применялся к агентскому executor; статус-бар мог врать.
+
+**Решение:**
+- `CommandExecutor::set_cwd` / `current_cwd` (default no-op). Local: `current_dir` на процесс. SSH: `cd` в persistent shell.
+- Выход из interactive: OSC 7 или POSIX `printf`/`pwd` probe, затем `set_cwd`.
+- Вход: local PTY spawn с cwd; SSH — `cd` в PTY. После agent `CommandFinished` — cwd из SSH-маркера `$PWD`.
+- Маркер SSH: `printf ... "$?" "$PWD"` (не отдельный unconfirmed `pwd`).
+- Windows local `cmd.exe` без OSC 7 — см. PLATFORM_NOTES.
+
+**Публичный API:** `CommandExecutor::set_cwd`/`current_cwd`; `CommandResult.cwd`; `posix_cd_*` / `OSC7_PWD_PROBE`.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -789,6 +789,7 @@ mod tests {
                 stderr: String::new(),
                 exit_code: Some(0),
                 duration: Duration::from_millis(10),
+                cwd: None,
             })
         }
 

--- a/crates/transport/src/cwd.rs
+++ b/crates/transport/src/cwd.rs
@@ -22,7 +22,10 @@ pub fn is_safe_cwd(path: &str) -> bool {
     !trimmed.is_empty() && trimmed.len() <= MAX_CWD_LEN
 }
 
-/// POSIX single-quote a path for `cd` / similar.
+/// POSIX single-quote a path for `cd`.
+///
+/// `\` is quoted (not treated as a bare-safe char) so dash/`printf` cannot
+/// reinterpret escapes. Inside single quotes a backslash is literal.
 pub fn posix_shell_quote(value: &str) -> String {
     if value
         .chars()
@@ -79,5 +82,9 @@ mod tests {
     fn cd_input_none_when_unsafe() {
         assert!(posix_cd_input("").is_none());
         assert_eq!(posix_cd_input("/opt/app").as_deref(), Some("cd /opt/app\n"));
+        assert_eq!(
+            posix_cd_command("/opt/app").as_deref(),
+            Some("cd /opt/app")
+        );
     }
 }

--- a/crates/transport/src/cwd.rs
+++ b/crates/transport/src/cwd.rs
@@ -1,0 +1,83 @@
+//! Working-directory helpers shared by local and SSH transports.
+//!
+//! Used to sync the agent executor with the interactive PTY (and the reverse)
+//! without writing files on the remote host.
+
+/// Maximum length of a cwd we will accept from OSC 7, `$PWD`, or `set_cwd`.
+pub const MAX_CWD_LEN: usize = 1024;
+
+/// Bytes written to a POSIX interactive shell to emit OSC 7 for the current pwd.
+///
+/// No files are created. The PTY is typically closed immediately after, so the
+/// command does not stay in the user's session.
+pub const OSC7_PWD_PROBE: &[u8] =
+    b"printf '\\033]7;file://localhost%s\\007' \"$(pwd)\"\n";
+
+/// Reject empty, oversized, or newline/NUL-containing paths.
+pub fn is_safe_cwd(path: &str) -> bool {
+    if path.contains('\n') || path.contains('\r') || path.as_bytes().contains(&0) {
+        return false;
+    }
+    let trimmed = path.trim();
+    !trimmed.is_empty() && trimmed.len() <= MAX_CWD_LEN
+}
+
+/// POSIX single-quote a path for `cd` / similar.
+pub fn posix_shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'))
+    {
+        value.to_string()
+    } else {
+        let escaped = value.replace('\'', "'\\''");
+        format!("'{escaped}'")
+    }
+}
+
+/// `cd <quoted-path>` plus newline, for writing to an interactive POSIX PTY.
+pub fn posix_cd_input(path: &str) -> Option<String> {
+    if !is_safe_cwd(path) {
+        return None;
+    }
+    Some(format!("cd {}\n", posix_shell_quote(path.trim())))
+}
+
+/// `cd <quoted-path>` without newline, for the agent SSH shell.
+pub fn posix_cd_command(path: &str) -> Option<String> {
+    if !is_safe_cwd(path) {
+        return None;
+    }
+    Some(format!("cd {}", posix_shell_quote(path.trim())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_and_control() {
+        assert!(!is_safe_cwd(""));
+        assert!(!is_safe_cwd("   "));
+        assert!(!is_safe_cwd("/tmp\n/evil"));
+        assert!(!is_safe_cwd("/tmp\r"));
+        assert!(!is_safe_cwd("a\0b"));
+    }
+
+    #[test]
+    fn quote_simple_path() {
+        assert_eq!(posix_shell_quote("/tmp/work"), "/tmp/work");
+    }
+
+    #[test]
+    fn quote_spaces_and_quotes() {
+        assert_eq!(posix_shell_quote("/home/a b"), "'/home/a b'");
+        assert_eq!(posix_shell_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn cd_input_none_when_unsafe() {
+        assert!(posix_cd_input("").is_none());
+        assert_eq!(posix_cd_input("/opt/app").as_deref(), Some("cd /opt/app\n"));
+    }
+}

--- a/crates/transport/src/interactive.rs
+++ b/crates/transport/src/interactive.rs
@@ -114,7 +114,12 @@ impl LocalInteractive {
 
     /// Create a local interactive terminal with the given initial size.
     pub async fn with_size(cols: u16, rows: u16) -> Result<Self> {
-        Self::with_shell_and_size(None, cols, rows).await
+        Self::with_shell_size_and_cwd(None, cols, rows, None).await
+    }
+
+    /// Create a local interactive PTY in `cwd` when set (tab cwd sync).
+    pub async fn with_size_in(cols: u16, rows: u16, cwd: Option<&str>) -> Result<Self> {
+        Self::with_shell_size_and_cwd(None, cols, rows, cwd).await
     }
 
     /// Create a local interactive terminal with a specific shell and size.
@@ -125,6 +130,16 @@ impl LocalInteractive {
         shell: Option<&str>,
         cols: u16,
         rows: u16,
+    ) -> Result<Self> {
+        Self::with_shell_size_and_cwd(shell, cols, rows, None).await
+    }
+
+    /// Create a local interactive terminal with a specific shell, size, and cwd.
+    pub async fn with_shell_size_and_cwd(
+        shell: Option<&str>,
+        cols: u16,
+        rows: u16,
+        cwd: Option<&str>,
     ) -> Result<Self> {
         let pty_system = native_pty_system();
         let pair = pty_system
@@ -140,7 +155,13 @@ impl LocalInteractive {
         let shell_prog = shell.unwrap_or(default_shell.as_str());
 
         let mut cmd = CommandBuilder::new(shell_prog);
-        cmd.cwd(std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")));
+        let dir = cwd
+            .map(str::trim)
+            .filter(|p| crate::is_safe_cwd(p))
+            .map(std::path::PathBuf::from)
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        cmd.cwd(dir);
 
         // Spawn the shell.
         let child = pair

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -8,6 +8,7 @@
 //! - [`LocalExecutor`] — local PTY implementation using `portable-pty` (Stage 3).
 //!   Only available with the `local` feature (enabled by default).
 
+pub mod cwd;
 pub mod error;
 pub mod interactive;
 #[cfg(feature = "local")]
@@ -27,6 +28,9 @@ pub use interactive::LocalInteractive;
 pub use interactive::{InteractiveTerminal, SshInteractive};
 #[cfg(feature = "local")]
 pub use local::LocalExecutor;
+pub use cwd::{
+    is_safe_cwd, posix_cd_command, posix_cd_input, posix_shell_quote, OSC7_PWD_PROBE,
+};
 pub use secret::SecretSubstitutingExecutor;
 pub use ssh::{SshExecutor, SshSession, SshTransportConfig};
 
@@ -41,6 +45,9 @@ pub struct CommandResult {
     pub exit_code: Option<i32>,
     /// Wall-clock duration the command ran for.
     pub duration: Duration,
+    /// Working directory after the command, when the transport can report it
+    /// (SSH marker includes `$PWD`; local uses the executor's stored cwd).
+    pub cwd: Option<String>,
 }
 
 /// A streaming event emitted during command execution.
@@ -87,6 +94,20 @@ pub trait CommandExecutor: Send + Sync {
     /// Cancel the currently running command by sending Ctrl-C (SIGINT).
     /// If no command is running, this is a no-op.
     async fn cancel(&self) -> Result<()>;
+
+    /// Point subsequent [`run`](Self::run) calls at `path` (tab cwd sync).
+    ///
+    /// Transport bookkeeping for Ctrl+T / OSC 7, not an LLM tool call.
+    /// Default is a no-op. `path` must pass [`is_safe_cwd`].
+    async fn set_cwd(&self, path: &str) -> Result<()> {
+        let _ = path;
+        Ok(())
+    }
+
+    /// Last known working directory for this executor, if tracked.
+    async fn current_cwd(&self) -> Option<String> {
+        None
+    }
 }
 
 // Re-export the async_trait macro so downstream crates don't need a direct dep.

--- a/crates/transport/src/local.rs
+++ b/crates/transport/src/local.rs
@@ -4,10 +4,13 @@
 //! are run via PowerShell (`-NoProfile -NonInteractive -Command`). On Unix,
 //! commands are run via `sh -c`.
 //!
-//! Shell state (cwd, env) does NOT persist between calls — each command runs
-//! in a fresh process. The system prompt informs the agent of this.
+//! Shell state (env) does NOT persist between calls — each command runs
+//! in a fresh process. Working directory can persist via [`LocalExecutor::set_cwd`]
+//! (interactive ↔ agent sync). The system prompt still warns that `cd` inside
+//! a command does not stick.
 
-use std::sync::Arc;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use tokio::sync::Notify;
@@ -27,12 +30,14 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SE
 /// [`crate::CommandExecutor`] implementation backed by local subprocess execution.
 ///
 /// On Windows, uses PowerShell. On Unix, uses `sh`.
-/// Each command runs in a separate process — no persistent shell session.
+/// Each command runs in a separate process — env does not persist.
+/// Working directory persists when set via [`CommandExecutor::set_cwd`].
 /// Commands have a 5-minute timeout by default to prevent hanging on
 /// interactive prompts; override with [`LocalExecutor::with_timeout`].
 pub struct LocalExecutor {
     cancel_notify: Arc<Notify>,
     timeout: Duration,
+    cwd: Mutex<Option<PathBuf>>,
 }
 
 impl LocalExecutor {
@@ -47,6 +52,7 @@ impl LocalExecutor {
         Ok(Self {
             cancel_notify: Arc::new(Notify::new()),
             timeout,
+            cwd: Mutex::new(None),
         })
     }
 
@@ -84,6 +90,11 @@ impl crate::CommandExecutor for LocalExecutor {
         cmd.stderr(std::process::Stdio::piped());
         // Kill the child process if the future is dropped (cancel/timeout).
         cmd.kill_on_drop(true);
+        if let Ok(guard) = self.cwd.lock() {
+            if let Some(ref dir) = *guard {
+                cmd.current_dir(dir);
+            }
+        }
 
         // Wait for output, with timeout and cancel support.
         // When cancel/timeout fires, the output() future is dropped,
@@ -114,6 +125,9 @@ impl crate::CommandExecutor for LocalExecutor {
             stderr,
             exit_code,
             duration,
+            cwd: self.cwd.lock().ok().and_then(|g| {
+                g.as_ref().map(|p| p.to_string_lossy().into_owned())
+            }),
         })
     }
 
@@ -135,6 +149,24 @@ impl crate::CommandExecutor for LocalExecutor {
     async fn cancel(&self) -> Result<()> {
         self.cancel_notify.notify_one();
         Ok(())
+    }
+
+    async fn set_cwd(&self, path: &str) -> Result<()> {
+        if !crate::is_safe_cwd(path) {
+            return Err(CoreError::Other("invalid cwd".into()));
+        }
+        let mut guard = self.cwd.lock().map_err(|_| {
+            CoreError::Other("cwd lock poisoned".into())
+        })?;
+        *guard = Some(PathBuf::from(path.trim()));
+        Ok(())
+    }
+
+    async fn current_cwd(&self) -> Option<String> {
+        self.cwd
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().map(|p| p.to_string_lossy().into_owned()))
     }
 }
 
@@ -160,6 +192,7 @@ fn build_shell_command(command: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandExecutor;
 
     #[test]
     fn default_timeout_is_five_minutes() {
@@ -199,5 +232,33 @@ mod tests {
         let result = build_shell_command("ls");
         assert_eq!(result, "ls");
         assert!(!result.contains("OutputEncoding"));
+    }
+
+    #[tokio::test]
+    async fn set_cwd_is_used_by_subsequent_run() {
+        let exec = LocalExecutor::new().await.unwrap();
+        let marker = format!("filar_cwd_{}", std::process::id());
+        let dir = std::env::temp_dir().join(&marker);
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir_str = dir.to_string_lossy().into_owned();
+        exec.set_cwd(&dir_str).await.unwrap();
+        assert_eq!(exec.current_cwd().await.as_deref(), Some(dir_str.as_str()));
+        #[cfg(windows)]
+        let cmd = "(Get-Location).Path";
+        #[cfg(unix)]
+        let cmd = "pwd";
+        let result = exec.run(cmd).await.unwrap();
+        assert!(
+            result.stdout.contains(&marker),
+            "cwd output {:?} should contain {marker}",
+            result.stdout
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn set_cwd_rejects_newline() {
+        let exec = LocalExecutor::new().await.unwrap();
+        assert!(exec.set_cwd("/tmp\n/etc").await.is_err());
     }
 }

--- a/crates/transport/src/secret.rs
+++ b/crates/transport/src/secret.rs
@@ -109,6 +109,14 @@ impl CommandExecutor for SecretSubstitutingExecutor {
     async fn cancel(&self) -> Result<()> {
         self.inner.cancel().await
     }
+
+    async fn set_cwd(&self, path: &str) -> Result<()> {
+        self.inner.set_cwd(path).await
+    }
+
+    async fn current_cwd(&self) -> Option<String> {
+        self.inner.current_cwd().await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +156,7 @@ mod tests {
                 stderr: self.stderr.clone(),
                 exit_code: Some(0),
                 duration: std::time::Duration::from_millis(1),
+                cwd: None,
             })
         }
         async fn cancel(&self) -> Result<()> {

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
 use russh::client::{self, Handle, Msg};
@@ -415,9 +415,9 @@ impl SshSession {
         let marker_id = format!("req_{:08x}_{}", req_id, Uuid::new_v4().simple());
         let marker_tag = format!("{}{}", MARKER_PREFIX, marker_id);
 
-        // Build the full payload: <command>\n printf marker\n
+        // Build the full payload: <command>\n printf marker with exit + PWD\n
         let payload = format!(
-            "{}\nprintf '\\n{}__%d__\\n' \"$?\"\n",
+            "{}\nprintf '\\n{}__%d__%s__\\n' \"$?\" \"$PWD\"\n",
             command, marker_tag
         );
 
@@ -456,13 +456,14 @@ impl SshSession {
         // Read events until we find the marker — without holding any lock
         // that `cancel()` needs.
         match recv_until_marker(&mut event_rx, &marker_tag, self.command_timeout).await {
-            Ok((stdout, stderr, exit_code)) => {
+            Ok((stdout, stderr, exit_code, cwd)) => {
                 let duration = start.elapsed();
                 Ok(CommandResult {
                     stdout,
                     stderr,
                     exit_code,
                     duration,
+                    cwd,
                 })
             }
             Err(e) => {
@@ -627,6 +628,8 @@ pub struct SshExecutor {
     /// Secret provider used to resolve the SSH password on connect and on every
     /// auto-reconnect. Retained so re-dialling uses the same credential source.
     secrets: Arc<dyn SecretProvider>,
+    /// Last `$PWD` reported by the command marker (or [`set_cwd`]).
+    last_cwd: StdMutex<Option<String>>,
 }
 
 impl SshExecutor {
@@ -666,12 +669,23 @@ impl SshExecutor {
             target: target.clone(),
             config,
             secrets,
+            last_cwd: StdMutex::new(None),
         })
     }
 
     /// Close the underlying session.
     pub async fn close(&self) -> Result<()> {
         self.session.read().await.close().await
+    }
+
+    fn store_cwd_from(&self, result: &Result<CommandResult>) {
+        if let Ok(r) = result {
+            if let Some(cwd) = r.cwd.as_deref().filter(|p| crate::is_safe_cwd(p)) {
+                if let Ok(mut g) = self.last_cwd.lock() {
+                    *g = Some(cwd.to_string());
+                }
+            }
+        }
     }
 }
 
@@ -688,6 +702,7 @@ impl crate::CommandExecutor for SshExecutor {
         let should_reconnect =
             self.config.auto_reconnect && matches!(first, Err(CoreError::ConnectionLost(_)));
         if !should_reconnect {
+            self.store_cwd_from(&first);
             return first;
         }
 
@@ -726,11 +741,33 @@ impl crate::CommandExecutor for SshExecutor {
         );
 
         // Single retry on the fresh session.
-        self.session.read().await.run(command).await
+        let retry = self.session.read().await.run(command).await;
+        self.store_cwd_from(&retry);
+        retry
     }
 
     async fn cancel(&self) -> Result<()> {
         self.session.read().await.cancel().await
+    }
+
+    async fn set_cwd(&self, path: &str) -> Result<()> {
+        let cmd = crate::posix_cd_command(path)
+            .ok_or_else(|| CoreError::Other("invalid cwd".into()))?;
+        let result = self.run(&cmd).await?;
+        if result.exit_code.unwrap_or(-1) != 0 {
+            return Err(CoreError::Other(format!(
+                "cd failed with exit {}",
+                result.exit_code.unwrap_or(-1)
+            )));
+        }
+        if let Ok(mut g) = self.last_cwd.lock() {
+            *g = Some(path.trim().to_string());
+        }
+        Ok(())
+    }
+
+    async fn current_cwd(&self) -> Option<String> {
+        self.last_cwd.lock().ok().and_then(|g| g.clone())
     }
 }
 
@@ -906,16 +943,13 @@ async fn drain_until_marker(
 }
 
 /// Read events from the reader task until a marker of the form
-/// `<marker_tag>__<exit_code>__` is found. Returns the output before the
-/// marker and the parsed exit code.
-///
-/// Unlike `drain_until_marker`, this reads from an `mpsc::UnboundedReceiver`
-/// and does NOT touch the SSH channel directly — the reader task does that.
+/// `<marker_tag>__<exit_code>__[<pwd>__]` is found. Returns stdout, stderr,
+/// exit code, and optional `$PWD` from the marker.
 async fn recv_until_marker(
     event_rx: &mut mpsc::UnboundedReceiver<ChannelEvent>,
     marker_tag: &str,
     timeout: Duration,
-) -> Result<(String, String, Option<i32>)> {
+) -> Result<(String, String, Option<i32>, Option<String>)> {
     let mut buf = String::new();
     let mut stderr_buf = String::new();
     let deadline = tokio::time::Instant::now() + timeout;
@@ -930,41 +964,23 @@ async fn recv_until_marker(
             ChannelEvent::Data(text) => {
                 buf.push_str(&text);
 
-                // Look for the marker line: <marker_tag>__<digits>__
-                if let Some(pos) = buf.find(marker_tag) {
-                    let after_tag = &buf[pos + marker_tag.len()..];
-                    if let Some(rest) = after_tag.strip_prefix("__") {
-                        if let Some(end) = rest.find("__") {
-                            let code_str = &rest[..end];
-                            if let Ok(code) = code_str.trim().parse::<i32>() {
-                                let line_start =
-                                    buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
-                                let output = buf[..line_start].to_string();
-                                // Strip the synthetic trailing newline added by the
-                                // printf marker's leading '\n'. This removes
-                                // exactly one '\n' — not the command's own output.
-                                let output = output
-                                    .strip_suffix('\n')
-                                    .map(str::to_string)
-                                    .unwrap_or(output);
+                if let Some((code, cwd, line_start)) = parse_filar_marker(&buf, marker_tag) {
+                    let output = buf[..line_start].to_string();
+                    let output = output
+                        .strip_suffix('\n')
+                        .map(str::to_string)
+                        .unwrap_or(output);
 
-                                // Drain any trailing stderr that may still be
-                                // in the event pipeline. Without this, late
-                                // stderr could contaminate the next run's result.
-                                while let Ok(Some(ChannelEvent::Stderr(text))) =
-                                    tokio::time::timeout(
-                                        Duration::from_millis(50),
-                                        event_rx.recv(),
-                                    )
-                                    .await
-                                {
-                                    stderr_buf.push_str(&text);
-                                }
-                                return Ok((output, stderr_buf, Some(code)));
-                            }
-                        }
+                    while let Ok(Some(ChannelEvent::Stderr(text))) =
+                        tokio::time::timeout(
+                            Duration::from_millis(50),
+                            event_rx.recv(),
+                        )
+                        .await
+                    {
+                        stderr_buf.push_str(&text);
                     }
-                    // Marker tag found but couldn't parse exit code — keep reading.
+                    return Ok((output, stderr_buf, Some(code), cwd));
                 }
             }
             ChannelEvent::Stderr(text) => {
@@ -977,6 +993,31 @@ async fn recv_until_marker(
             }
         }
     }
+}
+
+/// Parse `<marker_tag>__<exit>__` or `<marker_tag>__<exit>__<pwd>__`.
+///
+/// Returns `(exit_code, cwd, start_of_marker_line)`.
+fn parse_filar_marker(buf: &str, marker_tag: &str) -> Option<(i32, Option<String>, usize)> {
+    let pos = buf.find(marker_tag)?;
+    let after_tag = &buf[pos + marker_tag.len()..];
+    let rest = after_tag.strip_prefix("__")?;
+    let end = rest.find("__")?;
+    let code: i32 = rest[..end].trim().parse().ok()?;
+    let after_code = &rest[end + 2..];
+    let line = after_code.split(['\n', '\r']).next().unwrap_or("");
+    let cwd = line
+        .strip_suffix("__")
+        .unwrap_or(line)
+        .trim()
+        .to_string();
+    let cwd = if crate::is_safe_cwd(&cwd) {
+        Some(cwd)
+    } else {
+        None
+    };
+    let line_start = buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    Some((code, cwd, line_start))
 }
 
 /// Read events from the reader task until `marker` is found. Used for
@@ -1034,11 +1075,30 @@ mod tests {
         let command = "echo hello";
         let marker_tag = "__FILAR_req_00000001";
         let payload = format!(
-            "{}\nprintf '\\n{}__%d__\\n' \"$?\"\n",
+            "{}\nprintf '\\n{}__%d__%s__\\n' \"$?\" \"$PWD\"\n",
             command, marker_tag
         );
         assert!(payload.contains("echo hello"));
-        assert!(payload.contains("__FILAR_req_00000001__%d__"));
+        assert!(payload.contains("__FILAR_req_00000001__%d__%s__"));
+    }
+
+    #[test]
+    fn parse_marker_with_pwd() {
+        let tag = "__FILAR_req_00000001";
+        let buf = "hello\n__FILAR_req_00000001__0__/tmp/work__\n";
+        let (code, cwd, start) = parse_filar_marker(buf, tag).unwrap();
+        assert_eq!(code, 0);
+        assert_eq!(cwd.as_deref(), Some("/tmp/work"));
+        assert_eq!(&buf[..start], "hello\n");
+    }
+
+    #[test]
+    fn parse_marker_exit_only() {
+        let tag = "__FILAR_req_00000001";
+        let buf = "out\n__FILAR_req_00000001__1__\n";
+        let (code, cwd, _) = parse_filar_marker(buf, tag).unwrap();
+        assert_eq!(code, 1);
+        assert!(cwd.is_none());
     }
 
     /// Integration test — requires a running SSH server.

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -684,27 +684,34 @@ impl SshExecutor {
     fn store_cwd_from(&self, result: &Result<CommandResult>) {
         if let Ok(r) = result {
             if let Some(cwd) = r.cwd.as_deref().filter(|p| crate::is_safe_cwd(p)) {
-                if let Ok(mut g) = self.last_cwd.lock() {
-                    *g = Some(cwd.to_string());
-                }
+                *lock_opt_string(&self.last_cwd) = Some(cwd.to_string());
             }
         }
     }
 
-    /// Prefix `cd … &&` once so the next *user-approved* command lands in `path`.
-    fn take_prefixed_command(&self, command: &str) -> String {
-        let pending = self.pending_cwd.lock().ok().and_then(|mut g| g.take());
+    /// Prefix `cd … &&` if a tab cwd is pending. Does not consume the pending
+    /// value until the command has been dispatched (see [`clear_pending_cwd`]).
+    fn prefixed_command(&self, command: &str) -> String {
+        let pending = lock_opt_string(&self.pending_cwd).clone();
         match pending.as_deref().and_then(crate::posix_cd_command) {
             Some(cd) => format!("{cd} && {command}"),
             None => command.to_string(),
         }
     }
+
+    fn clear_pending_cwd(&self) {
+        *lock_opt_string(&self.pending_cwd) = None;
+    }
+}
+
+fn lock_opt_string(m: &StdMutex<Option<String>>) -> std::sync::MutexGuard<'_, Option<String>> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 #[async_trait::async_trait]
 impl crate::CommandExecutor for SshExecutor {
     async fn run(&self, command: &str) -> Result<CommandResult> {
-        let command = self.take_prefixed_command(command);
+        let command = self.prefixed_command(command);
         // First attempt on the current session.
         let first = { self.session.read().await.run(&command).await };
 
@@ -715,6 +722,9 @@ impl crate::CommandExecutor for SshExecutor {
         let should_reconnect =
             self.config.auto_reconnect && matches!(first, Err(CoreError::ConnectionLost(_)));
         if !should_reconnect {
+            if !matches!(first, Err(CoreError::ConnectionLost(_))) {
+                self.clear_pending_cwd();
+            }
             self.store_cwd_from(&first);
             return first;
         }
@@ -755,6 +765,9 @@ impl crate::CommandExecutor for SshExecutor {
 
         // Single retry on the fresh session.
         let retry = self.session.read().await.run(&command).await;
+        if !matches!(retry, Err(CoreError::ConnectionLost(_))) {
+            self.clear_pending_cwd();
+        }
         self.store_cwd_from(&retry);
         retry
     }
@@ -767,17 +780,13 @@ impl crate::CommandExecutor for SshExecutor {
         let _ = crate::posix_cd_command(path)
             .ok_or_else(|| CoreError::Other("invalid cwd".into()))?;
         let path = path.trim().to_string();
-        if let Ok(mut g) = self.pending_cwd.lock() {
-            *g = Some(path.clone());
-        }
-        if let Ok(mut g) = self.last_cwd.lock() {
-            *g = Some(path);
-        }
+        *lock_opt_string(&self.pending_cwd) = Some(path.clone());
+        *lock_opt_string(&self.last_cwd) = Some(path);
         Ok(())
     }
 
     async fn current_cwd(&self) -> Option<String> {
-        self.last_cwd.lock().ok().and_then(|g| g.clone())
+        self.last_cwd.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 }
 
@@ -1007,7 +1016,8 @@ async fn recv_until_marker(
 
 /// Parse `<marker_tag>__<exit>__` or `<marker_tag>__<exit>__<pwd>__`.
 ///
-/// `pwd` is accepted only when the line is exactly `<pwd>__` (no `__` inside).
+/// `pwd` is the text before the last `__` on the marker line (so names like
+/// `my__project` still parse).
 fn parse_filar_marker(buf: &str, marker_tag: &str) -> Option<(i32, Option<String>, usize)> {
     let pos = buf.find(marker_tag)?;
     let after_tag = &buf[pos + marker_tag.len()..];
@@ -1017,7 +1027,7 @@ fn parse_filar_marker(buf: &str, marker_tag: &str) -> Option<(i32, Option<String
     let after_code = &rest[end + 2..];
     let line = after_code.split(['\n', '\r']).next().unwrap_or("");
     let cwd = line.strip_suffix("__").map(str::trim).and_then(|pwd| {
-        if crate::is_safe_cwd(pwd) && !pwd.contains("__") {
+        if crate::is_safe_cwd(pwd) {
             Some(pwd.to_string())
         } else {
             None
@@ -1109,12 +1119,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_marker_rejects_pwd_with_double_underscore() {
+    fn parse_marker_pwd_allows_double_underscore_in_name() {
         let tag = "__FILAR_req_00000001";
-        let buf = "out\n__FILAR_req_00000001__0__/tmp__evil__\n";
+        let buf = "out\n__FILAR_req_00000001__0__/home/u/my__project__\n";
         let (code, cwd, _) = parse_filar_marker(buf, tag).unwrap();
         assert_eq!(code, 0);
-        assert!(cwd.is_none());
+        assert_eq!(cwd.as_deref(), Some("/home/u/my__project"));
     }
 
     /// Integration test — requires a running SSH server.

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -630,6 +630,8 @@ pub struct SshExecutor {
     secrets: Arc<dyn SecretProvider>,
     /// Last `$PWD` reported by the command marker (or [`set_cwd`]).
     last_cwd: StdMutex<Option<String>>,
+    /// Applied once as `cd … &&` on the next [`run`] (user-approved command).
+    pending_cwd: StdMutex<Option<String>>,
 }
 
 impl SshExecutor {
@@ -670,6 +672,7 @@ impl SshExecutor {
             config,
             secrets,
             last_cwd: StdMutex::new(None),
+            pending_cwd: StdMutex::new(None),
         })
     }
 
@@ -687,13 +690,23 @@ impl SshExecutor {
             }
         }
     }
+
+    /// Prefix `cd … &&` once so the next *user-approved* command lands in `path`.
+    fn take_prefixed_command(&self, command: &str) -> String {
+        let pending = self.pending_cwd.lock().ok().and_then(|mut g| g.take());
+        match pending.as_deref().and_then(crate::posix_cd_command) {
+            Some(cd) => format!("{cd} && {command}"),
+            None => command.to_string(),
+        }
+    }
 }
 
 #[async_trait::async_trait]
 impl crate::CommandExecutor for SshExecutor {
     async fn run(&self, command: &str) -> Result<CommandResult> {
+        let command = self.take_prefixed_command(command);
         // First attempt on the current session.
-        let first = { self.session.read().await.run(command).await };
+        let first = { self.session.read().await.run(&command).await };
 
         // Reconnect only when the connection was lost *before* the command was
         // dispatched (the `ConnectionLost` variant). A command that may have
@@ -741,7 +754,7 @@ impl crate::CommandExecutor for SshExecutor {
         );
 
         // Single retry on the fresh session.
-        let retry = self.session.read().await.run(command).await;
+        let retry = self.session.read().await.run(&command).await;
         self.store_cwd_from(&retry);
         retry
     }
@@ -751,17 +764,14 @@ impl crate::CommandExecutor for SshExecutor {
     }
 
     async fn set_cwd(&self, path: &str) -> Result<()> {
-        let cmd = crate::posix_cd_command(path)
+        let _ = crate::posix_cd_command(path)
             .ok_or_else(|| CoreError::Other("invalid cwd".into()))?;
-        let result = self.run(&cmd).await?;
-        if result.exit_code.unwrap_or(-1) != 0 {
-            return Err(CoreError::Other(format!(
-                "cd failed with exit {}",
-                result.exit_code.unwrap_or(-1)
-            )));
+        let path = path.trim().to_string();
+        if let Ok(mut g) = self.pending_cwd.lock() {
+            *g = Some(path.clone());
         }
         if let Ok(mut g) = self.last_cwd.lock() {
-            *g = Some(path.trim().to_string());
+            *g = Some(path);
         }
         Ok(())
     }
@@ -997,7 +1007,7 @@ async fn recv_until_marker(
 
 /// Parse `<marker_tag>__<exit>__` or `<marker_tag>__<exit>__<pwd>__`.
 ///
-/// Returns `(exit_code, cwd, start_of_marker_line)`.
+/// `pwd` is accepted only when the line is exactly `<pwd>__` (no `__` inside).
 fn parse_filar_marker(buf: &str, marker_tag: &str) -> Option<(i32, Option<String>, usize)> {
     let pos = buf.find(marker_tag)?;
     let after_tag = &buf[pos + marker_tag.len()..];
@@ -1006,16 +1016,13 @@ fn parse_filar_marker(buf: &str, marker_tag: &str) -> Option<(i32, Option<String
     let code: i32 = rest[..end].trim().parse().ok()?;
     let after_code = &rest[end + 2..];
     let line = after_code.split(['\n', '\r']).next().unwrap_or("");
-    let cwd = line
-        .strip_suffix("__")
-        .unwrap_or(line)
-        .trim()
-        .to_string();
-    let cwd = if crate::is_safe_cwd(&cwd) {
-        Some(cwd)
-    } else {
-        None
-    };
+    let cwd = line.strip_suffix("__").map(str::trim).and_then(|pwd| {
+        if crate::is_safe_cwd(pwd) && !pwd.contains("__") {
+            Some(pwd.to_string())
+        } else {
+            None
+        }
+    });
     let line_start = buf[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
     Some((code, cwd, line_start))
 }
@@ -1098,6 +1105,15 @@ mod tests {
         let buf = "out\n__FILAR_req_00000001__1__\n";
         let (code, cwd, _) = parse_filar_marker(buf, tag).unwrap();
         assert_eq!(code, 1);
+        assert!(cwd.is_none());
+    }
+
+    #[test]
+    fn parse_marker_rejects_pwd_with_double_underscore() {
+        let tag = "__FILAR_req_00000001";
+        let buf = "out\n__FILAR_req_00000001__0__/tmp__evil__\n";
+        let (code, cwd, _) = parse_filar_marker(buf, tag).unwrap();
+        assert_eq!(code, 0);
         assert!(cwd.is_none());
     }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -362,8 +362,9 @@ pub struct Session {
     /// Set when `!ssh` succeeds for this tab. Used for display and system prompt.
     pub ssh_info: Option<String>,
     /// Last known working directory for the status bar (`None` = unknown).
-    /// Local tabs start from the process cwd; SSH is filled from OSC 7
-    /// (interactive PTY). Agent↔interactive sync of this value is #313.
+    /// Local tabs start from the process cwd; SSH is filled from OSC 7,
+    /// a POSIX `pwd` probe on Ctrl+T leave, or the SSH command marker `$PWD`.
+    /// Agent↔interactive sync applies this value via `CommandExecutor::set_cwd`.
     pub cwd: Option<String>,
     /// LLM profile selected via Ctrl+L. None = use App default.
     pub llm_profile: Option<String>,

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -20,8 +20,8 @@ use tracing::{error, info, warn};
 use filar_agent::{AgentBuilder, CommandConfirmer, LlmClient};
 use filar_core::{CommandConfirmMode, CoreError, Result, SecretProvider, StaticSecretProvider};
 use filar_transport::{
-    CommandExecutor, InteractiveTerminal, LocalInteractive, SecretSubstitutingExecutor,
-    SshExecutor, SshInteractive, SshTransportConfig,
+    posix_cd_input, CommandExecutor, InteractiveTerminal, LocalInteractive,
+    SecretSubstitutingExecutor, SshExecutor, SshInteractive, SshTransportConfig, OSC7_PWD_PROBE,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -91,6 +91,36 @@ fn route_term_chunk(app: &mut App, sid: SessionId, chunk: TermChunk) -> RouteOut
     }
 }
 
+/// Drain PTY output until `session.cwd` is set or `timeout` elapses.
+async fn drain_pty_cwd(
+    app: &mut App,
+    sid: SessionId,
+    term_rx: &mut Option<mpsc::UnboundedReceiver<(SessionId, TermChunk)>>,
+    timeout: Duration,
+) {
+    let Some(rx) = term_rx.as_mut() else {
+        return;
+    };
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Ok(Some((chunk_sid, chunk))) => {
+                let _ = route_term_chunk(app, chunk_sid, chunk);
+                if app
+                    .sessions
+                    .iter()
+                    .find(|s| s.id == sid)
+                    .and_then(|s| s.cwd.as_ref())
+                    .is_some()
+                {
+                    return;
+                }
+            }
+            _ => return,
+        }
+    }
+}
+
 use filar_core::ChatBlock;
 
 // ---------------------------------------------------------------------------
@@ -125,6 +155,16 @@ impl CommandExecutor for TuiExecutor {
     async fn cancel(&self) -> Result<()> {
         let executor = self.inner.read().await.clone();
         executor.cancel().await
+    }
+
+    async fn set_cwd(&self, path: &str) -> Result<()> {
+        let executor = self.inner.read().await.clone();
+        executor.set_cwd(path).await
+    }
+
+    async fn current_cwd(&self) -> Option<String> {
+        let executor = self.inner.read().await.clone();
+        executor.current_cwd().await
     }
 }
 
@@ -626,8 +666,41 @@ async fn run_app(
                 if app.take_toggle_interactive() {
                     let toggle_sid = app.sessions[app.active].id;
                     if in_interactive {
-                        // Exit interactive mode — close backend, abort reader.
+                        // Exit interactive: capture PTY cwd, apply it to the
+                        // agent executor, then close the backend.
                         if let Some((term, handle)) = interactive_backends.remove(&toggle_sid) {
+                            let is_ssh = match executors.get(&toggle_sid) {
+                                Some(e) => e.ssh_target.read().await.is_some(),
+                                None => false,
+                            };
+                            let cwd_known = app
+                                .sessions
+                                .iter()
+                                .find(|s| s.id == toggle_sid)
+                                .and_then(|s| s.cwd.as_ref())
+                                .is_some();
+                            if !cwd_known && (is_ssh || cfg!(unix)) {
+                                let _ = term.write_input(OSC7_PWD_PROBE).await;
+                                drain_pty_cwd(
+                                    &mut app,
+                                    toggle_sid,
+                                    &mut term_rx_opt,
+                                    Duration::from_millis(400),
+                                )
+                                .await;
+                            }
+                            if let Some(cwd) = app
+                                .sessions
+                                .iter()
+                                .find(|s| s.id == toggle_sid)
+                                .and_then(|s| s.cwd.clone())
+                            {
+                                if let Some(entry) = executors.get(&toggle_sid) {
+                                    if let Err(e) = entry.executor.set_cwd(&cwd).await {
+                                        warn!(error = %e, "failed to sync executor cwd");
+                                    }
+                                }
+                            }
                             let _ = term.close().await;
                             handle.abort();
                         }
@@ -647,18 +720,39 @@ async fn run_app(
                             Some(g) => g.read().await.clone(),
                             None => None,
                         };
+                        let mut tab_cwd = app
+                            .sessions
+                            .iter()
+                            .find(|s| s.id == toggle_sid)
+                            .and_then(|s| s.cwd.clone());
+                        if tab_cwd.is_none() {
+                            if let Some(entry) = executors.get(&toggle_sid) {
+                                tab_cwd = entry.executor.current_cwd().await;
+                                if let Some(ref c) = tab_cwd {
+                                    if let Some(idx) = app.find_session_idx(toggle_sid) {
+                                        app.sessions[idx].cwd = Some(c.clone());
+                                    }
+                                }
+                            }
+                        }
                         let term_result: Result<Arc<dyn InteractiveTerminal>> =
                             if let Some(ref target) = ssh_target {
                                 SshInteractive::connect(target, cols, rows)
                                     .await
                                     .map(|t| Arc::new(t) as Arc<dyn InteractiveTerminal>)
                             } else {
-                                LocalInteractive::with_size(cols, rows)
+                                LocalInteractive::with_size_in(cols, rows, tab_cwd.as_deref())
                                     .await
                                     .map(|t| Arc::new(t) as Arc<dyn InteractiveTerminal>)
                             };
                         match term_result {
                             Ok(term) => {
+                                if ssh_target.is_some() {
+                                    if let Some(input) = tab_cwd.as_deref().and_then(posix_cd_input)
+                                    {
+                                        let _ = term.write_input(input.as_bytes()).await;
+                                    }
+                                }
                                 let model = TerminalModel::new(cols, rows);
                                 let term_for_read = term.clone();
                                 let sid = toggle_sid;
@@ -1140,8 +1234,21 @@ async fn run_app(
                                     .ok()
                                     .map(|p| p.display().to_string());
                             } else {
-                                // Unknown until OSC 7 / #313 — no unconfirmed remote `pwd`.
+                                // Unknown until OSC 7 / command marker / #313 sync.
                                 app.sessions[idx].cwd = None;
+                            }
+                        }
+                    }
+                    if let TuiEvent::Agent {
+                        session_id,
+                        event: filar_agent::AgentEvent::CommandFinished { denied: false, .. },
+                    } = &event
+                    {
+                        if let Some(entry) = executors.get(session_id) {
+                            if let Some(cwd) = entry.executor.current_cwd().await {
+                                if let Some(idx) = app.find_session_idx(*session_id) {
+                                    app.sessions[idx].cwd = Some(cwd);
+                                }
                             }
                         }
                     }

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -11,7 +11,7 @@ Add findings here whenever a platform difference is discovered.
 | macOS Ctrl vs ⌘, Fn+F1 | [macOS shortcuts](#macos-shortcuts) | #292 |
 | Windows console missing `⌘` glyph | [TUI help overlay glyphs](#tui-help-overlay-glyphs) | #310 |
 | GUI launcher paste / show password | [GUI launcher secrets](#gui-launcher-secrets-macos) | #312 |
-| Interactive PTY shell | [Local interactive shell](#local-interactive-shell-ctrlt) | #293 |
+| Interactive PTY shell | [Local interactive shell](#local-interactive-shell-ctrlt) | #293, #313 |
 | Release assets / packaging | [Release binaries (CI)](#release-binaries-ci) | #289, #297, #80 |
 
 ## Clipboard
@@ -224,4 +224,10 @@ and `logs/` all share this single app root.
 > Agent command execution (`LocalExecutor`) is separate: Unix still uses
 > `sh -c`, Windows PowerShell. Only the interactive PTY follows `$SHELL`
 > ([#293](https://github.com/devlawey/filar/issues/293)).
+>
+> Cwd sync (#313): on Unix/macOS and on SSH (POSIX remote), leaving
+> interactive can emit OSC 7 via `printf`/`pwd` if the shell did not.
+> Windows **local** interactive is `cmd.exe`, which typically does not
+> emit OSC 7; leave-sync then uses the last known tab cwd only. Entering
+> interactive still spawns `cmd.exe` with `CommandBuilder::cwd`.
 


### PR DESCRIPTION
Closes #313

## Summary
- Leaving interactive (Ctrl+T) applies the PTY working directory to the tab executor via `CommandExecutor::set_cwd` (local: `current_dir` on the next subprocess; SSH: `cd` on the persistent shell).
- Entering interactive starts the local PTY in that cwd; SSH PTY gets a quoted `cd` after connect.
- Status-bar pwd updates from OSC 7, a POSIX leave-probe (`printf` OSC 7 from `$(pwd)` — no remote files), and `$PWD` in the existing SSH command marker (not a separate unconfirmed `pwd`).

## Tests
- `cargo test --workspace` — green
- New: `posix_shell_quote` / `is_safe_cwd`, SSH marker parse with/without pwd, `LocalExecutor::set_cwd` used by the next `run`
- `#[ignore]` docker-sshd not run

## Manual smoke
1. Local: Ctrl+T, `cd` to a dir, Ctrl+T back; next agent `pwd` / `Get-Location` is that dir; status bar matches.
2. SSH: same; also `cd` in agent (approved), Ctrl+T — PTY starts there.
3. Zero-install: no new files on the remote.

## Notes
- Windows **local** interactive is `cmd.exe` (usually no OSC 7); leave-sync then uses last known cwd. Documented in PLATFORM_NOTES.
- `set_cwd` is transport bookkeeping for a user Ctrl+T, not an LLM tool — it does not go through the confirm dialog.