### PR TITLE
fix(tui): place ! shell cursor after last char (#337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Chat wrap/pad use unicode display columns (and expand tabs) so long
   wrap / CJK / columnar output no longer leave stale glyphs after scroll
   ([#333](https://github.com/devlawey/filar/issues/333)).
+- Shell (`!`) input prompt no longer double-spaces `$`, so the cursor sits
+  after the last character instead of on it
+  ([#337](https://github.com/devlawey/filar/issues/337)).
 
 ## [1.0.2] - 2026-08-21
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4992,3 +4992,18 @@ CHANGELOG.
 
 **Next steps:** human macOS Terminal long agent cycle with `ps`-style
 columns + CJK (agent cannot drive interactive TUI).
+
+## Issue #337: fix(tui) — ! shell cursor past end
+
+**Milestone:** 1.0.3. **Branch:** `fix/337-shell-cursor-end`.
+
+**Problem:** shell prompt was `"$ "` then `format!("{prompt} ")` added a
+second space (display width 3) while `place_cursor` assumed width 2 →
+caret sat on the last input character.
+
+**Done:** shell glyph is `"$"` (space added once); cursor/TestBackend
+regression tests; CHANGELOG.
+
+**Public contract:** none.
+
+**Next steps:** human TUI glance at `!pwd` caret (agent cannot drive TUI).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5006,4 +5006,5 @@ regression tests; CHANGELOG.
 
 **Public contract:** none.
 
-**Next steps:** human TUI glance at `!pwd` caret (agent cannot drive TUI).
+**Next steps:** human TUI glance at `!` / `!pwd` caret (agent cannot drive
+interactive TUI; TestBackend asserts cover place_cursor math).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -5000,6 +5000,7 @@ mod tests {
         assert!(app.input.is_empty());
         app.execute_help_action(HelpAction::Shell);
         assert_eq!(app.input, "!");
+        assert_eq!(app.cursor_pos, 1, "cursor must sit past '!' (#337)");
     }
 
     #[test]

--- a/crates/tui/src/ui/input.rs
+++ b/crates/tui/src/ui/input.rs
@@ -167,17 +167,20 @@ mod tests {
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
-    fn draw_input(app: &mut App, width: u16, height: u16) -> (u16, u16) {
+    fn draw_input(app: &mut App, width: u16, height: u16) -> Result<(u16, u16), String> {
         let backend = TestBackend::new(width, height);
-        let mut terminal = Terminal::new(backend).unwrap();
+        let mut terminal =
+            Terminal::new(backend).map_err(|e| format!("TestBackend terminal: {e}"))?;
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, width, height);
                 render_input_area(f, app, area);
             })
-            .unwrap();
-        let pos = terminal.get_cursor_position().unwrap();
-        (pos.x, pos.y)
+            .map_err(|e| format!("draw input: {e}"))?;
+        let pos = terminal
+            .get_cursor_position()
+            .map_err(|e| format!("cursor position: {e}"))?;
+        Ok((pos.x, pos.y))
     }
 
     #[test]
@@ -190,7 +193,7 @@ mod tests {
         assert_eq!(app.input, "!");
         assert_eq!(app.cursor_pos, 1, "cursor must be past '!'");
         // Prompt "$ " (2 cols) + bang at col 2 → cursor after bang at col 3.
-        let (x, y) = draw_input(&mut app, 40, 3);
+        let (x, y) = draw_input(&mut app, 40, 3).expect("draw shell bang");
         assert_eq!(y, 0);
         assert_eq!(x, 3, "cursor after '$ !', got col {x}");
     }
@@ -201,7 +204,7 @@ mod tests {
         app.input = "!pwd".into();
         app.cursor_pos = 4;
         // "$ " + "!pwd" → cursor after 'd' at column 2+4=6.
-        let (x, _) = draw_input(&mut app, 40, 3);
+        let (x, _) = draw_input(&mut app, 40, 3).expect("draw !pwd");
         assert_eq!(x, 6);
     }
 
@@ -211,7 +214,7 @@ mod tests {
         app.input = "hi".into();
         app.cursor_pos = 2;
         // Prompt glyph + space (2) + "hi" → cursor at col 4.
-        let (x, _) = draw_input(&mut app, 40, 3);
+        let (x, _) = draw_input(&mut app, 40, 3).expect("draw normal input");
         assert_eq!(x, 4);
     }
 }

--- a/crates/tui/src/ui/input.rs
+++ b/crates/tui/src/ui/input.rs
@@ -31,11 +31,14 @@ pub(crate) fn render_input_area(f: &mut Frame, app: &mut App, area: Rect) {
 fn render_normal_input(f: &mut Frame, app: &mut App, area: Rect) {
     let glyphs = app.theme.glyphs();
 
-    // Shell-escape: input starts with `!` -> prompt `$ ` in warning.
+    // Shell-escape: input starts with `!` -> `$` prompt in warning.
+    // Prompt glyph is a single char (like `❯` / `>`); the trailing space is
+    // added once via `format!("{prompt} ")` so display width stays 2 and
+    // matches `place_cursor` / click mapping (#337).
     let is_shell = app.input.starts_with('!');
 
     let (prompt, prompt_style, text_style) = if is_shell {
-        ("$ ", app.theme.warning_fg(), app.theme.warning_fg())
+        ("$", app.theme.warning_fg(), app.theme.warning_fg())
     } else {
         (glyphs.prompt, app.theme.user_style(), app.theme.fg_style())
     };
@@ -155,4 +158,60 @@ fn place_cursor(f: &mut Frame, app: &App, area: Rect, prompt_width: u16, scroll_
     let cursor_x = area.x + prompt_width + cursor_col;
     let cursor_y = area.y + cursor_row.min(area.height.saturating_sub(1));
     f.set_cursor_position((cursor_x, cursor_y));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use filar_core::CommandConfirmMode;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn draw_input(app: &mut App, width: u16, height: u16) -> (u16, u16) {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, width, height);
+                render_input_area(f, app, area);
+            })
+            .unwrap();
+        let pos = terminal.get_cursor_position().unwrap();
+        (pos.x, pos.y)
+    }
+
+    #[test]
+    fn shell_bang_places_cursor_after_prefix() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('!'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.input, "!");
+        assert_eq!(app.cursor_pos, 1, "cursor must be past '!'");
+        // Prompt "$ " (2 cols) + bang at col 2 → cursor after bang at col 3.
+        let (x, y) = draw_input(&mut app, 40, 3);
+        assert_eq!(y, 0);
+        assert_eq!(x, 3, "cursor after '$ !', got col {x}");
+    }
+
+    #[test]
+    fn shell_command_places_cursor_after_last_char() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.input = "!pwd".into();
+        app.cursor_pos = 4;
+        // "$ " + "!pwd" → cursor after 'd' at column 2+4=6.
+        let (x, _) = draw_input(&mut app, 40, 3);
+        assert_eq!(x, 6);
+    }
+
+    #[test]
+    fn normal_input_cursor_still_after_last_char() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.input = "hi".into();
+        app.cursor_pos = 2;
+        // Prompt glyph + space (2) + "hi" → cursor at col 4.
+        let (x, _) = draw_input(&mut app, 40, 3);
+        assert_eq!(x, 4);
+    }
 }


### PR DESCRIPTION
## Summary
- Shell (`!`) prompt glyph is `$` (one space via `format!`), matching `place_cursor` width 2 — caret sits after the last character (#337).
- TestBackend cursor asserts for `!`, `!pwd`, and normal input; HelpAction::Shell checks `cursor_pos == 1`.

Closes #337

## Test plan
- [x] `cargo test -p filar-tui --lib ui::input::tests`
- [x] `cargo test --workspace`
- [x] `cargo build --workspace`
- [ ] Manual TUI: type `!pwd` and confirm caret is past `d`

**DoD note:** Interactive TUI cannot be driven from this agent environment. TestBackend cursor-position tests cover the off-by-one; human glance left for release smoke.