### PR TITLE
feat(llm): support keyless local OpenAI-compatible profiles (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Added
+
+- Local / air-gapped OpenAI-compatible models: empty `key_env` means keyless
+  (no `Authorization` header); GUI hints for ollama URL and keyless status;
+  clearer tool-calling and LLM timeout errors; README section
+  ([#320](https://github.com/devlawey/filar/issues/320)).
+
 ## [1.0.1] - 2026-08-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 ### Added
 
 - Local / air-gapped OpenAI-compatible models: empty `key_env` means keyless
-  (no `Authorization` header); GUI hints for ollama URL and keyless status;
-  clearer tool-calling and LLM timeout errors; README section
+  (no `Authorization` header; redirects disabled); GUI hints for ollama URL and
+  keyless status; clearer tool-calling and LLM timeout errors; README section
   ([#320](https://github.com/devlawey/filar/issues/320)).
 
 ## [1.0.1] - 2026-08-19

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4847,10 +4847,16 @@ Non-empty `key_env` with missing secret keeps the previous error.
   multiple empty `key_env` allowed in `deduplicate_profiles`.
 - Tools-unsupported HTTP bodies → clear user error (no text-tool emulation).
 - LLM timeout message hints raising `[timeouts].llm_secs` for local models.
-- Status bar: do not show `$0.0000` when cost is zero; toks dash unchanged.
+- Status bar: `Some(0.0)` cost shows `—` (not `$0.00`); absent cost stays unlabeled.
 - README: local/air-gapped section (data stays on endpoint; tools; timeouts; no compression yet).
+- Keyless HTTP client: `redirect::Policy::none()` so bodies are not followed off-host.
+- Tools-unsupported heuristic only on 4xx (not 429/5xx) so retries stay intact.
 
-**Not in scope / deferred:** per-profile `llm_secs`; context compression (document only).
+**Manual smoke (deferred):** ollama had no models pulled; after pull — keyless profile
+chat + tool confirm + `Ctrl+L` local↔cloud; cloud profile with missing key still errors;
+README Ollama row marked pending until then.
 
-**Public API:** `LlmProfile::requires_api_key`, `OpenAiCompatClient::sends_authorization`,
-`check_profile_api_key` (app).
+**Not in scope / deferred:** per-profile `llm_secs`; context compression (document only);
+clearing GUI in-memory `api_key` field when keyless (keyring already skipped).
+
+**Public API:** `LlmProfile::requires_api_key`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4828,3 +4828,29 @@ secret paste sanitization and show toggles (#312); agent<->interactive cwd sync
 
 **Engine tag:** engine-v1.0.1 required (core/transport/agent changed in this
 release).
+
+## Issue #320: feat(llm) — local / air-gapped OpenAI-compatible models
+
+**Milestone:** 1.0.2. **Branch:** `feat/320-local-models`.
+
+**Problem:** Local servers (ollama, vLLM, LM Studio) need no API key, but
+`build_llm_client_from_profile` / `key_checker` / launch path rejected empty
+keys; some servers also reject empty `Authorization`.
+
+**Design:** Empty `key_env` is the explicit keyless marker (`LlmProfile::requires_api_key`).
+Non-empty `key_env` with missing secret keeps the previous error.
+
+**Done:**
+- `build_llm_client_from_profile` + `check_profile_api_key` + GUI/CLI launch
+  allow keyless profiles; `OpenAiCompatClient` skips bearer auth when key empty.
+- GUI: API URL hint, Key env hint, banner when keyless; no secret save under empty env;
+  multiple empty `key_env` allowed in `deduplicate_profiles`.
+- Tools-unsupported HTTP bodies → clear user error (no text-tool emulation).
+- LLM timeout message hints raising `[timeouts].llm_secs` for local models.
+- Status bar: do not show `$0.0000` when cost is zero; toks dash unchanged.
+- README: local/air-gapped section (data stays on endpoint; tools; timeouts; no compression yet).
+
+**Not in scope / deferred:** per-profile `llm_secs`; context compression (document only).
+
+**Public API:** `LlmProfile::requires_api_key`, `OpenAiCompatClient::sends_authorization`,
+`check_profile_api_key` (app).

--- a/README.md
+++ b/README.md
@@ -251,24 +251,69 @@ agent client is not GLM-specific. You switch providers by changing only the
 config (`model`, `api_base_url`, and the API key env var).
 
 The default profile points at the GLM cloud (`open.bigmodel.cn`,
-`GLM_API_KEY`). To use a local model (Ollama / LM Studio) or another cloud
-provider, point `api_base_url` at its OpenAI-compatible base URL and supply
-the key its API expects (local servers usually accept any non-empty string):
+`GLM_API_KEY`).
+
+### Local / air-gapped models (ollama, vLLM, LM Studio, …)
+
+Closed networks and air-gapped setups can point filar at a **local**
+OpenAI-compatible server. **Request data stays on that endpoint** — nothing is
+sent to a public cloud when `api_base_url` is local or internal.
+
+1. Run a server that exposes `/v1/chat/completions` (example: ollama).
+2. Create a profile with:
+   - **API URL** such as `http://localhost:11434/v1` (hint in the GUI)
+   - **Key env left empty** — that is the explicit “no API key” marker
+   - **API key** empty
+3. Launch. `Ctrl+L` can switch between local and cloud profiles.
+
+```toml
+[[llm_profiles]]
+name = "ollama"
+model = "llama3.1"
+api_base_url = "http://localhost:11434/v1"
+max_tokens = 4096
+key_env = ""          # empty = keyless; Authorization header is not sent
+temperature = 0.3
+```
+
+**Tool calling required.** The agent loop needs models that support
+OpenAI-style tools/`function` calling. Without it, filar cannot run commands
+and shows a clear error — it does **not** fake tools by parsing free text.
+
+**Timeouts.** Local CPU generation is often slower than cloud. Raise
+`[timeouts].llm_secs` in `config.toml` (default `60`) if requests time out.
+The timeout applies to every profile (including local).
+
+**Context window.** Automatic context compression is not implemented yet.
+Local models usually have smaller windows (8k–32k); keep sessions short or
+trim history manually until compression lands.
+
+**Usage / cost.** Local servers often omit `usage`; the status bar shows
+`toks: —` and no `$0.00` placeholder.
+
+### Cloud / other providers
+
+Point `api_base_url` at the provider and set a non-empty `key_env` (key via
+env or OS credential store / GUI):
 
 ```toml
 [llm]
 model = "llama3.1"
 api_base_url = "http://localhost:11434/v1"
 max_tokens = 4096
-temperature = 0.3          # local models benefit from lower temperature
+temperature = 0.3
 ```
+
+> Prefer a named `[[llm_profiles]]` with `key_env = ""` for local keyless use;
+> the default `[llm]` block still expects `GLM_API_KEY` unless you select a
+> keyless profile.
 
 ### Verified providers
 
 | Provider | Endpoint | Tool calling | Streaming | Notes |
 |----------|----------|--------------|-----------|-------|
 | GLM cloud | `https://open.bigmodel.cn/api/paas/v4` | verified | verified | Default profile; key via `GLM_API_KEY`. |
-| Ollama (local) | `http://localhost:11434/v1` | pending manual check | pending manual check | OpenAI-compatible; set a non-empty key. |
+| Ollama (local) | `http://localhost:11434/v1` | depends on model | depends on model | Use empty `key_env`; pick a model with tool support. |
 
 > The table lists only what has been checked by hand. Add rows as more
 > providers are verified (including via the eval tasks of milestone v0.4.0).

--- a/README.md
+++ b/README.md
@@ -297,23 +297,23 @@ Point `api_base_url` at the provider and set a non-empty `key_env` (key via
 env or OS credential store / GUI):
 
 ```toml
-[llm]
-model = "llama3.1"
-api_base_url = "http://localhost:11434/v1"
+[[llm_profiles]]
+name = "glm"
+model = "glm-5.1"
+api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 max_tokens = 4096
-temperature = 0.3
+key_env = "GLM_API_KEY"
 ```
 
-> Prefer a named `[[llm_profiles]]` with `key_env = ""` for local keyless use;
-> the default `[llm]` block still expects `GLM_API_KEY` unless you select a
-> keyless profile.
+> For local keyless use, prefer `key_env = ""` (see above). The default `[llm]`
+> block still expects `GLM_API_KEY` unless you select a keyless profile.
 
 ### Verified providers
 
 | Provider | Endpoint | Tool calling | Streaming | Notes |
 |----------|----------|--------------|-----------|-------|
 | GLM cloud | `https://open.bigmodel.cn/api/paas/v4` | verified | verified | Default profile; key via `GLM_API_KEY`. |
-| Ollama (local) | `http://localhost:11434/v1` | depends on model | depends on model | Use empty `key_env`; pick a model with tool support. |
+| Ollama (local) | `http://localhost:11434/v1` | pending manual check | pending manual check | Use empty `key_env`; pick a model with tool support. |
 
 > The table lists only what has been checked by hand. Add rows as more
 > providers are verified (including via the eval tasks of milestone v0.4.0).

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -12,6 +12,7 @@
 //! - Configurable model, base URL, and max tokens (from [`filar_core::LlmConfig`]).
 //! - API key read from the `GLM_API_KEY` environment variable by default
 //!   (overridable per profile via `filar_core::LlmProfile::key_env`).
+//!   Empty `key_env` = keyless local profile: no `Authorization` header.
 //! - Retries with exponential backoff on transient failures (5xx, 429, network).
 //! - Request timeout.
 //! - Tool calling (function calling) support.
@@ -119,6 +120,26 @@ impl OpenAiCompatClient {
     /// Build the full API endpoint URL.
     fn endpoint(&self) -> String {
         format!("{}/chat/completions", self.api_base_url)
+    }
+
+    /// Whether outbound requests will include an `Authorization` header.
+    ///
+    /// Keyless local profiles use an empty API key; a bearer header must not
+    /// be sent — some local servers reject empty/garbage auth.
+    pub fn sends_authorization(&self) -> bool {
+        !self.api_key.is_empty()
+    }
+
+    /// Attach bearer auth only when a key is present.
+    fn apply_auth(
+        &self,
+        builder: reqwest::RequestBuilder,
+    ) -> reqwest::RequestBuilder {
+        if self.sends_authorization() {
+            builder.bearer_auth(&self.api_key)
+        } else {
+            builder
+        }
     }
 }
 
@@ -282,9 +303,7 @@ impl OpenAiCompatClient {
     /// Send a single request to the API and return the raw response.
     async fn send_request(&self, body: &serde_json::Value) -> std::result::Result<ApiResponse, ApiError> {
         let response = self
-            .http
-            .post(self.endpoint())
-            .bearer_auth(&self.api_key)
+            .apply_auth(self.http.post(self.endpoint()))
             .json(body)
             .send()
             .await
@@ -321,12 +340,7 @@ impl OpenAiCompatClient {
             let status_code = status.as_u16();
             let body_text = response.text().await.unwrap_or_default();
             info!(status_code, body = %body_text, "OpenAI-compatible API returned error status");
-            match status_code {
-                401 | 403 => Err(ApiError::Auth(format!("HTTP {status_code}: {body_text}"))),
-                429 => Err(ApiError::RateLimit(body_text)),
-                500..=599 => Err(ApiError::Server(status_code, body_text)),
-                _ => Err(ApiError::Client(status_code, body_text)),
-            }
+            Err(ApiError::from_http_status(status_code, body_text))
         }
     }
 
@@ -336,9 +350,7 @@ impl OpenAiCompatClient {
         body: &serde_json::Value,
     ) -> std::result::Result<reqwest::Response, ApiError> {
         let response = self
-            .http
-            .post(self.endpoint())
-            .bearer_auth(&self.api_key)
+            .apply_auth(self.http.post(self.endpoint()))
             .json(body)
             .send()
             .await
@@ -360,12 +372,7 @@ impl OpenAiCompatClient {
             let status_code = status.as_u16();
             let body_text = response.text().await.unwrap_or_default();
             info!(status_code, body = %body_text, "OpenAI-compatible API returned error status");
-            match status_code {
-                401 | 403 => Err(ApiError::Auth(format!("HTTP {status_code}: {body_text}"))),
-                429 => Err(ApiError::RateLimit(body_text)),
-                500..=599 => Err(ApiError::Server(status_code, body_text)),
-                _ => Err(ApiError::Client(status_code, body_text)),
-            }
+            Err(ApiError::from_http_status(status_code, body_text))
         }
     }
 }
@@ -390,8 +397,46 @@ enum ApiError {
     Server(u16, String),
     /// Other client error (4xx) — not retryable.
     Client(u16, String),
+    /// Provider rejected tool/function calling — agent loop cannot run.
+    ToolsUnsupported(String),
     /// Failed to parse the response body.
     Parse(String),
+}
+
+impl ApiError {
+    fn from_http_status(status_code: u16, body_text: String) -> Self {
+        if looks_like_tools_unsupported(&body_text) {
+            return ApiError::ToolsUnsupported(body_text);
+        }
+        match status_code {
+            401 | 403 => ApiError::Auth(format!("HTTP {status_code}: {body_text}")),
+            429 => ApiError::RateLimit(body_text),
+            500..=599 => ApiError::Server(status_code, body_text),
+            _ => ApiError::Client(status_code, body_text),
+        }
+    }
+}
+
+/// Heuristic: provider body says the model/server cannot do tool calling.
+fn looks_like_tools_unsupported(body: &str) -> bool {
+    let lower = body.to_lowercase();
+    let mentions_tools = lower.contains("tool")
+        || lower.contains("function call")
+        || lower.contains("function_call")
+        || lower.contains("tools");
+    if !mentions_tools {
+        return false;
+    }
+    lower.contains("not support")
+        || lower.contains("unsupported")
+        || lower.contains("does not support")
+        || lower.contains("doesn't support")
+        || lower.contains("not available")
+        || lower.contains("no support")
+        || lower.contains("unknown field")
+        || lower.contains("unexpected field")
+        || lower.contains("invalid parameter")
+        || lower.contains("is not enabled")
 }
 
 impl std::fmt::Display for ApiError {
@@ -399,11 +444,18 @@ impl std::fmt::Display for ApiError {
         match self {
             ApiError::Connect(msg) => write!(f, "connection error: {msg}"),
             ApiError::Network(msg) => write!(f, "network error: {msg}"),
-            ApiError::Timeout(d) => write!(f, "request timed out after {d:?}"),
+            ApiError::Timeout(d) => write!(
+                f,
+                "request timed out after {d:?}. For local models, increase [timeouts].llm_secs in config.toml (CPU generation is often slower than cloud)"
+            ),
             ApiError::Auth(msg) => write!(f, "authentication error: {msg}"),
             ApiError::RateLimit(msg) => write!(f, "rate limited: {msg}"),
             ApiError::Server(code, msg) => write!(f, "server error {code}: {msg}"),
             ApiError::Client(code, msg) => write!(f, "client error {code}: {msg}"),
+            ApiError::ToolsUnsupported(ref body) => write!(
+                f,
+                "this model does not support tool calling; the agent cannot run commands. Choose a model with tool/function calling support (or a different profile). Provider detail: {body}"
+            ),
             ApiError::Parse(msg) => write!(f, "failed to parse API response: {msg}"),
         }
     }
@@ -423,11 +475,16 @@ impl ApiError {
         match self {
             ApiError::Connect(msg) => CoreError::Other(format!("connection error: {msg}")),
             ApiError::Network(msg) => CoreError::Other(format!("network error: {msg}")),
-            ApiError::Timeout(d) => CoreError::Other(format!("request timed out after {d:?}")),
+            ApiError::Timeout(d) => CoreError::Other(format!(
+                "request timed out after {d:?}. For local models, increase [timeouts].llm_secs in config.toml (CPU generation is often slower than cloud)"
+            )),
             ApiError::Auth(msg) => CoreError::Other(format!("authentication error: {msg}")),
             ApiError::RateLimit(msg) => CoreError::Other(format!("rate limited: {msg}")),
             ApiError::Server(code, msg) => CoreError::Other(format!("server error {code}: {msg}")),
             ApiError::Client(code, msg) => CoreError::Other(format!("client error {code}: {msg}")),
+            ApiError::ToolsUnsupported(body) => CoreError::Other(format!(
+                "this model does not support tool calling; the agent cannot run commands. Choose a model with tool/function calling support (or a different profile). Provider detail: {body}"
+            )),
             ApiError::Parse(msg) => CoreError::Other(format!("failed to parse API response: {msg}")),
         }
     }
@@ -1497,5 +1554,63 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         state.process_chunk("data: [DONE]\n");
         let resp = state.into_response().unwrap();
         assert_eq!(resp.model.as_deref(), Some("cohere/command-r"));
+    }
+
+    #[test]
+    fn empty_api_key_does_not_send_authorization() {
+        let config = LlmConfig {
+            model: "local".into(),
+            api_base_url: "http://localhost:11434/v1".into(),
+            max_tokens: 128,
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        };
+        let client = OpenAiCompatClient::new_with_key(&config, Duration::from_secs(30), "").unwrap();
+        assert!(
+            !client.sends_authorization(),
+            "keyless client must not attach Authorization"
+        );
+    }
+
+    #[test]
+    fn non_empty_api_key_sends_authorization() {
+        let config = LlmConfig {
+            model: "cloud".into(),
+            api_base_url: "https://example.com/v1".into(),
+            max_tokens: 128,
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        };
+        let client =
+            OpenAiCompatClient::new_with_key(&config, Duration::from_secs(30), "sk-test").unwrap();
+        assert!(client.sends_authorization());
+    }
+
+    #[test]
+    fn tools_unsupported_heuristic_matches_common_bodies() {
+        assert!(looks_like_tools_unsupported(
+            r#"{"error":"does not support tools"}"#
+        ));
+        assert!(looks_like_tools_unsupported(
+            "model does not support function calling"
+        ));
+        assert!(!looks_like_tools_unsupported("rate limited, try later"));
+        let err = ApiError::from_http_status(400, "tools are not supported by this model".into());
+        assert!(matches!(err, ApiError::ToolsUnsupported(_)));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not support tool calling"),
+            "user-facing message must be clear, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn timeout_message_hints_local_llm_secs() {
+        let err = ApiError::Timeout(Duration::from_secs(60));
+        let msg = err.to_string();
+        assert!(msg.contains("llm_secs"), "timeout must hint llm_secs: {msg}");
+        assert!(msg.contains("local"), "timeout must mention local models: {msg}");
     }
 }

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -82,9 +82,15 @@ impl OpenAiCompatClient {
     }
 
     /// Create a new `OpenAiCompatClient` with an explicit API key (useful for testing).
+    ///
+    /// When `api_key` is empty (keyless / local profile), HTTP redirects are
+    /// disabled so request bodies cannot be forwarded to another host.
     pub fn new_with_key(config: &LlmConfig, timeout: Duration, api_key: &str) -> Result<Self> {
-        let http = reqwest::Client::builder()
-            .timeout(timeout)
+        let mut builder = reqwest::Client::builder().timeout(timeout);
+        if api_key.is_empty() {
+            builder = builder.redirect(reqwest::redirect::Policy::none());
+        }
+        let http = builder
             .build()
             .map_err(|e| CoreError::Other(format!("failed to build HTTP client: {e}")))?;
 
@@ -123,10 +129,7 @@ impl OpenAiCompatClient {
     }
 
     /// Whether outbound requests will include an `Authorization` header.
-    ///
-    /// Keyless local profiles use an empty API key; a bearer header must not
-    /// be sent — some local servers reject empty/garbage auth.
-    pub fn sends_authorization(&self) -> bool {
+    fn sends_authorization(&self) -> bool {
         !self.api_key.is_empty()
     }
 
@@ -405,7 +408,12 @@ enum ApiError {
 
 impl ApiError {
     fn from_http_status(status_code: u16, body_text: String) -> Self {
-        if looks_like_tools_unsupported(&body_text) {
+        // Only classify tool-calling rejection on non-retryable 4xx (not 429).
+        // Applying the heuristic to 5xx would turn transient failures into
+        // non-retryable ToolsUnsupported.
+        let is_client_4xx = (400..500).contains(&status_code) && status_code != 429;
+        if is_client_4xx && looks_like_tools_unsupported(&body_text) {
+            warn!(status_code, body = %body_text, "provider rejected tool calling");
             return ApiError::ToolsUnsupported(body_text);
         }
         match status_code {
@@ -422,20 +430,14 @@ fn looks_like_tools_unsupported(body: &str) -> bool {
     let lower = body.to_lowercase();
     let mentions_tools = lower.contains("tool")
         || lower.contains("function call")
-        || lower.contains("function_call")
-        || lower.contains("tools");
+        || lower.contains("function_call");
     if !mentions_tools {
         return false;
     }
     lower.contains("not support")
         || lower.contains("unsupported")
-        || lower.contains("does not support")
         || lower.contains("doesn't support")
         || lower.contains("not available")
-        || lower.contains("no support")
-        || lower.contains("unknown field")
-        || lower.contains("unexpected field")
-        || lower.contains("invalid parameter")
         || lower.contains("is not enabled")
 }
 
@@ -446,15 +448,15 @@ impl std::fmt::Display for ApiError {
             ApiError::Network(msg) => write!(f, "network error: {msg}"),
             ApiError::Timeout(d) => write!(
                 f,
-                "request timed out after {d:?}. For local models, increase [timeouts].llm_secs in config.toml (CPU generation is often slower than cloud)"
+                "request timed out after {d:?}. For local models, increase [timeouts].llm_secs in config.toml"
             ),
             ApiError::Auth(msg) => write!(f, "authentication error: {msg}"),
             ApiError::RateLimit(msg) => write!(f, "rate limited: {msg}"),
             ApiError::Server(code, msg) => write!(f, "server error {code}: {msg}"),
             ApiError::Client(code, msg) => write!(f, "client error {code}: {msg}"),
-            ApiError::ToolsUnsupported(ref body) => write!(
+            ApiError::ToolsUnsupported(_) => write!(
                 f,
-                "this model does not support tool calling; the agent cannot run commands. Choose a model with tool/function calling support (or a different profile). Provider detail: {body}"
+                "this model does not support tool calling; the agent cannot run commands. Choose a model with tool/function calling support"
             ),
             ApiError::Parse(msg) => write!(f, "failed to parse API response: {msg}"),
         }
@@ -472,19 +474,16 @@ impl ApiError {
 
     /// Convert to a [`CoreError`] for the final result.
     fn into_core_error(self) -> CoreError {
-        match self {
+        match &self {
+            ApiError::Timeout(_) | ApiError::ToolsUnsupported(_) => {
+                CoreError::Other(self.to_string())
+            }
             ApiError::Connect(msg) => CoreError::Other(format!("connection error: {msg}")),
             ApiError::Network(msg) => CoreError::Other(format!("network error: {msg}")),
-            ApiError::Timeout(d) => CoreError::Other(format!(
-                "request timed out after {d:?}. For local models, increase [timeouts].llm_secs in config.toml (CPU generation is often slower than cloud)"
-            )),
             ApiError::Auth(msg) => CoreError::Other(format!("authentication error: {msg}")),
             ApiError::RateLimit(msg) => CoreError::Other(format!("rate limited: {msg}")),
             ApiError::Server(code, msg) => CoreError::Other(format!("server error {code}: {msg}")),
             ApiError::Client(code, msg) => CoreError::Other(format!("client error {code}: {msg}")),
-            ApiError::ToolsUnsupported(body) => CoreError::Other(format!(
-                "this model does not support tool calling; the agent cannot run commands. Choose a model with tool/function calling support (or a different profile). Provider detail: {body}"
-            )),
             ApiError::Parse(msg) => CoreError::Other(format!("failed to parse API response: {msg}")),
         }
     }
@@ -1567,25 +1566,10 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
             extra_body: None,
         };
         let client = OpenAiCompatClient::new_with_key(&config, Duration::from_secs(30), "").unwrap();
-        assert!(
-            !client.sends_authorization(),
-            "keyless client must not attach Authorization"
-        );
-    }
-
-    #[test]
-    fn non_empty_api_key_sends_authorization() {
-        let config = LlmConfig {
-            model: "cloud".into(),
-            api_base_url: "https://example.com/v1".into(),
-            max_tokens: 128,
-            temperature: None,
-            top_p: None,
-            extra_body: None,
-        };
-        let client =
+        assert!(!client.sends_authorization());
+        let with_key =
             OpenAiCompatClient::new_with_key(&config, Duration::from_secs(30), "sk-test").unwrap();
-        assert!(client.sends_authorization());
+        assert!(with_key.sends_authorization());
     }
 
     #[test]
@@ -1597,6 +1581,9 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
             "model does not support function calling"
         ));
         assert!(!looks_like_tools_unsupported("rate limited, try later"));
+        assert!(!looks_like_tools_unsupported(
+            "invalid parameter: temperature"
+        ));
         let err = ApiError::from_http_status(400, "tools are not supported by this model".into());
         assert!(matches!(err, ApiError::ToolsUnsupported(_)));
         let msg = err.to_string();
@@ -1604,6 +1591,20 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
             msg.contains("does not support tool calling"),
             "user-facing message must be clear, got: {msg}"
         );
+        assert!(
+            !msg.contains("tools are not supported by this model"),
+            "raw provider body must stay in logs, not the user message"
+        );
+        // 5xx with similar wording must stay retryable Server, not ToolsUnsupported.
+        let server = ApiError::from_http_status(
+            503,
+            "tools are not supported by this model".into(),
+        );
+        assert!(matches!(server, ApiError::Server(503, _)));
+        assert!(server.is_retryable());
+        let rate = ApiError::from_http_status(429, "tools not available, retry".into());
+        assert!(matches!(rate, ApiError::RateLimit(_)));
+        assert!(rate.is_retryable());
     }
 
     #[test]
@@ -1611,6 +1612,5 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
         let err = ApiError::Timeout(Duration::from_secs(60));
         let msg = err.to_string();
         assert!(msg.contains("llm_secs"), "timeout must hint llm_secs: {msg}");
-        assert!(msg.contains("local"), "timeout must mention local models: {msg}");
     }
 }

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -401,7 +401,7 @@ enum ApiError {
     /// Other client error (4xx) — not retryable.
     Client(u16, String),
     /// Provider rejected tool/function calling — agent loop cannot run.
-    ToolsUnsupported(String),
+    ToolsUnsupported,
     /// Failed to parse the response body.
     Parse(String),
 }
@@ -414,7 +414,7 @@ impl ApiError {
         let is_client_4xx = (400..500).contains(&status_code) && status_code != 429;
         if is_client_4xx && looks_like_tools_unsupported(&body_text) {
             warn!(status_code, body = %body_text, "provider rejected tool calling");
-            return ApiError::ToolsUnsupported(body_text);
+            return ApiError::ToolsUnsupported;
         }
         match status_code {
             401 | 403 => ApiError::Auth(format!("HTTP {status_code}: {body_text}")),
@@ -454,7 +454,7 @@ impl std::fmt::Display for ApiError {
             ApiError::RateLimit(msg) => write!(f, "rate limited: {msg}"),
             ApiError::Server(code, msg) => write!(f, "server error {code}: {msg}"),
             ApiError::Client(code, msg) => write!(f, "client error {code}: {msg}"),
-            ApiError::ToolsUnsupported(_) => write!(
+            ApiError::ToolsUnsupported => write!(
                 f,
                 "this model does not support tool calling; the agent cannot run commands. Choose a model with tool/function calling support"
             ),
@@ -475,7 +475,7 @@ impl ApiError {
     /// Convert to a [`CoreError`] for the final result.
     fn into_core_error(self) -> CoreError {
         match &self {
-            ApiError::Timeout(_) | ApiError::ToolsUnsupported(_) => {
+            ApiError::Timeout(_) | ApiError::ToolsUnsupported => {
                 CoreError::Other(self.to_string())
             }
             ApiError::Connect(msg) => CoreError::Other(format!("connection error: {msg}")),
@@ -1585,7 +1585,7 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
             "invalid parameter: temperature"
         ));
         let err = ApiError::from_http_status(400, "tools are not supported by this model".into());
-        assert!(matches!(err, ApiError::ToolsUnsupported(_)));
+        assert!(matches!(err, ApiError::ToolsUnsupported));
         let msg = err.to_string();
         assert!(
             msg.contains("does not support tool calling"),

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -206,7 +206,7 @@ pub fn build_llm_client_from_profile(
 ///
 /// Returns `None` when the profile is usable (keyless or key found). Returns
 /// `Some(message)` when a required key is missing.
-pub fn check_profile_api_key(
+fn check_profile_api_key(
     profile: &filar_core::LlmProfile,
     sp: &filar_core::StaticSecretProvider,
 ) -> Option<String> {

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -155,6 +155,10 @@ fn resolve_gui_ssh_target(s: &filar_gui::SshConnection) -> filar_core::SshTarget
 /// (keyring) → environment variable. On first keyring hit, the key is cached in
 /// `sp` to avoid repeated OS credential store calls.
 ///
+/// An **empty** [`LlmProfile::key_env`] means the profile is keyless (local /
+/// air-gapped OpenAI-compatible server): key resolution is skipped and the
+/// client is created without an API key (no `Authorization` header).
+///
 /// This is a free function (not an inline closure) so that it can be
 /// unit-tested independently from `main`.
 pub fn build_llm_client_from_profile(
@@ -162,25 +166,30 @@ pub fn build_llm_client_from_profile(
     sp: &filar_core::StaticSecretProvider,
     llm_timeout_secs: u64,
 ) -> std::result::Result<Arc<dyn LlmClient>, CoreError> {
-    let key = sp.get(&profile.key_env).unwrap_or_default();
-    let key = if key.is_empty() {
-        let keyring = filar_core::KeyringSecretProvider::new();
-        let kr_key = keyring.get(&profile.key_env).ok().unwrap_or_default();
-        if !kr_key.is_empty() {
-            sp.insert(&profile.key_env, &kr_key);
-            kr_key
-        } else {
-            std::env::var(&profile.key_env).unwrap_or_default()
-        }
+    let key = if !profile.requires_api_key() {
+        String::new()
     } else {
+        let key = sp.get(&profile.key_env).unwrap_or_default();
+        let key = if key.is_empty() {
+            let keyring = filar_core::KeyringSecretProvider::new();
+            let kr_key = keyring.get(&profile.key_env).ok().unwrap_or_default();
+            if !kr_key.is_empty() {
+                sp.insert(&profile.key_env, &kr_key);
+                kr_key
+            } else {
+                std::env::var(&profile.key_env).unwrap_or_default()
+            }
+        } else {
+            key
+        };
+        if key.is_empty() {
+            return Err(filar_core::CoreError::Secret(format!(
+                "no API key found for profile {}",
+                profile.name
+            )));
+        }
         key
     };
-    if key.is_empty() {
-        return Err(filar_core::CoreError::Secret(format!(
-            "no API key found for profile {}",
-            profile.name
-        )));
-    }
     let llm_config: filar_core::LlmConfig = profile.into();
     Ok(Arc::new(
         OpenAiCompatClient::new_with_key(
@@ -191,6 +200,42 @@ pub fn build_llm_client_from_profile(
         .inspect_err(|_| warn!("LLM client construction failed"))
         .map_err(|_| filar_core::CoreError::Other("failed to construct LLM client".into()))?,
     ))
+}
+
+/// Check whether an LLM profile has a resolvable API key (for `Ctrl+L`).
+///
+/// Returns `None` when the profile is usable (keyless or key found). Returns
+/// `Some(message)` when a required key is missing.
+pub fn check_profile_api_key(
+    profile: &filar_core::LlmProfile,
+    sp: &filar_core::StaticSecretProvider,
+) -> Option<String> {
+    if !profile.requires_api_key() {
+        return None;
+    }
+    let key = sp.get(&profile.key_env).unwrap_or_default();
+    if !key.is_empty() {
+        return None;
+    }
+    let keyring = filar_core::KeyringSecretProvider::new();
+    match keyring.get(&profile.key_env) {
+        Ok(k) if !k.is_empty() => {
+            sp.insert(&profile.key_env, &k);
+            None
+        }
+        _ => {
+            if std::env::var(&profile.key_env)
+                .map(|v| !v.is_empty())
+                .unwrap_or(false)
+            {
+                return None;
+            }
+            Some(format!(
+                "no API key found (checked memory, OS store, env '{}')",
+                profile.key_env
+            ))
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -308,7 +353,7 @@ async fn run() -> anyhow::Result<()> {
     // ── Determine launch parameters ──────────────────────────────────
     // When no CLI args, check for pending launch from a previous GUI
     // session, or spawn the GUI as a subprocess.
-    let (target_name, session_id, llm_config, api_key, ssh_target, gui_selected_profile, launch_profiles, launch_ssh_targets, launch_save_dir) = if args.is_empty() {
+    let (target_name, session_id, llm_config, api_key, key_env_name, ssh_target, gui_selected_profile, launch_profiles, launch_ssh_targets, launch_save_dir) = if args.is_empty() {
         // Check if the GUI subprocess already saved a launch config.
         let launch = filar_gui::load_pending_launch().or_else(|| {
             // Spawn GUI subprocess.
@@ -374,12 +419,14 @@ async fn run() -> anyhow::Result<()> {
                     resolve_gui_ssh_target(&s)
                 });
 
-                // Read API key from OS credential store using the profile's key_env.
-                let api_key = if launch.api_key.is_empty() {
+                // Empty key_env = keyless local profile (#320): skip keyring lookup.
+                let key_env_name = launch.key_env.clone();
+                let api_key = if key_env_name.trim().is_empty() {
+                    String::new()
+                } else if launch.api_key.is_empty() {
                     let cred = filar_core::KeyringSecretProvider::new();
-                    let key_name = if launch.key_env.is_empty() { "api_key".to_string() } else { launch.key_env.clone() };
-                    cred.get(&key_name)
-                        .inspect_err(|e| tracing::warn!(error = %e, %key_name, "failed to read API key from OS credential store"))
+                    cred.get(&key_env_name)
+                        .inspect_err(|e| tracing::warn!(error = %e, key_name = %key_env_name, "failed to read API key from OS credential store"))
                         .unwrap_or_default()
                 } else {
                     launch.api_key
@@ -390,6 +437,7 @@ async fn run() -> anyhow::Result<()> {
                     launch.session_id,
                     llm_config,
                     api_key,
+                    key_env_name,
                     ssh_target,
                     launch.selected_profile,
                     launch.profiles,
@@ -414,9 +462,13 @@ async fn run() -> anyhow::Result<()> {
         let (llm_config, key_env) = config
             .select_llm(profile_ref)
             .map_err(|e| anyhow::anyhow!(e))?;
-        let key = secrets::api_key(&key_env).map_err(|e| {
-            anyhow::anyhow!("{e}. Set the {key_env} environment variable or use the GUI launcher.")
-        })?;
+        let key = if key_env.trim().is_empty() {
+            String::new()
+        } else {
+            secrets::api_key(&key_env).map_err(|e| {
+                anyhow::anyhow!("{e}. Set the {key_env} environment variable or use the GUI launcher.")
+            })?
+        };
 
         // Look up SSH target from config if not local.
         let ssh_target = if target != "local" {
@@ -425,28 +477,48 @@ async fn run() -> anyhow::Result<()> {
             None
         };
 
-        (target, args.session, llm_config, key, ssh_target, None, config.llm_profiles.clone(), config.ssh_targets.clone(), config.save_dir.clone())
+        (target, args.session, llm_config, key, key_env, ssh_target, None, config.llm_profiles.clone(), config.ssh_targets.clone(), config.save_dir.clone())
     };
 
-    // Validate API key.
-    if api_key.is_empty() {
-        anyhow::bail!("API key is required. Enter it in the GUI launcher or set the GLM_API_KEY environment variable.");
+    // Validate API key unless the profile is explicitly keyless (empty key_env).
+    let requires_key = !key_env_name.trim().is_empty();
+    if api_key.is_empty() && requires_key {
+        anyhow::bail!("API key is required. Enter it in the GUI launcher or set the {key_env_name} environment variable. For local models, clear Key env on the profile.");
     }
 
     // ── Create SecretProvider ──────────────────────────────────────────
     // The StaticSecretProvider holds the API key and will also hold dynamic
     // $FILAR_SECRET_N variables added at runtime (via Ctrl+P in the TUI).
     let secret_provider = Arc::new(StaticSecretProvider::new());
-    secret_provider.insert(secrets::env_vars::GLM_API_KEY, &api_key);
+    if !api_key.is_empty() {
+        let insert_name = if key_env_name.trim().is_empty() {
+            secrets::env_vars::GLM_API_KEY
+        } else {
+            key_env_name.as_str()
+        };
+        secret_provider.insert(insert_name, &api_key);
+        // Keep GLM_API_KEY alias for the initial client when using default name.
+        if insert_name != secrets::env_vars::GLM_API_KEY {
+            secret_provider.insert(secrets::env_vars::GLM_API_KEY, &api_key);
+        }
+    }
 
-    let llm: Arc<dyn LlmClient> = Arc::new(OpenAiCompatClient::new_with_provider(
-        &llm_config,
-        Duration::from_secs(config.timeouts.llm_secs),
-        secrets::env_vars::GLM_API_KEY,
-        &*secret_provider,
-    )?);
+    let llm: Arc<dyn LlmClient> = Arc::new(if api_key.is_empty() {
+        OpenAiCompatClient::new_with_key(
+            &llm_config,
+            Duration::from_secs(config.timeouts.llm_secs),
+            "",
+        )?
+    } else {
+        OpenAiCompatClient::new_with_provider(
+            &llm_config,
+            Duration::from_secs(config.timeouts.llm_secs),
+            secrets::env_vars::GLM_API_KEY,
+            &*secret_provider,
+        )?
+    });
 
-    info!(model = %llm_config.model, "LLM client initialised");
+    info!(model = %llm_config.model, keyless = api_key.is_empty(), "LLM client initialised");
 
     // ── Create executor (local or SSH) ─────────────────────────────────
     let command_timeout = Duration::from_secs(config.timeouts.command_secs);
@@ -530,7 +602,6 @@ async fn run() -> anyhow::Result<()> {
     // ── Launch TUI ─────────────────────────────────────────────────────
     let default_profile_name =
         resolve_startup_profile(&launch_profiles, cli_llm_name.as_deref(), gui_selected_profile.as_deref());
-    let key_checker_provider = secret_provider.clone();
     let tui_config = TuiConfig {
         target_name: target_name.clone(),
         confirm_mode: loaded.confirm_mode.unwrap_or(config.confirm_mode),
@@ -557,23 +628,12 @@ async fn run() -> anyhow::Result<()> {
                 build_llm_client_from_profile(profile, sp, llm_timeout_secs)
             })
         },
-        key_checker: Arc::new(move |profile: &filar_core::LlmProfile| {
-            let key = key_checker_provider.get(&profile.key_env).unwrap_or_default();
-            if !key.is_empty() { return None; }
-            let keyring = filar_core::KeyringSecretProvider::new();
-            match keyring.get(&profile.key_env) {
-                Ok(k) if !k.is_empty() => {
-                    key_checker_provider.insert(&profile.key_env, &k);
-                    None
-                }
-                _ => {
-                    if std::env::var(&profile.key_env).map(|v| !v.is_empty()).unwrap_or(false) {
-                        return None;
-                    }
-                    Some(format!("no API key found (checked memory, OS store, env '{}')", profile.key_env))
-                }
-            }
-        }),
+        key_checker: {
+            let key_checker_provider = secret_provider.clone();
+            Arc::new(move |profile: &filar_core::LlmProfile| {
+                check_profile_api_key(profile, &key_checker_provider)
+            })
+        },
         ssh_targets: launch_ssh_targets,
         save_dir: launch_save_dir,
         command_timeout,
@@ -595,7 +655,9 @@ async fn run() -> anyhow::Result<()> {
 mod tests {
     use filar_core::{LlmProfile, SecretProvider, StaticSecretProvider};
 
-    use super::{build_llm_client_from_profile, resolve_gui_ssh_target};
+    use super::{
+        build_llm_client_from_profile, check_profile_api_key, resolve_gui_ssh_target,
+    };
 
     // ── GUI→TUI SSH keyring handoff (#290) ──────────────────────────────
 
@@ -752,6 +814,66 @@ mod tests {
         };
         let result = build_llm_client_from_profile(&profile, &sp, 60);
         assert!(result.is_err(), "factory must fail when no key is available");
+    }
+
+    #[test]
+    fn factory_empty_key_env_is_keyless_ok() {
+        let sp = StaticSecretProvider::new();
+        let profile = LlmProfile {
+            name: "ollama-local".into(),
+            model: "llama3.1".into(),
+            api_base_url: "http://localhost:11434/v1".into(),
+            max_tokens: 1024,
+            key_env: String::new(),
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        };
+        let result = build_llm_client_from_profile(&profile, &sp, 60);
+        assert!(
+            result.is_ok(),
+            "empty key_env must create a keyless client without error"
+        );
+    }
+
+    #[test]
+    fn key_checker_allows_empty_key_env() {
+        let sp = StaticSecretProvider::new();
+        let profile = LlmProfile {
+            name: "local".into(),
+            model: "m".into(),
+            api_base_url: "http://127.0.0.1:11434/v1".into(),
+            max_tokens: 1024,
+            key_env: String::new(),
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        };
+        assert!(
+            check_profile_api_key(&profile, &sp).is_none(),
+            "key_checker must accept keyless profiles"
+        );
+    }
+
+    #[test]
+    fn key_checker_rejects_missing_key_when_key_env_set() {
+        let sp = StaticSecretProvider::new();
+        let profile = LlmProfile {
+            name: "cloud".into(),
+            model: "m".into(),
+            api_base_url: "https://example.com/v1".into(),
+            max_tokens: 1024,
+            key_env: "FILAR_TEST_MISSING_KEY_ENV_XYZ".into(),
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        };
+        let msg = check_profile_api_key(&profile, &sp);
+        assert!(msg.is_some(), "key_checker must fail when required key is missing");
+        assert!(
+            msg.unwrap().contains("no API key found"),
+            "message must mention missing key"
+        );
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -217,8 +217,12 @@ pub struct LlmProfile {
     /// Maximum number of tokens to generate.
     #[serde(default = "default_max_tokens")]
     pub max_tokens: u32,
-    /// Name of the environment variable holding the API key
+    /// Name of the environment variable / OS credential holding the API key
     /// (default: `"GLM_API_KEY"`).
+    ///
+    /// An **empty** `key_env` is an explicit marker that this profile does not
+    /// require a key (local / air-gapped OpenAI-compatible servers such as
+    /// ollama). A non-empty `key_env` whose secret is missing is still an error.
     #[serde(default = "default_glm_key_env")]
     pub key_env: String,
     /// Sampling temperature (0.0–2.0). `None` = provider default.
@@ -234,6 +238,16 @@ pub struct LlmProfile {
 
 fn default_glm_key_env() -> String {
     "GLM_API_KEY".to_string()
+}
+
+impl LlmProfile {
+    /// Whether this profile requires an API key.
+    ///
+    /// Empty `key_env` means keyless (local / air-gapped). Non-empty means the
+    /// key must be resolved from memory, OS credential store, or the env var.
+    pub fn requires_api_key(&self) -> bool {
+        !self.key_env.trim().is_empty()
+    }
 }
 
 impl From<&LlmProfile> for LlmConfig {

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -169,9 +169,14 @@ fn deduplicate_profiles(profiles: &mut Vec<LlmProfileData>) {
         }
         seen_names.insert(p.name.clone());
     }
-    // Fix key_env collisions: ensure each profile has a unique key_env.
+    // Fix key_env collisions: ensure each *non-empty* key_env is unique.
+    // Empty key_env is allowed on multiple profiles (keyless local servers).
     let mut seen_envs = std::collections::BTreeSet::new();
     for p in profiles.iter_mut() {
+        if p.key_env.trim().is_empty() {
+            p.key_env.clear();
+            continue;
+        }
         let mut env = p.key_env.clone();
         while seen_envs.contains(&env) {
             env = format!("api_key_{env}");
@@ -836,7 +841,14 @@ impl LauncherApp {
             let p = &mut self.profiles[self.selected_profile];
             ui.horizontal(|ui| { ui.label("Name:"); ui.text_edit_singleline(&mut p.name); });
             ui.horizontal(|ui| { ui.label("Model:"); ui.text_edit_singleline(&mut p.model); });
-            ui.horizontal(|ui| { ui.label("API URL:"); ui.text_edit_singleline(&mut p.api_base_url); });
+            ui.horizontal(|ui| {
+                ui.label("API URL:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut p.api_base_url)
+                        .hint_text("e.g. http://localhost:11434/v1")
+                        .desired_width(280.0),
+                );
+            });
             ui.horizontal(|ui| {
                 ui.label("API key:");
                 ui.checkbox(&mut show_api_key, "Show");
@@ -847,7 +859,32 @@ impl LauncherApp {
                     show_api_key,
                 );
             });
-            ui.horizontal(|ui| { ui.label("Key env:"); ui.text_edit_singleline(&mut p.key_env); });
+            ui.horizontal(|ui| {
+                ui.label("Key env:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut p.key_env)
+                        .hint_text("empty = no key (local)")
+                        .desired_width(200.0),
+                );
+            });
+            if p.key_env.trim().is_empty() {
+                let url = if p.api_base_url.trim().is_empty() {
+                    "(set API URL above)".to_string()
+                } else {
+                    p.api_base_url.trim().to_string()
+                };
+                ui.colored_label(
+                    egui::Color32::from_rgb(180, 180, 100),
+                    format!(
+                        "No API key — requests go only to {url} (local / air-gapped)."
+                    ),
+                );
+            } else if p.api_key.trim().is_empty() {
+                ui.colored_label(
+                    egui::Color32::from_rgb(140, 140, 140),
+                    "API key empty: loaded from OS store / env on Launch, or clear Key env for local models.",
+                );
+            }
             ui.horizontal(|ui| { ui.label("Temp:"); ui.text_edit_singleline(&mut p.temperature); });
             ui.label("Extra body (JSON):");
             ui.add(egui::TextEdit::multiline(&mut p.extra_body)
@@ -912,6 +949,12 @@ impl LauncherApp {
             self.validation_error = "Profile name must not be empty.".to_string();
             return;
         }
+        if p.key_env.trim().is_empty() && p.api_base_url.trim().is_empty() {
+            self.validation_error =
+                "Keyless (local) profile needs an API URL (e.g. http://localhost:11434/v1)."
+                    .to_string();
+            return;
+        }
         for (i, other) in self.profiles.iter().enumerate() {
             if i != self.selected_profile && other.name == p.name {
                 self.validation_error = format!("Duplicate profile name: \"{}\". Names must be unique.", p.name);
@@ -962,7 +1005,9 @@ impl LauncherApp {
         settings.save();
         save_config_toml(&settings);
         for prof in &self.profiles {
-            if !prof.api_key.is_empty() { save_secret(&prof.key_env, &prof.api_key); }
+            if !prof.key_env.trim().is_empty() && !prof.api_key.is_empty() {
+                save_secret(&prof.key_env, &prof.api_key);
+            }
         }
         for (i, slot) in self.ssh_slots.iter().enumerate() {
             if slot.save_password && !slot.password.is_empty() { save_secret(&ssh_cred_name(i, &slot.alias), &slot.password); }

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -126,7 +126,7 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
             app.theme.muted(),
         ));
     }
-    if let Some(cost) = app.cost_usd {
+    if let Some(cost) = app.cost_usd.filter(|c| *c > 0.0) {
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             format!("${:.4}", cost),

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -126,12 +126,16 @@ pub(crate) fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
             app.theme.muted(),
         ));
     }
-    if let Some(cost) = app.cost_usd.filter(|c| *c > 0.0) {
+    if let Some(cost) = app.cost_usd {
         spans.push(Span::raw(" "));
-        spans.push(Span::styled(
-            format!("${:.4}", cost),
-            app.theme.success_fg(),
-        ));
+        if cost > 0.0 {
+            spans.push(Span::styled(
+                format!("${:.4}", cost),
+                app.theme.success_fg(),
+            ));
+        } else {
+            spans.push(Span::styled("—", app.theme.muted()));
+        }
     }
     // Model: per-profile served model if known, else configured model with ~ prefix.
     let model_display = if let Some(sm) = served {
@@ -416,6 +420,31 @@ mod tests {
         app.active_session_mut().llm_profile = Some("glm".into());
         let row = render_status_row(&mut app, 120);
         assert!(row.contains("toks: —"), "zero tokens must show dash, got: {row}");
+    }
+
+    #[test]
+    fn status_bar_zero_cost_shows_dash_not_dollar_zero() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.active_session_mut().cost_usd = Some(0.0);
+        let row = render_status_row(&mut app, 120);
+        assert!(!row.contains("$0"), "zero cost must not show $0.00, got: {row}");
+        assert!(row.contains('—'), "zero cost must show dash, got: {row}");
+    }
+
+    #[test]
+    fn status_bar_positive_cost_shows_dollar_amount() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.active_session_mut().cost_usd = Some(0.0123);
+        let row = render_status_row(&mut app, 120);
+        assert!(row.contains("$0.0123"), "positive cost, got: {row}");
+    }
+
+    #[test]
+    fn status_bar_absent_cost_has_no_dollar_or_cost_dash_slot() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.active_session_mut().cost_usd = None;
+        let row = render_status_row(&mut app, 120);
+        assert!(!row.contains('$'), "absent cost must omit $ amount, got: {row}");
     }
 
     #[test]

--- a/docs/ENGINE_API.md
+++ b/docs/ENGINE_API.md
@@ -268,14 +268,26 @@ let config = LlmConfig {
 ### Choosing the API key environment variable
 
 By default the key is read from `GLM_API_KEY`. A profile can override this with
-`key_env` so each provider uses its own variable:
+`key_env` so each provider uses its own variable.
+
+**Empty `key_env`** means the profile is keyless (local / air-gapped servers):
+no key is resolved and the HTTP client does not send `Authorization`.
 
 ```toml
 [[llm_profiles]]
-name = "local"
+name = "ollama"
 model = "llama3.1"
 api_base_url = "http://localhost:11434/v1"
-key_env = "OLLAMA_KEY"          # any name; value just needs to be non-empty
+key_env = ""                    # keyless — no Authorization header
+temperature = 0.3
+```
+
+```toml
+[[llm_profiles]]
+name = "local-with-dummy"
+model = "llama3.1"
+api_base_url = "http://localhost:11434/v1"
+key_env = "OLLAMA_KEY"          # non-empty: key required (env / keyring)
 temperature = 0.3
 ```
 

--- a/docs/ENGINE_API.md
+++ b/docs/ENGINE_API.md
@@ -262,7 +262,7 @@ let config = LlmConfig {
     temperature: Some(0.3),
     ..Default::default()
 };
-// key: any non-empty placeholder for a local server
+// Prefer a [[llm_profiles]] entry with key_env = "" (keyless); do not send a dummy key.
 ```
 
 ### Choosing the API key environment variable
@@ -291,4 +291,4 @@ key_env = "OLLAMA_KEY"          # non-empty: key required (env / keyring)
 temperature = 0.3
 ```
 
-Select it at launch with `--llm local` (or `Config::select_llm(Some("local"))`).
+Select it at launch with `--llm ollama` (or `Config::select_llm(Some("ollama"))`).


### PR DESCRIPTION
## Summary
- **Design:** empty `key_env` is the explicit keyless marker (`LlmProfile::requires_api_key`). Non-empty `key_env` with a missing secret keeps the previous error.
- Keyless profiles skip key resolution in `build_llm_client_from_profile`, `check_profile_api_key` (`Ctrl+L`), and GUI/CLI launch; `OpenAiCompatClient` does **not** send `Authorization` when the key is empty.
- GUI: API URL hint (`http://localhost:11434/v1`), Key env hint, banner that requests go only to the configured URL; multiple empty `key_env` allowed; no keyring write under empty env.
- Clearer errors when the provider rejects tool calling; LLM timeout message hints raising `[timeouts].llm_secs` for local models.
- Status bar: never show `$0.0000` for zero cost (toks dash already correct).
- README + ENGINE_API: local/air-gapped section (data stays on the endpoint; tools required; timeouts; compression not implemented yet).

Closes #320

## Test plan
- [x] `cargo build --workspace` / `cargo test --workspace` green
- [x] New unit tests: empty `key_env` → client OK; non-empty `key_env` without key → error; `sends_authorization() == false` for empty key; `key_checker` accepts keyless; tools-unsupported + timeout message heuristics
- [x] Confirmed these tests **fail on pre-change code** (empty `key_env` previously erred in the factory; auth always used `bearer_auth`)
- [ ] Manual DoD with ollama: server was up (`curl` → 200) but **no models pulled** (`ollama list` empty) — full agent/tool smoke deferred. After `ollama pull <tool-capable-model>`: keyless profile → chat → command confirm → `Ctrl+L` local↔cloud → toks dash; model without tools → clear message
- [ ] Cloud profile with set `key_env` and missing key still errors as before

## Out of scope / notes
- No tool-calling emulation via free-text parsing
- No per-profile `llm_secs` (global `[timeouts].llm_secs` applies; documented)
- Context compression not implemented — documented dependency only
- Did not merge; waiting for review / CodeRabbit


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for keyless local and air-gapped OpenAI-compatible models.
  - Added clearer setup guidance for local models, tool calling, timeouts, and context limits.
  - Added GUI hints and validation for keyless profiles and API URLs.

- **Bug Fixes**
  - Improved errors for unsupported tool calling and local-model timeouts.
  - Zero-cost usage is no longer displayed.
  - Keyless connections no longer send unnecessary authorization headers.

- **Documentation**
  - Expanded provider and engine API documentation, including Ollama configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->