### PR TITLE
fix(tui): paste at char index for UTF-8 (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   `$FILAR_SECRET_N` / `sudo -S` hint in command output
   ([#331](https://github.com/devlawey/filar/issues/331)).
 
+### Fixed
+
+- Paste into the input field uses char indices (not bytes), so UTF-8 /
+  Cyrillic mid-string paste no longer panics or jumps the cursor
+  ([#332](https://github.com/devlawey/filar/issues/332)).
+
 ## [1.0.2] - 2026-08-21
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4957,3 +4957,17 @@ enrich path); no trait/`CommandExecutor`/`LlmClient` signature changes.
 **Next steps:** manual TUI — trigger sudo password failure and confirm short
 hint in command block (not runnable in this agent CI/agent shell; left for
 human DoD). Full `docs/SMOKE.md` remains a release gate, not per-issue.
+
+## Issue #332: fix(tui) — paste UTF-8 char vs byte cursor
+
+**Milestone:** 1.0.3. **Branch:** `fix/332-paste-utf8-cursor`.
+
+**Design:** `paste_text` mirrors `insert_char`: `cursor_pos` → byte via
+`char_indices().nth`; advance cursor by pasted char count.
+
+**Done:** fix + UTF-8 / Cyrillic / long multiline regression tests; CHANGELOG.
+
+**Public contract:** none (TUI-internal `App::paste_text`).
+
+**Next steps:** human macOS TUI paste mid-Cyrillic (agent env cannot drive
+interactive paste); PasswordInput path covered by existing unit test.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1368,9 +1368,16 @@ impl App {
                 if clean.is_empty() {
                     return;
                 }
-                let pos = self.cursor_pos.min(self.input.len());
-                self.input.insert_str(pos, &clean);
-                self.cursor_pos = pos + clean.len();
+                let char_count = self.input.chars().count();
+                let insert_at = self.cursor_pos.min(char_count);
+                let byte_pos = self
+                    .input
+                    .char_indices()
+                    .nth(insert_at)
+                    .map(|(i, _)| i)
+                    .unwrap_or(self.input.len());
+                self.input.insert_str(byte_pos, &clean);
+                self.cursor_pos = insert_at + clean.chars().count();
             }
             AppMode::PasswordInput => {
                 // Same as typing: masked, never logged, never in history.
@@ -6376,6 +6383,48 @@ mod tests {
         app.paste_text("XYZ");
         assert_eq!(app.input, "heXYZllo");
         assert_eq!(app.cursor_pos, 5); // moved after inserted text
+    }
+
+    #[test]
+    fn paste_mid_utf8_uses_char_index_not_bytes() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        // "привет" is 6 chars / 12 bytes; cursor before 'и' (char index 2).
+        app.input = "привет".into();
+        app.cursor_pos = 2;
+        app.paste_text("XY");
+        assert_eq!(app.input, "прXYивет");
+        assert_eq!(app.cursor_pos, 4);
+    }
+
+    #[test]
+    fn paste_into_cyrillic_prefix_advances_by_char_count() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.input = "абв".into();
+        app.cursor_pos = 3; // end
+        app.paste_text("гдеж");
+        assert_eq!(app.input, "абвгдеж");
+        assert_eq!(app.cursor_pos, 7);
+    }
+
+    #[test]
+    fn paste_long_multiline_utf8_no_panic() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.input = "начало конец".into();
+        app.cursor_pos = 7; // after space, before "конец"
+        let blob = "раз\nдва\r\nтри ".repeat(40);
+        app.paste_text(&blob);
+        assert!(app.input.starts_with("начало "));
+        assert!(app.input.ends_with("конец"));
+        assert!(!app.input.contains('\n'));
+        assert!(!app.input.contains('\r'));
+        assert_eq!(
+            app.cursor_pos,
+            7 + blob
+                .chars()
+                .filter(|c| *c != '\r')
+                .map(|c| if c == '\n' { ' ' } else { c })
+                .count()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix `paste_text` to convert `cursor_pos` (char index) to a byte offset via `char_indices`, matching `insert_char`.
- Advance cursor by pasted **character** count, not bytes.
- Regression tests: mid-UTF-8, Cyrillic append, long multiline (newlines→spaces).

Closes #332

## Test plan
- [x] `cargo test -p filar-tui paste_`
- [x] `cargo test --workspace`
- [x] `cargo build --workspace`
- [ ] Manual macOS TUI: non-empty Cyrillic input, paste mid-string / long clipboard (agent cannot drive interactive paste)

**DoD note:** Interactive TUI paste cannot be driven from this agent environment; unit tests cover the panic/cursor cases.