### PR TITLE
fix(tui): sync cwd on Ctrl+T hide for status and agent (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Shell (`!`) input prompt no longer double-spaces `$`, so the cursor sits
   after the last character instead of on it
   ([#337](https://github.com/devlawey/filar/issues/337)).
+- Ctrl+T hide refreshes tab cwd via OSC 7 probe and `set_cwd` (status bar +
+  agent) without tearing down the PTY; stale enter-time cwd no longer skips
+  the probe ([#338](https://github.com/devlawey/filar/issues/338)).
 
 ## [1.0.2] - 2026-08-21
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5008,3 +5008,21 @@ regression tests; CHANGELOG.
 
 **Next steps:** human TUI glance at `!` / `!pwd` caret (agent cannot drive
 interactive TUI; TestBackend asserts cover place_cursor math).
+
+## Issue #338: fix(tui) — cwd sync on Ctrl+T hide + status bar
+
+**Milestone:** 1.0.3. **Branch:** `fix/338-cwd-sync-status`.
+
+**Problem:** #313 leave-sync only ran on PTY teardown; normal Ctrl+T **hide**
+kept the PTY and never probed/`set_cwd`. Stale `cwd_known` also skipped probe.
+
+**Design:** `pending_cwd_sync` on hide → runner `sync_cwd_from_interactive`
+(always OSC 7 probe on Unix/SSH, restore previous on timeout, `set_cwd`);
+same helper on full teardown. Status bar already reads `Session.cwd`.
+
+**Done:** app queue + runner helper; unit tests; PLATFORM_NOTES; CHANGELOG.
+
+**Public contract:** none (TUI-internal).
+
+**Next steps:** human smoke `Ctrl+T` → `cd /tmp` → `Ctrl+T` → status/`!pwd`
+(agent cannot drive interactive PTY).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -566,8 +566,12 @@ impl App {
     }
 
     /// Take and clear tabs awaiting OSC 7 / executor cwd sync (PTY kept alive).
+    /// Deduplicates so repeated hide before the runner drains still sync once.
     pub fn take_pending_cwd_sync(&mut self) -> Vec<SessionId> {
-        std::mem::take(&mut self.pending_cwd_sync)
+        let mut v = std::mem::take(&mut self.pending_cwd_sync);
+        v.sort_by_key(|id| id.0);
+        v.dedup();
+        v
     }
 
     /// Take and clear the list of sessions awaiting a local executor (for runner to process).
@@ -3213,9 +3217,7 @@ impl App {
     pub fn hide_interactive_view(&mut self) {
         if self.mode == AppMode::Interactive {
             let sid = self.sessions[self.active].id;
-            if !self.pending_cwd_sync.contains(&sid) {
-                self.pending_cwd_sync.push(sid);
-            }
+            self.pending_cwd_sync.push(sid);
             self.mode = AppMode::Normal;
             self.selection = None;
             self.mouse_drag = None;
@@ -6070,8 +6072,11 @@ mod tests {
         let sid = app.sessions[0].id;
         app.enter_interactive(crate::terminal::TerminalModel::new(80, 24));
         app.hide_interactive_view();
+        app.hide_interactive_view(); // mode already Normal — no second push
         app.show_interactive_view();
         app.hide_interactive_view();
+        app.hide_interactive_view(); // still Interactive→Normal once; push again while queued
+        // Two pushes from two Interactive→Normal transitions; take dedups.
         assert_eq!(app.take_pending_cwd_sync(), vec![sid]);
     }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -199,6 +199,9 @@ pub struct App {
     /// runner without closing the tab (set by session restore when the tab was
     /// in Interactive mode).
     pub pending_term_teardown: Vec<SessionId>,
+    /// SessionIds awaiting a cwd refresh from a live interactive PTY (Ctrl+T
+    /// hide keeps the PTY; runner probes OSC 7 and `set_cwd` without teardown).
+    pub pending_cwd_sync: Vec<SessionId>,
     /// SessionIds of new tabs awaiting a local executor from the runner.
     /// App signals the runner here; runner creates the executor asynchronously
     /// and stores it in its per-session map.
@@ -424,6 +427,7 @@ impl App {
             help_bar_area: Rect::default(),
             closed_ids: Vec::new(),
             pending_term_teardown: Vec::new(),
+            pending_cwd_sync: Vec::new(),
             pending_local_executors: Vec::new(),
             help_overlay_visible: false,
             help_scroll: 0,
@@ -559,6 +563,11 @@ impl App {
     /// Take and clear the list of tabs awaiting interactive-backend teardown.
     pub fn take_pending_term_teardown(&mut self) -> Vec<SessionId> {
         std::mem::take(&mut self.pending_term_teardown)
+    }
+
+    /// Take and clear tabs awaiting OSC 7 / executor cwd sync (PTY kept alive).
+    pub fn take_pending_cwd_sync(&mut self) -> Vec<SessionId> {
+        std::mem::take(&mut self.pending_cwd_sync)
     }
 
     /// Take and clear the list of sessions awaiting a local executor (for runner to process).
@@ -3198,8 +3207,15 @@ impl App {
     }
 
     /// Hide the interactive view, keeping the terminal alive in the background.
+    ///
+    /// Queues a cwd sync so the agent executor and status bar pick up any `cd`
+    /// done in the PTY (#338). The runner probes OSC 7 without closing the PTY.
     pub fn hide_interactive_view(&mut self) {
         if self.mode == AppMode::Interactive {
+            let sid = self.sessions[self.active].id;
+            if !self.pending_cwd_sync.contains(&sid) {
+                self.pending_cwd_sync.push(sid);
+            }
             self.mode = AppMode::Normal;
             self.selection = None;
             self.mouse_drag = None;
@@ -6032,10 +6048,48 @@ mod tests {
     #[test]
     fn hide_view_keeps_terminal_alive() {
         let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        let sid = app.sessions[0].id;
         app.enter_interactive(crate::terminal::TerminalModel::new(80, 24));
         app.hide_interactive_view();
         assert_eq!(app.mode, AppMode::Normal);
         assert!(app.terminal.is_some(), "terminal model must persist");
+        assert_eq!(
+            app.take_pending_cwd_sync(),
+            vec![sid],
+            "hide must queue OSC7/cwd sync for runner (#338)"
+        );
+        assert!(
+            app.take_pending_cwd_sync().is_empty(),
+            "take clears the queue"
+        );
+    }
+
+    #[test]
+    fn hide_view_queues_cwd_sync_once_per_session() {
+        let mut app = App::new("t0".into(), CommandConfirmMode::Always);
+        let sid = app.sessions[0].id;
+        app.enter_interactive(crate::terminal::TerminalModel::new(80, 24));
+        app.hide_interactive_view();
+        app.show_interactive_view();
+        app.hide_interactive_view();
+        assert_eq!(app.take_pending_cwd_sync(), vec![sid]);
+    }
+
+    #[test]
+    fn status_target_reflects_cwd_after_sync() {
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.cwd = None;
+        assert!(
+            !app.status_target().contains('/'),
+            "no pwd when unknown: {}",
+            app.status_target()
+        );
+        app.cwd = Some("/tmp/filar-cwd-sync".into());
+        assert!(
+            app.status_target().contains("/tmp/filar-cwd-sync"),
+            "status must show synced cwd: {}",
+            app.status_target()
+        );
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -91,7 +91,7 @@ fn route_term_chunk(app: &mut App, sid: SessionId, chunk: TermChunk) -> RouteOut
     }
 }
 
-/// Drain PTY output until `session.cwd` is set or `timeout` elapses.
+/// Drain PTY output until `session.cwd` is set (fresh after clear) or timeout.
 async fn drain_pty_cwd(
     app: &mut App,
     sid: SessionId,
@@ -117,6 +117,59 @@ async fn drain_pty_cwd(
                 }
             }
             _ => return,
+        }
+    }
+}
+
+/// Probe OSC 7 on a live interactive PTY, update `session.cwd`, and `set_cwd`
+/// on the agent executor. Does not close the backend (#338).
+///
+/// Always probes on Unix/SSH so a stale `session.cwd` from enter-time does not
+/// skip refresh. Restores the previous cwd if the probe times out.
+async fn sync_cwd_from_interactive(
+    app: &mut App,
+    sid: SessionId,
+    term: &Arc<dyn InteractiveTerminal>,
+    executors: &HashMap<SessionId, ExecutorEntry>,
+    term_rx: &mut Option<mpsc::UnboundedReceiver<(SessionId, TermChunk)>>,
+) {
+    let is_ssh = match executors.get(&sid) {
+        Some(e) => e.ssh_target.read().await.is_some(),
+        None => false,
+    };
+    let prev = app
+        .sessions
+        .iter()
+        .find(|s| s.id == sid)
+        .and_then(|s| s.cwd.clone());
+    if is_ssh || cfg!(unix) {
+        if let Some(idx) = app.find_session_idx(sid) {
+            app.sessions[idx].cwd = None;
+        }
+        let _ = term.write_input(OSC7_PWD_PROBE).await;
+        drain_pty_cwd(app, sid, term_rx, Duration::from_millis(400)).await;
+        let still_empty = app
+            .sessions
+            .iter()
+            .find(|s| s.id == sid)
+            .and_then(|s| s.cwd.as_ref())
+            .is_none();
+        if still_empty {
+            if let Some(idx) = app.find_session_idx(sid) {
+                app.sessions[idx].cwd = prev;
+            }
+        }
+    }
+    if let Some(cwd) = app
+        .sessions
+        .iter()
+        .find(|s| s.id == sid)
+        .and_then(|s| s.cwd.clone())
+    {
+        if let Some(entry) = executors.get(&sid) {
+            if let Err(e) = entry.executor.set_cwd(&cwd).await {
+                warn!(error = %e, "failed to sync executor cwd");
+            }
         }
     }
 }
@@ -674,38 +727,14 @@ async fn run_app(
                         // Exit interactive: capture PTY cwd, apply it to the
                         // agent executor, then close the backend.
                         if let Some((term, handle)) = interactive_backends.remove(&toggle_sid) {
-                            let is_ssh = match executors.get(&toggle_sid) {
-                                Some(e) => e.ssh_target.read().await.is_some(),
-                                None => false,
-                            };
-                            let cwd_known = app
-                                .sessions
-                                .iter()
-                                .find(|s| s.id == toggle_sid)
-                                .and_then(|s| s.cwd.as_ref())
-                                .is_some();
-                            if !cwd_known && (is_ssh || cfg!(unix)) {
-                                let _ = term.write_input(OSC7_PWD_PROBE).await;
-                                drain_pty_cwd(
-                                    &mut app,
-                                    toggle_sid,
-                                    &mut term_rx_opt,
-                                    Duration::from_millis(400),
-                                )
-                                .await;
-                            }
-                            if let Some(cwd) = app
-                                .sessions
-                                .iter()
-                                .find(|s| s.id == toggle_sid)
-                                .and_then(|s| s.cwd.clone())
-                            {
-                                if let Some(entry) = executors.get(&toggle_sid) {
-                                    if let Err(e) = entry.executor.set_cwd(&cwd).await {
-                                        warn!(error = %e, "failed to sync executor cwd");
-                                    }
-                                }
-                            }
+                            sync_cwd_from_interactive(
+                                &mut app,
+                                toggle_sid,
+                                &term,
+                                &executors,
+                                &mut term_rx_opt,
+                            )
+                            .await;
                             let _ = term.close().await;
                             handle.abort();
                         }
@@ -1180,6 +1209,23 @@ async fn run_app(
             if let Some((term, handle)) = interactive_backends.remove(&sid) {
                 let _ = term.close().await;
                 handle.abort();
+            }
+        }
+
+        // Ctrl+T hide: refresh session.cwd + agent executor from the live PTY
+        // without tearing it down (#338).
+        for sid in app.take_pending_cwd_sync() {
+            if let Some((term, _)) = interactive_backends.get(&sid) {
+                let term = term.clone();
+                sync_cwd_from_interactive(
+                    &mut app,
+                    sid,
+                    &term,
+                    &executors,
+                    &mut term_rx_opt,
+                )
+                .await;
+                needs_redraw = true;
             }
         }
 

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -146,20 +146,26 @@ async fn sync_cwd_from_interactive(
         if let Some(idx) = app.find_session_idx(sid) {
             app.sessions[idx].cwd = None;
         }
-        let _ = term.write_input(OSC7_PWD_PROBE).await;
-        drain_pty_cwd(app, sid, term_rx, Duration::from_millis(400)).await;
-        let still_empty = app
-            .sessions
-            .iter()
-            .find(|s| s.id == sid)
-            .and_then(|s| s.cwd.as_ref())
-            .is_none();
-        if still_empty {
+        if term.write_input(OSC7_PWD_PROBE).await.is_err() {
             if let Some(idx) = app.find_session_idx(sid) {
                 app.sessions[idx].cwd = prev;
             }
+        } else {
+            drain_pty_cwd(app, sid, term_rx, Duration::from_millis(400)).await;
+            let still_empty = app
+                .sessions
+                .iter()
+                .find(|s| s.id == sid)
+                .and_then(|s| s.cwd.as_ref())
+                .is_none();
+            if still_empty {
+                if let Some(idx) = app.find_session_idx(sid) {
+                    app.sessions[idx].cwd = prev;
+                }
+            }
         }
     }
+    // Always apply known cwd to the executor (incl. Windows last-known path).
     if let Some(cwd) = app
         .sessions
         .iter()

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -11,7 +11,7 @@ Add findings here whenever a platform difference is discovered.
 | macOS Ctrl vs ⌘, Fn+F1 | [macOS shortcuts](#macos-shortcuts) | #292 |
 | Windows console missing `⌘` glyph | [TUI help overlay glyphs](#tui-help-overlay-glyphs) | #310 |
 | GUI launcher paste / show password | [GUI launcher secrets](#gui-launcher-secrets-macos) | #312 |
-| Interactive PTY shell | [Local interactive shell](#local-interactive-shell-ctrlt) | #293, #313 |
+| Interactive PTY shell | [Local interactive shell](#local-interactive-shell-ctrlt) | #293, #313, #338 |
 | Release assets / packaging | [Release binaries (CI)](#release-binaries-ci) | #289, #297, #80 |
 | Chat wrap display columns | [Chat display width vs char count](#chat-display-width-vs-char-count-333) | #333 |
 
@@ -226,11 +226,13 @@ and `logs/` all share this single app root.
 > `sh -c`, Windows PowerShell. Only the interactive PTY follows `$SHELL`
 > ([#293](https://github.com/devlawey/filar/issues/293)).
 >
-> Cwd sync (#313): on Unix/macOS and on SSH (POSIX remote), leaving
-> interactive can emit OSC 7 via `printf`/`pwd` if the shell did not.
-> Windows **local** interactive is `cmd.exe`, which typically does not
-> emit OSC 7; leave-sync then uses the last known tab cwd only. Entering
-> interactive still spawns `cmd.exe` with `CommandBuilder::cwd`.
+> Cwd sync (#313, #338): on Unix/macOS and on SSH (POSIX remote), **hiding**
+> interactive (`Ctrl+T`) or fully leaving it probes OSC 7 via `printf`/`pwd`
+> and applies `CommandExecutor::set_cwd`, so the status bar and agent/`!`
+> commands share the PTY directory. A stale enter-time cwd does not skip the
+> probe. Windows **local** interactive is `cmd.exe`, which typically does not
+> emit OSC 7; sync then keeps the last known tab cwd. Entering interactive
+> still spawns `cmd.exe` with `CommandBuilder::cwd`.
 
 ## Agent local commands and controlling TTY (#329)
 


### PR DESCRIPTION
## Summary
- Ctrl+T **hide** queues `pending_cwd_sync`; runner probes OSC 7 and `set_cwd` without closing the PTY (#338).
- Always probe on Unix/SSH (stale enter-time cwd no longer skips refresh); restore previous cwd on timeout.
- Same helper used on full interactive teardown; PLATFORM_NOTES updated.

Closes #338

## Test plan
- [x] `cargo test -p filar-tui --lib hide_view`
- [x] `cargo test -p filar-tui --lib status_target_reflects`
- [x] `cargo test --workspace`
- [ ] Manual: `Ctrl+T` → `cd /tmp` → `Ctrl+T` → status bar shows `/tmp`, `!pwd` matches (agent cannot drive PTY)

**DoD note:** Interactive PTY cannot be driven from this agent environment; unit tests cover the hide→queue contract and status string.