### PR TITLE
fix(tui): wrap/pad chat by display columns (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Paste into the input field uses char indices (not bytes), so UTF-8 /
   Cyrillic mid-string paste no longer panics or jumps the cursor
   ([#332](https://github.com/devlawey/filar/issues/332)).
+- Chat wrap/pad use unicode display columns (and expand tabs) so long
+  wrap / CJK / columnar output no longer leave stale glyphs after scroll
+  ([#333](https://github.com/devlawey/filar/issues/333)).
 
 ## [1.0.2] - 2026-08-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4971,3 +4971,24 @@ human DoD). Full `docs/SMOKE.md` remains a release gate, not per-issue.
 
 **Next steps:** human macOS TUI paste mid-Cyrillic (agent env cannot drive
 interactive paste); PasswordInput path covered by existing unit test.
+
+## Issue #333: fix(tui) — glyph artifacts on wrap / columnar output
+
+**Milestone:** 1.0.3. **Branch:** `fix/333-glyph-artifacts-wrap`.
+
+**Problem:** #325 cell-reset + char-count pad fixed short-over-long ASCII
+scroll, but wrap/pad still used `chars().count()` while ratatui paints by
+unicode-width; CJK/wide glyphs and `\t` columns under/over-filled the
+viewport → ghost glyphs until resize.
+
+**Design:** `wrap_text` + `pad_line_to_width` use display columns
+(`unicode-width` 0.1, same as ratatui); expand tabs (stop 8); truncate
+over-wide lines; keep #325 reset_area_cells.
+
+**Done:** tests for CJK wrap/pad, tab expand, wide+columnar scroll; PLATFORM_NOTES;
+CHANGELOG.
+
+**Public contract:** none (TUI-internal layout).
+
+**Next steps:** human macOS Terminal long agent cycle with `ps`-style
+columns + CJK (agent cannot drive interactive TUI).

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -19,3 +19,5 @@ alacritty_terminal = { workspace = true }
 arboard = { workspace = true }
 chrono = { workspace = true }
 tokio-util = { workspace = true }
+# Match ratatui 0.28 (display columns for wrap/pad; #333).
+unicode-width = "0.1"

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -108,8 +108,8 @@ pub(crate) fn render_chat_history(f: &mut Frame, app: &mut App, area: Rect) {
     // N is the number of lines below the viewport (= scroll after clamping).
     if app.scroll > 0 && area.height >= 3 && area.width >= 3 {
         let indicator = format!("\u{2193} {} new", app.scroll);
-        // Use char count, not byte length — `↓` (U+2193) is 3 bytes but 1 column.
-        let indicator_width = indicator.chars().count() as u16;
+        // Display columns (↓ is width 1); match pad/wrap (#333).
+        let indicator_width = unicode_width::UnicodeWidthStr::width(indicator.as_str()) as u16;
         let indicator_width = indicator_width.min(inner_width);
         let indicator_area = Rect::new(
             area.x + area.width.saturating_sub(indicator_width),
@@ -141,18 +141,48 @@ fn reset_area_cells(f: &mut Frame, area: Rect) {
     }
 }
 
-/// Pad `line` with trailing spaces up to `width` display columns (char count,
-/// matching the rest of the chat layout which does not use unicode-width).
+/// Pad `line` with trailing spaces up to `width` **display columns**
+/// (ratatui / unicode-width). Truncate if the line is already wider so the
+/// Paragraph never spills past the viewport (#333).
 fn pad_line_to_width(mut line: Line<'static>, width: usize) -> Line<'static> {
-    let current: usize = line
-        .spans
-        .iter()
-        .map(|s| s.content.chars().count())
-        .sum();
+    let current = line.width();
     if current < width {
         line.spans.push(Span::raw(" ".repeat(width - current)));
+        return line;
+    }
+    if current > width {
+        return truncate_line_to_width(line, width);
     }
     line
+}
+
+/// Truncate a styled line to at most `width` display columns.
+fn truncate_line_to_width(line: Line<'static>, width: usize) -> Line<'static> {
+    use unicode_width::UnicodeWidthChar;
+
+    let mut new_spans: Vec<Span<'static>> = Vec::new();
+    let mut used = 0usize;
+    for span in line.spans {
+        if used >= width {
+            break;
+        }
+        let mut kept = String::new();
+        for c in span.content.chars() {
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+            if used + cw > width {
+                break;
+            }
+            kept.push(c);
+            used += cw;
+        }
+        if !kept.is_empty() {
+            new_spans.push(Span::styled(kept, span.style));
+        }
+    }
+    if used < width {
+        new_spans.push(Span::raw(" ".repeat(width - used)));
+    }
+    Line::from(new_spans)
 }
 
 /// Apply selection background to a rendered line.
@@ -296,8 +326,69 @@ mod tests {
     fn pad_line_to_width_extends_short_line() {
         let line = Line::from("hi");
         let padded = pad_line_to_width(line, 5);
-        let w: usize = padded.spans.iter().map(|s| s.content.chars().count()).sum();
-        assert_eq!(w, 5);
+        assert_eq!(padded.width(), 5);
+    }
+
+    #[test]
+    fn pad_line_to_width_uses_display_columns_for_wide_chars() {
+        // Two CJK chars = 4 columns; pad to 6 → two trailing spaces.
+        let padded = pad_line_to_width(Line::from("你好"), 6);
+        assert_eq!(padded.width(), 6);
+        let text: String = padded.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.ends_with("  "));
+    }
+
+    #[test]
+    fn pad_line_to_width_truncates_overwide() {
+        let padded = pad_line_to_width(Line::from("你好世界"), 4);
+        assert_eq!(padded.width(), 4);
+        let text: String = padded.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "你好");
+    }
+
+    #[test]
+    fn scroll_wide_and_columnar_leaves_no_stale_glyphs() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Allowlist);
+        // Wide CJK + tab-aligned columns that used to overflow char-based wrap.
+        app.messages = vec![
+            ChatBlock::User("用户消息".repeat(20)),
+            ChatBlock::Agent("代理回复".repeat(20)),
+            ChatBlock::Command {
+                command: "ps".into(),
+                explanation: String::new(),
+                output: Some("PID\tTTY\tTIME\tCMD\n1\t??\t0:00.01\t/sbin/launchd\n".repeat(8)),
+                approved: true,
+            },
+            ChatBlock::User("short".into()),
+            ChatBlock::Agent("ok".into()),
+        ];
+        app.message_rev = 1;
+        app.scroll = 0;
+
+        let backend = TestBackend::new(40, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 40, 8);
+                render_chat_history(f, &mut app, area);
+            })
+            .unwrap();
+
+        app.scroll = 10;
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 40, 8);
+                render_chat_history(f, &mut app, area);
+            })
+            .unwrap();
+
+        let buf = terminal.backend().buffer();
+        for y in 0..8 {
+            let row = chat_row(buf, y, 40);
+            assert_eq!(row.chars().count(), 40, "row {y} must be fully painted: {row:?}");
+            // No raw tab characters should reach the buffer.
+            assert!(!row.contains('\t'), "tab leaked on row {y}: {row:?}");
+        }
     }
 }
 

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -160,6 +160,8 @@ fn pad_line_to_width(mut line: Line<'static>, width: usize) -> Line<'static> {
 fn truncate_line_to_width(line: Line<'static>, width: usize) -> Line<'static> {
     use unicode_width::UnicodeWidthChar;
 
+    let style = line.style;
+    let alignment = line.alignment;
     let mut new_spans: Vec<Span<'static>> = Vec::new();
     let mut used = 0usize;
     for span in line.spans {
@@ -169,7 +171,8 @@ fn truncate_line_to_width(line: Line<'static>, width: usize) -> Line<'static> {
         let mut kept = String::new();
         for c in span.content.chars() {
             let cw = UnicodeWidthChar::width(c).unwrap_or(0);
-            if used + cw > width {
+            // Keep combining marks with the preceding base even at the edge.
+            if cw > 0 && used + cw > width {
                 break;
             }
             kept.push(c);
@@ -182,7 +185,10 @@ fn truncate_line_to_width(line: Line<'static>, width: usize) -> Line<'static> {
     if used < width {
         new_spans.push(Span::raw(" ".repeat(width - used)));
     }
-    Line::from(new_spans)
+    let mut out = Line::from(new_spans);
+    out.style = style;
+    out.alignment = alignment;
+    out
 }
 
 /// Apply selection background to a rendered line.
@@ -363,7 +369,8 @@ mod tests {
             ChatBlock::Agent("ok".into()),
         ];
         app.message_rev = 1;
-        app.scroll = 0;
+        // High scroll → oldest lines (wide CJK) fill the viewport first.
+        app.scroll = 40;
 
         let backend = TestBackend::new(40, 12);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -374,7 +381,18 @@ mod tests {
             })
             .unwrap();
 
-        app.scroll = 10;
+        let before: Vec<String> = (0..8)
+            .map(|y| chat_row(terminal.backend().buffer(), y, 40))
+            .collect();
+        assert!(
+            before
+                .iter()
+                .any(|r| r.contains('用') || r.contains('代') || r.contains("PID") || r.contains("CMD")),
+            "first frame should show wide/columnar content: {before:?}"
+        );
+
+        // Back to bottom: short lines must fully replace prior wide cells.
+        app.scroll = 0;
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 40, 8);
@@ -386,8 +404,16 @@ mod tests {
         for y in 0..8 {
             let row = chat_row(buf, y, 40);
             assert_eq!(row.chars().count(), 40, "row {y} must be fully painted: {row:?}");
-            // No raw tab characters should reach the buffer.
             assert!(!row.contains('\t'), "tab leaked on row {y}: {row:?}");
+            if row.trim().chars().count() < 10 {
+                assert!(
+                    !row.contains('用')
+                        && !row.contains('代')
+                        && !row.contains("PID")
+                        && !row.contains("launchd"),
+                    "stale wide/columnar glyphs on row {y}: {row:?}"
+                );
+            }
         }
     }
 }

--- a/crates/tui/src/ui/text.rs
+++ b/crates/tui/src/ui/text.rs
@@ -1,8 +1,30 @@
 //! Text utility helpers — emoji stripping, line wrapping, and markdown-lite rendering.
 
 use ratatui::text::Span;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::theme::Theme;
+
+/// Tab stop used when expanding `\t` for wrap/pad (columnar `ps` / tables).
+const TAB_STOP: usize = 8;
+
+/// Expand horizontal tabs to spaces at [`TAB_STOP`] boundaries so wrap and
+/// pad agree with typical terminal columnar layout (#333).
+pub(crate) fn expand_tabs(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut col = 0usize;
+    for c in s.chars() {
+        if c == '\t' {
+            let spaces = TAB_STOP - (col % TAB_STOP);
+            out.push_str(&" ".repeat(spaces));
+            col += spaces;
+        } else {
+            out.push(c);
+            col += UnicodeWidthChar::width(c).unwrap_or(0);
+        }
+    }
+    out
+}
 
 /// Strip emoji and other non-renderable Unicode characters from a string.
 /// Windows terminal (conhost) can't display most emojis, so they show as '?'.
@@ -29,31 +51,40 @@ pub(crate) fn strip_emoji(s: &str) -> String {
         .collect()
 }
 
-/// Wrap a single line of text to fit within `width` characters.
-/// Returns one or more strings, each at most `width` chars wide.
+/// Wrap a single line of text to fit within `width` **display columns**
+/// (unicode-width, matching ratatui). Tabs are expanded first (#333).
+///
+/// Returns one or more strings, each at most `width` columns wide. A single
+/// grapheme wider than `width` is placed alone on its own line.
 pub(crate) fn wrap_text(text: &str, width: usize) -> Vec<String> {
     if width == 0 {
         return vec![text.to_string()];
     }
     let mut result = Vec::new();
     for line in text.lines() {
-        let char_count = line.chars().count();
-        if char_count <= width {
-            result.push(line.to_string());
-        } else {
-            let mut current = String::new();
-            let mut count = 0;
-            for c in line.chars() {
-                if count >= width {
-                    result.push(std::mem::take(&mut current));
-                    count = 0;
-                }
-                current.push(c);
-                count += 1;
+        let line = expand_tabs(line);
+        let line_width = UnicodeWidthStr::width(line.as_str());
+        if line_width <= width {
+            result.push(line);
+            continue;
+        }
+        let mut current = String::new();
+        let mut col = 0usize;
+        for c in line.chars() {
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+            if col > 0 && col + cw > width {
+                result.push(std::mem::take(&mut current));
+                col = 0;
             }
-            if !current.is_empty() {
-                result.push(current);
+            current.push(c);
+            col += cw;
+            if col >= width {
+                result.push(std::mem::take(&mut current));
+                col = 0;
             }
+        }
+        if !current.is_empty() {
+            result.push(current);
         }
     }
     if result.is_empty() {
@@ -243,6 +274,20 @@ mod tests {
     #[test]
     fn wrap_text_zero_width() {
         assert_eq!(wrap_text("hello", 0), vec!["hello"]);
+    }
+
+    #[test]
+    fn wrap_text_wide_chars_by_display_columns() {
+        // Each CJK char is 2 columns; width 4 → two chars per line.
+        assert_eq!(wrap_text("你好世界", 4), vec!["你好", "世界"]);
+    }
+
+    #[test]
+    fn wrap_text_expands_tabs_for_columns() {
+        let lines = wrap_text("a\tb", 16);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "a       b");
+        assert_eq!(UnicodeWidthStr::width(lines[0].as_str()), 9);
     }
 
     // --- Markdown-lite tests ---

--- a/crates/tui/src/ui/text.rs
+++ b/crates/tui/src/ui/text.rs
@@ -55,7 +55,8 @@ pub(crate) fn strip_emoji(s: &str) -> String {
 /// (unicode-width, matching ratatui). Tabs are expanded first (#333).
 ///
 /// Returns one or more strings, each at most `width` columns wide. A single
-/// grapheme wider than `width` is placed alone on its own line.
+/// character wider than `width` is placed alone on its own line. Zero-width
+/// combining marks stay with their preceding base character.
 pub(crate) fn wrap_text(text: &str, width: usize) -> Vec<String> {
     if width == 0 {
         return vec![text.to_string()];
@@ -72,16 +73,14 @@ pub(crate) fn wrap_text(text: &str, width: usize) -> Vec<String> {
         let mut col = 0usize;
         for c in line.chars() {
             let cw = UnicodeWidthChar::width(c).unwrap_or(0);
-            if col > 0 && col + cw > width {
+            // Only break before a positive-width char; combining marks (cw=0)
+            // stay attached to the previous base.
+            if cw > 0 && col > 0 && col + cw > width {
                 result.push(std::mem::take(&mut current));
                 col = 0;
             }
             current.push(c);
             col += cw;
-            if col >= width {
-                result.push(std::mem::take(&mut current));
-                col = 0;
-            }
         }
         if !current.is_empty() {
             result.push(current);
@@ -288,6 +287,13 @@ mod tests {
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0], "a       b");
         assert_eq!(UnicodeWidthStr::width(lines[0].as_str()), 9);
+    }
+
+    #[test]
+    fn wrap_text_keeps_combining_mark_with_base() {
+        let acute = '\u{0301}';
+        let s = format!("a{acute}b");
+        assert_eq!(wrap_text(&s, 1), vec![format!("a{acute}"), "b".into()]);
     }
 
     // --- Markdown-lite tests ---

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -13,6 +13,7 @@ Add findings here whenever a platform difference is discovered.
 | GUI launcher paste / show password | [GUI launcher secrets](#gui-launcher-secrets-macos) | #312 |
 | Interactive PTY shell | [Local interactive shell](#local-interactive-shell-ctrlt) | #293, #313 |
 | Release assets / packaging | [Release binaries (CI)](#release-binaries-ci) | #289, #297, #80 |
+| Chat wrap display columns | [Chat display width vs char count](#chat-display-width-vs-char-count-333) | #333 |
 
 ## Clipboard
 
@@ -243,4 +244,17 @@ and `logs/` all share this single app root.
 > Before #329, Unix local agent children inherited the TUI’s controlling
 > terminal, so macOS `sudo` wrote `Password:` on top of ratatui while the
 > session stayed in Thinking.
+
+## Chat display width vs char count (#333)
+
+Chat wrap/pad (#325 follow-up) measure lines in **unicode display columns**
+(same `unicode-width` 0.1 as ratatui), not `chars().count()`. Tabs in
+command output are expanded to spaces (tab stop 8) before wrap so
+columnar tools (`ps`, aligned tables) stay consistent.
+
+| Concern | Note |
+|---------|------|
+| CJK / wide glyphs | Two columns each; char-count wrap overflowed the viewport and left ghosts after scroll |
+| Ambiguous width (e.g. some box-drawing) | Follow unicode-width/ratatui; Terminal.app vs Windows Terminal can still differ for East-Asian Ambiguous characters — report if still visible after #333 |
+| Interactive PTY scrollback | Separate `TerminalModel` path; not changed by #333 |
 


### PR DESCRIPTION
## Summary
- Chat `wrap_text` / `pad_line_to_width` use unicode **display columns** (same `unicode-width` 0.1 as ratatui), not `chars().count()`.
- Expand tabs (stop 8) before wrap for columnar stdout; truncate over-wide lines.
- Keep #325 `reset_area_cells`; add CJK / tab / wide+columnar scroll regressions; PLATFORM_NOTES.

Closes #333

## Test plan
- [x] `cargo test -p filar-tui --lib`
- [x] `cargo test --workspace`
- [x] `cargo build --workspace`
- [ ] Manual macOS TUI: long agent cycle with wrapped CJK + `ps`-style columns, scroll without resize (agent cannot drive interactive TUI)

**DoD note:** Interactive TUI cannot be driven from this agent environment; buffer tests cover the wide/columnar class.