### PR TITLE
fix(agent): shorten sudo/password guidance (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Password/TTY failure guidance shortened to a compact Ctrl+P /
+  `$FILAR_SECRET_N` / `sudo -S` hint in command output
+  ([#331](https://github.com/devlawey/filar/issues/331)).
+
 ## [1.0.2] - 2026-08-21
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4941,3 +4941,12 @@ gate (#329). #322 closed not_planned (manual config edit).
 
 **Smoke:** dual-platform checklist in `docs/SMOKE.md` (#298) — manual after
 CI assets land.
+
+## Issue #331: ux(agent) — shorten sudo/password guidance
+
+**Milestone:** 1.0.3. **Branch:** `fix/331-shorten-password-guidance`.
+
+**Design:** option 1 — one short `PASSWORD_PROMPT_GUIDANCE` (~2 lines) for both
+UI and LLM tool result (no separate user/LLM split).
+
+**Done:** shortened constant; length assert in unit test; CHANGELOG.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4955,4 +4955,5 @@ UI and LLM tool result (no separate user/LLM split).
 enrich path); no trait/`CommandExecutor`/`LlmClient` signature changes.
 
 **Next steps:** manual TUI — trigger sudo password failure and confirm short
-hint in command block. Full `docs/SMOKE.md` remains a release gate, not per-issue.
+hint in command block (not runnable in this agent CI/agent shell; left for
+human DoD). Full `docs/SMOKE.md` remains a release gate, not per-issue.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4950,3 +4950,9 @@ CI assets land.
 UI and LLM tool result (no separate user/LLM split).
 
 **Done:** shortened constant; length assert in unit test; CHANGELOG.
+
+**Public contract:** `pub const PASSWORD_PROMPT_GUIDANCE` text shortened (same
+enrich path); no trait/`CommandExecutor`/`LlmClient` signature changes.
+
+**Next steps:** manual TUI — trigger sudo password failure and confirm short
+hint in command block. Full `docs/SMOKE.md` remains a release gate, not per-issue.

--- a/crates/agent/src/password_prompt.rs
+++ b/crates/agent/src/password_prompt.rs
@@ -1,14 +1,12 @@
 //! Detect interactive password prompts in tool output and steer the agent
-//! toward Ctrl+P / `$FILAR_SECRET_N` (see #329).
+//! toward Ctrl+P / `$FILAR_SECRET_N` (see #329, #331).
 
-/// Guidance appended when a command fails because it needs a TTY password.
+/// Short guidance appended when a command fails because it needs a TTY password.
+/// Kept to ~2 lines so it stays readable in the TUI command block (#331).
 pub const PASSWORD_PROMPT_GUIDANCE: &str = "\
-This command needs a password, but agent tool calls cannot use an interactive \
-TTY password prompt (it would hang or paint over the UI). Ask the user to press \
-Ctrl+P, enter the password into the masked field, then retry using the given \
-$FILAR_SECRET_N placeholder — e.g. `printf '%s\\n' \"$FILAR_SECRET_1\" | sudo -S …` \
-(POSIX) or an equivalent non-interactive form. Never embed the real password in \
-the command text.";
+Password required (no interactive TTY). Ask the user for Ctrl+P → \
+$FILAR_SECRET_N, then retry with e.g. `printf '%s\\n' \"$FILAR_SECRET_1\" | sudo -S …`. \
+Do not embed the real password in the command.";
 
 /// Heuristic: output looks like a password / sudo TTY failure.
 pub fn looks_like_password_prompt(output: &str) -> bool {
@@ -60,6 +58,14 @@ mod tests {
         let once = enrich_password_prompt_message("sudo: a password is required");
         assert!(once.contains(PASSWORD_PROMPT_GUIDANCE));
         assert!(once.contains("Ctrl+P"));
+        assert!(once.contains("$FILAR_SECRET_N"));
+        assert!(once.contains("sudo -S"));
+        // Keep UI-friendly: guidance itself should stay short.
+        assert!(
+            PASSWORD_PROMPT_GUIDANCE.len() < 220,
+            "guidance too long for TUI: {} chars",
+            PASSWORD_PROMPT_GUIDANCE.len()
+        );
         let twice = enrich_password_prompt_message(&once);
         assert_eq!(
             twice.matches(PASSWORD_PROMPT_GUIDANCE).count(),


### PR DESCRIPTION
## Summary
- Shorten `PASSWORD_PROMPT_GUIDANCE` to a compact Ctrl+P / `$FILAR_SECRET_N` / `sudo -S` hint (#331 option 1).
- Unit test asserts guidance length stays UI-friendly and enrich still appends once.

Closes #331

## Test plan
- [x] `cargo test -p filar-agent password_prompt`
- [x] `cargo test --workspace`
- [x] `cargo build --workspace`
- [ ] Manual TUI: trigger sudo password failure and confirm short hint in command block

**DoD note:** Interactive TUI/GUI cannot be driven from this agent environment (no real tty session / human approve for sudo). Manual check left for a human before release smoke; unit coverage verifies guidance content and length.

**CI note:** `eval-smoke` failed with `0/1 tests` (infra-looking); change is guidance string only — system prompt / eval prompts unchanged.