### PR TITLE
fix(tui): confirm modal OOB panic on long commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   include the same guidance
   ([#323](https://github.com/devlawey/filar/issues/323)).
 
+### Fixed
+
+- Confirm modal clamps/truncates oversized commands so long heredocs no longer
+  panic the TUI buffer; `PanicHookGuard` skips `take_hook` while unwinding
+  ([#324](https://github.com/devlawey/filar/issues/324)).
+
 ## [1.0.1] - 2026-08-19
 
 ### Changed

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4878,3 +4878,16 @@ cancel-only long-job path in this PR (options 2/4 deferred).
 
 **Not in scope:** true background job tool, idle-activity timeout, confirm
 cancel-only long runs.
+
+## Issue #324: fix(tui) — confirm modal OOB panic on long commands
+
+**Milestone:** 1.0.2. **Branch:** `fix/324-confirm-modal-oob`.
+
+**Problem:** Huge confirm commands (Modelfile heredoc) made `modal_height` ≫
+terminal → ratatui buffer OOB panic; `PanicHookGuard::drop` then aborted.
+
+**Done:**
+- Clamp modal to chat area; truncate explanation/command with notice; buttons
+  always reserved.
+- `PanicHookGuard::drop` no-ops when `thread::panicking()`.
+- Regression tests with TestBackend + huge command.

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -246,6 +246,11 @@ impl PanicHookGuard {
 
 impl Drop for PanicHookGuard {
     fn drop(&mut self) {
+        // Never call take_hook/set_hook while unwinding — that panics again and
+        // turns a recoverable TUI panic into abort (#324).
+        if std::thread::panicking() {
+            return;
+        }
         // Restore the original panic hook.
         let _ = std::panic::take_hook();
     }

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -231,20 +231,18 @@ fn truncate_to_rows(text: &str, width: usize, max_rows: usize) -> String {
     let mut kept: Vec<String> = Vec::new();
     let mut rows = 0usize;
     let all: Vec<&str> = text.split('\n').collect();
+    let mut dropped = false;
 
-    for (idx, line) in all.iter().enumerate() {
+    for line in &all {
         let line_rows = estimate_wrapped_rows(line, width);
         if rows + line_rows <= max_rows {
             kept.push((*line).to_string());
             rows += line_rows;
-            // If this was the last source line we would be done, but we already
-            // know the full text overflows — so more content follows somehow.
-            // Continue; after the loop we force an ellipsis.
-            let _ = idx;
             continue;
         }
 
         // Current line does not fit as a whole — take a prefix into `remain` rows.
+        dropped = true;
         let remain = max_rows.saturating_sub(rows);
         if remain == 0 {
             break;
@@ -256,9 +254,12 @@ fn truncate_to_rows(text: &str, width: usize, max_rows: usize) -> String {
         return kept.join("\n");
     }
 
-    // All kept lines fit exactly in `max_rows`, but source still had more
-    // (or we broke because remain==0). Force a visible ellipsis.
-    ensure_ellipsis(&mut kept, width, max_rows);
+    // Dropped remaining lines (remain==0 break) — force a visible ellipsis.
+    // Never call this when every source line was kept (that path cannot happen
+    // after the early full-fit return, but guard anyway).
+    if dropped || kept.len() < all.len() {
+        ensure_ellipsis(&mut kept, width, max_rows);
+    }
     if kept.is_empty() {
         "…".to_string()
     } else {
@@ -501,13 +502,9 @@ mod tests {
     }
 
     #[test]
-    fn truncate_leading_empty_lines_respects_budget() {
-        let text = "\n\nABCDEFGHIJKLMNOPQRSTUVWXYZ".repeat(3);
-        let out = truncate_to_rows(&text, 8, 3);
-        assert!(
-            estimate_wrapped_rows(&out, 8) <= 3,
-            "overflow rows: {out:?}"
-        );
-        assert!(out.contains('…') || out == "…");
+    fn truncate_does_not_ellipsis_when_text_fits() {
+        let out = truncate_to_rows("hello\nworld", 20, 5);
+        assert_eq!(out, "hello\nworld");
+        assert!(!out.contains('…'));
     }
 }

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -507,4 +507,15 @@ mod tests {
         assert_eq!(out, "hello\nworld");
         assert!(!out.contains('…'));
     }
+
+    #[test]
+    fn truncate_leading_empty_lines_respects_budget() {
+        let text = format!("{}{}", "\n\n", "ABCDEFGHIJKLMNOPQRSTUVWXYZ".repeat(5));
+        let out = truncate_to_rows(&text, 8, 3);
+        assert!(
+            estimate_wrapped_rows(&out, 8) <= 3,
+            "overflow rows: {out:?}"
+        );
+        assert!(out.contains('…') || out == "…");
+    }
 }

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -12,6 +12,9 @@
 //! Mouse clicks on a button activate it directly; hover highlights the button
 //! (underline) without changing the selection — Enter always activates the
 //! keyboard-selected button, preserving the safety default.
+//!
+//! Long commands/explanations are truncated so the modal never exceeds the
+//! available area (avoids ratatui buffer OOB panics — #324).
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -21,74 +24,86 @@ use ratatui::Frame;
 
 use crate::app::App;
 
+/// Minimum modal height: top/bottom borders + one content row + buttons.
+const MIN_MODAL_HEIGHT: u16 = 4;
+
 /// Render the confirmation modal centered over `area` (typically the chat area).
 ///
 /// Stores button rectangles in [`App::confirm_button_areas`] for hit-testing.
+/// The modal is always clamped to `area`; oversized commands are truncated with
+/// a visible notice so Approve/Deny remain on-screen.
 pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     // Clear previous button areas (populated during this render).
     // NOTE: hovered_button is NOT cleared here — it is transient state set by
     // mouse Moved events and must persist across renders for hover styling.
     app.confirm_button_areas.clear();
 
+    if area.width < 32 || area.height < MIN_MODAL_HEIGHT {
+        return;
+    }
+
     let Some(confirm) = &app.pending_confirm else {
         return;
     };
 
-    // --- Build content lines (everything except buttons) ---
-    let mut lines: Vec<Line> = Vec::new();
-
-    if !confirm.explanation.is_empty() {
-        lines.push(Line::from(Span::styled(
-            confirm.explanation.as_str(),
-            app.theme.fg_style(),
-        )));
-    }
-
-    if confirm.destructive {
-        lines.push(Line::from(Span::styled(
-            "WARNING: This command may be destructive!",
-            app.theme.danger_fg(),
-        )));
-    }
-
-    let command_text = format!("$ {}", confirm.command);
-    lines.push(Line::from(Span::styled(
-        command_text.as_str(),
-        app.theme.warning_fg(),
-    )));
-
-    lines.push(Line::from(""));
+    // Snapshot fields we need so we can drop the borrow before mutating `app`
+    // further (button areas). Styles still need `app.theme` later.
+    let explanation = confirm.explanation.clone();
+    let command = confirm.command.clone();
+    let destructive = confirm.destructive;
 
     // --- Estimate modal dimensions ---
     // Minimum width 32 so buttons fit inside borders (30 chars + 2 borders).
     let modal_width = 70u16.min(area.width.saturating_sub(8)).max(32);
     let inner_width = (modal_width.saturating_sub(2)) as usize; // -2 borders
 
-    // Estimate how many rendered rows each text segment will occupy after
-    // wrapping, so the content area is tall enough to show everything.
-    let explanation_rows = if !confirm.explanation.is_empty() {
-        estimate_wrapped_rows(&confirm.explanation, inner_width)
+    let command_text = format!("$ {command}");
+    let explanation_rows = if !explanation.is_empty() {
+        estimate_wrapped_rows(&explanation, inner_width)
     } else {
         0
     };
-    let warning_rows = if confirm.destructive { 1 } else { 0 };
+    let warning_rows = if destructive { 1 } else { 0 };
     let command_rows = estimate_wrapped_rows(&command_text, inner_width);
-    let empty_rows = 1; // separator line
+    let empty_rows = 1; // separator line before buttons
 
-    let content_height = (explanation_rows + warning_rows + command_rows + empty_rows) as u16;
-    // +2 for borders, +1 for buttons line
-    let modal_height = content_height + 1 + 2;
+    let natural_content = (explanation_rows + warning_rows + command_rows + empty_rows) as u16;
+    // +2 borders +1 buttons
+    let natural_height = natural_content.saturating_add(3);
 
-    // Center within the area.
+    // Clamp to the host area so Rect never extends past the frame buffer.
+    let modal_height = natural_height.min(area.height).max(MIN_MODAL_HEIGHT);
+    let max_content_rows = modal_height.saturating_sub(3) as usize;
+
+    let lines = build_modal_lines(
+        &explanation,
+        &command_text,
+        destructive,
+        app.theme.fg_style(),
+        app.theme.danger_fg(),
+        app.theme.warning_fg(),
+        app.theme.muted(),
+        inner_width,
+        max_content_rows,
+    );
+    let content_height = max_content_rows.min(lines.len()).max(1) as u16;
+
+    // Center within the area (height already ≤ area.height).
     let modal_x = area.x + (area.width.saturating_sub(modal_width)) / 2;
     let modal_y = area.y + (area.height.saturating_sub(modal_height)) / 2;
     let modal_area = Rect::new(modal_x, modal_y, modal_width, modal_height);
 
-    // Clear the area under the modal so chat content doesn't bleed through.
+    // Absolute guard: never write past the frame buffer.
+    let frame = f.area();
+    if modal_area.x.saturating_add(modal_area.width) > frame.width
+        || modal_area.y.saturating_add(modal_area.height) > frame.height
+    {
+        return;
+    }
+
     f.render_widget(Clear, modal_area);
 
-    // Border colour: danger for destructive, warning otherwise.
-    let border_color = if confirm.destructive {
+    let border_color = if destructive {
         app.theme.danger
     } else {
         app.theme.warning
@@ -108,25 +123,147 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     let inner = block.inner(modal_area);
     f.render_widget(&block, modal_area);
 
-    // Split inner area: content + buttons.
+    if inner.height < 2 || inner.width == 0 {
+        return;
+    }
+
+    // Split inner area: content + buttons (buttons always get 1 row).
+    let content_len = content_height.min(inner.height.saturating_sub(1));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(content_height),
-            Constraint::Length(1), // buttons line
+            Constraint::Length(content_len),
+            Constraint::Length(1),
         ])
         .split(inner);
 
-    // Render content (explanation, warning, command, empty line).
     let content = Paragraph::new(lines).wrap(Wrap { trim: false });
     f.render_widget(content, chunks[0]);
-
-    // Render buttons.
     render_buttons(f, app, chunks[1]);
+}
+
+/// Build modal body lines, truncating so wrapped height ≤ `max_rows`.
+fn build_modal_lines(
+    explanation: &str,
+    command_text: &str,
+    destructive: bool,
+    fg: Style,
+    danger: Style,
+    warning: Style,
+    muted: Style,
+    inner_width: usize,
+    max_rows: usize,
+) -> Vec<Line<'static>> {
+    if max_rows == 0 {
+        return Vec::new();
+    }
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut used = 0usize;
+
+    let push = |lines: &mut Vec<Line<'static>>, used: &mut usize, text: String, style: Style| {
+        let rows = estimate_wrapped_rows(&text, inner_width);
+        if *used + rows > max_rows {
+            return false;
+        }
+        lines.push(Line::from(Span::styled(text, style)));
+        *used += rows;
+        true
+    };
+
+    if !explanation.is_empty() {
+        let truncated = truncate_to_rows(explanation, inner_width, max_rows.saturating_sub(2).max(1));
+        if !push(&mut lines, &mut used, truncated, fg) && max_rows > 0 {
+            lines.push(Line::from(Span::styled(
+                "… (explanation truncated)".to_string(),
+                muted,
+            )));
+            used = used.saturating_add(1).min(max_rows);
+        }
+    }
+
+    if destructive && used < max_rows {
+        let _ = push(
+            &mut lines,
+            &mut used,
+            "WARNING: This command may be destructive!".to_string(),
+            danger,
+        );
+    }
+
+    if used < max_rows {
+        let cmd_budget = max_rows.saturating_sub(used).saturating_sub(1).max(1);
+        let truncated = truncate_to_rows(command_text, inner_width, cmd_budget);
+        let was_cut = truncated != command_text
+            || estimate_wrapped_rows(command_text, inner_width) > cmd_budget;
+        let _ = push(&mut lines, &mut used, truncated, warning);
+        if was_cut && used < max_rows {
+            let _ = push(
+                &mut lines,
+                &mut used,
+                "… (command truncated)".to_string(),
+                muted,
+            );
+        }
+    }
+
+    // Trailing blank separator when there is room.
+    if used < max_rows {
+        lines.push(Line::from(""));
+    }
+
+    lines
+}
+
+/// Truncate `text` so its wrapped row count is ≤ `max_rows`.
+fn truncate_to_rows(text: &str, width: usize, max_rows: usize) -> String {
+    if max_rows == 0 || width == 0 {
+        return String::new();
+    }
+    if estimate_wrapped_rows(text, width) <= max_rows {
+        return text.to_string();
+    }
+
+    let mut out = String::new();
+    let mut rows = 0usize;
+    for (i, line) in text.split('\n').enumerate() {
+        let line_rows = estimate_wrapped_rows(line, width);
+        if rows + line_rows > max_rows {
+            // Fit a prefix of this line into remaining rows.
+            let remain = max_rows.saturating_sub(rows);
+            if remain == 0 {
+                break;
+            }
+            let chars_budget = remain.saturating_mul(width).saturating_sub(1); // room for …
+            let prefix: String = line.chars().take(chars_budget).collect();
+            if i > 0 || !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(&prefix);
+            out.push('…');
+            break;
+        }
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(line);
+        rows += line_rows;
+    }
+    if out.is_empty() {
+        let chars_budget = max_rows.saturating_mul(width).saturating_sub(1);
+        let prefix: String = text.chars().take(chars_budget).collect();
+        format!("{prefix}…")
+    } else {
+        out
+    }
 }
 
 /// Render the Approve and Deny buttons, storing their areas for hit-testing.
 fn render_buttons(f: &mut Frame, app: &mut App, area: Rect) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+
     let approve_label = "[ Approve (a) ]";
     let deny_label = "[ Deny (d) ]";
     let spacing = "   ";
@@ -138,22 +275,18 @@ fn render_buttons(f: &mut Frame, app: &mut App, area: Rect) {
 
     let start_x = area.x + (area.width.saturating_sub(total_len)) / 2;
 
-    let approve_area = Rect::new(start_x, area.y, approve_len, 1);
-    let deny_area = Rect::new(
-        start_x + approve_len + spacing_len,
-        area.y,
-        deny_len,
-        1,
-    );
+    let approve_area = Rect::new(start_x, area.y, approve_len.min(area.width), 1);
+    let deny_x = start_x.saturating_add(approve_len).saturating_add(spacing_len);
+    let deny_area = Rect::new(deny_x, area.y, deny_len.min(area.width.saturating_sub(deny_x.saturating_sub(area.x))), 1);
 
-    // Store for hit-testing.
-    app.confirm_button_areas.push((approve_area, true));
-    app.confirm_button_areas.push((deny_area, false));
+    // Only store hit zones that sit inside the host area.
+    if approve_area.width > 0 {
+        app.confirm_button_areas.push((approve_area, true));
+    }
+    if deny_area.width > 0 && deny_area.x < area.x.saturating_add(area.width) {
+        app.confirm_button_areas.push((deny_area, false));
+    }
 
-    // Styles: selected button (active for Enter) gets inverted colours
-    // (fg↔bg) + BOLD.  Hovered-but-not-selected button gets UNDERLINED to
-    // visually distinguish hover from selection.  Unselected, unhovered
-    // buttons get surface background with coloured text.
     let approve_selected = app.confirm_selected;
     let approve_hovered = app.hovered_button == Some(true);
     let approve_style = if approve_selected {
@@ -194,14 +327,24 @@ fn render_buttons(f: &mut Frame, app: &mut App, area: Rect) {
         Paragraph::new(approve_label).style(approve_style),
         approve_area,
     );
-    f.render_widget(
-        Paragraph::new(spacing).style(app.theme.muted()),
-        Rect::new(start_x + approve_len, area.y, spacing_len, 1),
+    let spacing_area = Rect::new(
+        start_x.saturating_add(approve_len),
+        area.y,
+        spacing_len.min(area.width.saturating_sub(approve_len)),
+        1,
     );
-    f.render_widget(
-        Paragraph::new(deny_label).style(deny_style),
-        deny_area,
-    );
+    if spacing_area.width > 0 {
+        f.render_widget(
+            Paragraph::new(spacing).style(app.theme.muted()),
+            spacing_area,
+        );
+    }
+    if deny_area.width > 0 {
+        f.render_widget(
+            Paragraph::new(deny_label).style(deny_style),
+            deny_area,
+        );
+    }
 }
 
 /// Estimate how many terminal rows `text` will occupy after wrapping at
@@ -222,4 +365,93 @@ fn estimate_wrapped_rows(text: &str, width: usize) -> usize {
         })
         .sum::<usize>()
         .max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, AppMode, PendingConfirm};
+    use filar_core::CommandConfirmMode;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use tokio::sync::oneshot;
+
+    fn render_confirm(app: &mut App, width: u16, height: u16) {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                // Simulate chat area inset like the real layout (status + help).
+                let chat = Rect::new(0, 2, width, height.saturating_sub(4).max(MIN_MODAL_HEIGHT));
+                app.chat_area = chat;
+                render_confirm_modal(f, app, chat);
+            })
+            .expect("confirm render must not panic");
+    }
+
+    fn pending(command: &str, destructive: bool) -> PendingConfirm {
+        let (tx, _rx) = oneshot::channel();
+        PendingConfirm {
+            command: command.to_string(),
+            explanation: "long command".into(),
+            destructive,
+            respond_to: tx,
+        }
+    }
+
+    #[test]
+    fn huge_command_does_not_panic_on_small_terminal() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Allowlist);
+        let huge = format!(
+            "cat > /tmp/Modelfile.dev <<'EOF'\n{}\nEOF\necho done",
+            "PARAMETER x 1\n".repeat(80)
+        );
+        app.pending_confirm = Some(pending(&huge, false));
+        app.mode = AppMode::Confirming;
+        render_confirm(&mut app, 120, 30);
+        assert!(
+            !app.confirm_button_areas.is_empty(),
+            "buttons must remain hittable after truncate"
+        );
+        for (rect, _) in &app.confirm_button_areas {
+            assert!(
+                rect.y < 30,
+                "button y={} must stay inside 120x30 frame",
+                rect.y
+            );
+        }
+    }
+
+    #[test]
+    fn destructive_huge_command_clamped() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        let huge = "rm -rf /\n".repeat(100);
+        app.pending_confirm = Some(pending(&huge, true));
+        app.mode = AppMode::Confirming;
+        render_confirm(&mut app, 80, 24);
+        assert!(!app.confirm_button_areas.is_empty());
+    }
+
+    #[test]
+    fn tiny_area_skips_modal_without_panic() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.pending_confirm = Some(pending("echo hi", false));
+        app.mode = AppMode::Confirming;
+        let backend = TestBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                render_confirm_modal(f, &mut app, Rect::new(0, 0, 20, 2));
+            })
+            .unwrap();
+        assert!(app.confirm_button_areas.is_empty());
+    }
+
+    #[test]
+    fn truncate_to_rows_shortens_long_text() {
+        let text = "abcdefghijklmnopqrstuvwxyz".repeat(10);
+        let out = truncate_to_rows(&text, 10, 3);
+        assert!(estimate_wrapped_rows(&out, 10) <= 3);
+        assert!(out.contains('…'));
+    }
 }

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -216,6 +216,10 @@ fn build_modal_lines(
 }
 
 /// Truncate `text` so its wrapped row count is ≤ `max_rows`.
+///
+/// When any content is dropped, the result always includes a trailing `…`
+/// (possibly replacing the last character of the last kept line) so truncation
+/// is never silent.
 fn truncate_to_rows(text: &str, width: usize, max_rows: usize) -> String {
     if max_rows == 0 || width == 0 {
         return String::new();
@@ -224,37 +228,70 @@ fn truncate_to_rows(text: &str, width: usize, max_rows: usize) -> String {
         return text.to_string();
     }
 
-    let mut out = String::new();
+    let mut kept: Vec<String> = Vec::new();
     let mut rows = 0usize;
-    for (i, line) in text.split('\n').enumerate() {
+    let all: Vec<&str> = text.split('\n').collect();
+
+    for (idx, line) in all.iter().enumerate() {
         let line_rows = estimate_wrapped_rows(line, width);
-        if rows + line_rows > max_rows {
-            // Fit a prefix of this line into remaining rows.
-            let remain = max_rows.saturating_sub(rows);
-            if remain == 0 {
-                break;
-            }
-            let chars_budget = remain.saturating_mul(width).saturating_sub(1); // room for …
-            let prefix: String = line.chars().take(chars_budget).collect();
-            if i > 0 || !out.is_empty() {
-                out.push('\n');
-            }
-            out.push_str(&prefix);
-            out.push('…');
+        if rows + line_rows <= max_rows {
+            kept.push((*line).to_string());
+            rows += line_rows;
+            // If this was the last source line we would be done, but we already
+            // know the full text overflows — so more content follows somehow.
+            // Continue; after the loop we force an ellipsis.
+            let _ = idx;
+            continue;
+        }
+
+        // Current line does not fit as a whole — take a prefix into `remain` rows.
+        let remain = max_rows.saturating_sub(rows);
+        if remain == 0 {
             break;
         }
-        if i > 0 {
-            out.push('\n');
-        }
-        out.push_str(line);
-        rows += line_rows;
+        let take = remain.saturating_mul(width).saturating_sub(1);
+        let mut prefix: String = line.chars().take(take).collect();
+        prefix.push('…');
+        kept.push(prefix);
+        return kept.join("\n");
     }
-    if out.is_empty() {
-        let chars_budget = max_rows.saturating_mul(width).saturating_sub(1);
-        let prefix: String = text.chars().take(chars_budget).collect();
-        format!("{prefix}…")
+
+    // All kept lines fit exactly in `max_rows`, but source still had more
+    // (or we broke because remain==0). Force a visible ellipsis.
+    ensure_ellipsis(&mut kept, width, max_rows);
+    if kept.is_empty() {
+        "…".to_string()
     } else {
-        out
+        kept.join("\n")
+    }
+}
+
+/// Ensure `kept` ends with `…` and still wraps to ≤ `max_rows`.
+fn ensure_ellipsis(kept: &mut Vec<String>, width: usize, max_rows: usize) {
+    if kept.is_empty() {
+        kept.push("…".to_string());
+        return;
+    }
+    if kept.last().is_some_and(|l| l.ends_with('…')) {
+        return;
+    }
+    let last = kept.last().cloned().unwrap_or_default();
+    let candidate = format!("{last}…");
+    let mut trial = kept.clone();
+    if let Some(slot) = trial.last_mut() {
+        *slot = candidate.clone();
+    }
+    if estimate_wrapped_rows(&trial.join("\n"), width) <= max_rows {
+        *kept.last_mut().unwrap() = candidate;
+        return;
+    }
+    // Replace last character of last line.
+    let mut chars: Vec<char> = last.chars().collect();
+    if chars.is_empty() {
+        *kept.last_mut().unwrap() = "…".to_string();
+    } else {
+        *chars.last_mut().unwrap() = '…';
+        *kept.last_mut().unwrap() = chars.into_iter().collect();
     }
 }
 
@@ -453,5 +490,24 @@ mod tests {
         let out = truncate_to_rows(&text, 10, 3);
         assert!(estimate_wrapped_rows(&out, 10) <= 3);
         assert!(out.contains('…'));
+    }
+
+    #[test]
+    fn truncate_marks_when_budget_exact() {
+        // Three short lines, budget 2 → keep first two with ellipsis on last kept.
+        let out = truncate_to_rows("aa\nbb\ncc\ndd", 10, 2);
+        assert!(estimate_wrapped_rows(&out, 10) <= 2, "got {out:?}");
+        assert!(out.contains('…'), "silent truncate forbidden: {out:?}");
+    }
+
+    #[test]
+    fn truncate_leading_empty_lines_respects_budget() {
+        let text = "\n\nABCDEFGHIJKLMNOPQRSTUVWXYZ".repeat(3);
+        let out = truncate_to_rows(&text, 8, 3);
+        assert!(
+            estimate_wrapped_rows(&out, 8) <= 3,
+            "overflow rows: {out:?}"
+        );
+        assert!(out.contains('…') || out == "…");
     }
 }


### PR DESCRIPTION
## Summary
- Clamp/truncate confirm modal to chat area; keep Approve/Deny visible.
- `PanicHookGuard::drop` does not call `take_hook` while panicking.
- Regression tests for huge commands on 120×30 / 80×24.

Closes #324

## Test plan
- [x] `cargo test -p filar-tui --lib ui::confirm`
- [x] `cargo test --workspace`
- [ ] Manual: agent proposes huge heredoc → confirm modal truncates, no abort


Made with [Cursor](https://cursor.com)