### PR TITLE
feat(tui): native file/folder picker inserts path in agent input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Ctrl+S Markdown export filenames include a short topic slug from the first
   user message (`host.topic.date.time.md`)
   ([#343](https://github.com/devlawey/filar/issues/343)).
+- Native file/folder picker in agent input: `/` at path-token start, `Ctrl+Shift+F`
+  (file), `Ctrl+Shift+D` (folder); inserts quoted absolute path from local FS
+  ([#344](https://github.com/devlawey/filar/issues/344)).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "filar-transport",
  "futures",
  "ratatui",
+ "rfd",
  "tokio",
  "tokio-util",
  "tracing",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5058,3 +5058,19 @@ preview from the first user message.
 **Public contract:** none.
 
 **Next steps:** none (filename unit-tested).
+
+## Issue #344: feat(tui) — file/folder picker in agent input
+
+**Milestone:** 1.0.3. **Branch:** `feat/344-path-picker`.
+
+**Problem:** typing long absolute paths in agent input is awkward.
+
+**Design:** `path_picker` module (`rfd`); `/` at path-token start or
+`Ctrl+Shift+F`/`Ctrl+Shift+D` queue picker; runner suspends TUI, opens native
+dialog, inserts quoted path + trailing space. Local FS only (zero-install).
+
+**Done:** `path_picker.rs`, App wiring, help entries, unit tests; CHANGELOG.
+
+**Public contract:** none.
+
+**Next steps:** human smoke native dialog on macOS (agent cannot open GUI).

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -19,5 +19,6 @@ alacritty_terminal = { workspace = true }
 arboard = { workspace = true }
 chrono = { workspace = true }
 tokio-util = { workspace = true }
+rfd = { workspace = true }
 # Match ratatui 0.28 (display columns for wrap/pad; #333).
 unicode-width = "0.1"

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -253,6 +253,8 @@ pub struct App {
     pub session_select_index: usize,
     /// Cached list of saved session metadata shown in the overlay.
     pub session_select_metas: Vec<SessionMeta>,
+    /// Native path picker queued from Normal input (^⇧F / `/` at path start).
+    pub pending_path_picker: Option<crate::path_picker::PathPickerKind>,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -452,6 +454,7 @@ impl App {
             session_select_visible: false,
             session_select_index: 0,
             session_select_metas: Vec::new(),
+            pending_path_picker: None,
         }
     }
 
@@ -1758,6 +1761,23 @@ impl App {
             return;
         }
 
+        // Ctrl+Shift+F / Ctrl+Shift+D — native file/folder picker (#344).
+        if self.mode == AppMode::Normal {
+            let ctrl_shift_key = |en: char, ru: char| {
+                key.modifiers.contains(KeyModifiers::CONTROL)
+                    && key.modifiers.contains(KeyModifiers::SHIFT)
+                    && matches!(key.code, KeyCode::Char(c) if c.eq_ignore_ascii_case(&en) || c == ru)
+            };
+            if ctrl_shift_key('f', 'а') {
+                self.pending_path_picker = Some(crate::path_picker::PathPickerKind::File);
+                return;
+            }
+            if ctrl_shift_key('d', 'в') {
+                self.pending_path_picker = Some(crate::path_picker::PathPickerKind::Folder);
+                return;
+            }
+        }
+
         // Global control hotkeys — active in every mode EXCEPT Interactive, where
         // all keys (including ^Q/^Z/^C) are forwarded to the remote PTY.
         //
@@ -1908,7 +1928,17 @@ impl App {
                 KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                     // Any char input cancels history browsing.
                     self.history_pos = None;
-                    self.insert_char(c);
+                    if c == '/'
+                        && crate::path_picker::path_token_starts_at_cursor(
+                            &self.input,
+                            self.cursor_pos,
+                        )
+                    {
+                        self.pending_path_picker =
+                            Some(crate::path_picker::PathPickerKind::File);
+                    } else {
+                        self.insert_char(c);
+                    }
                 }
                 KeyCode::Backspace => {
                     self.history_pos = None;
@@ -3300,6 +3330,28 @@ impl App {
     }
 
     // ----- Input editing helpers (char-index based) -----
+
+    /// Take a queued native path-picker request (handled by the runner).
+    pub fn take_pending_path_picker(&mut self) -> Option<crate::path_picker::PathPickerKind> {
+        self.pending_path_picker.take()
+    }
+
+    /// Insert a filesystem path at the input cursor (Normal / Confirming).
+    pub fn insert_path_at_cursor(&mut self, path: &std::path::Path) {
+        if !matches!(self.mode, AppMode::Normal | AppMode::Confirming) {
+            return;
+        }
+        let formatted = crate::path_picker::format_path_for_input(path);
+        if formatted.is_empty() {
+            return;
+        }
+        let text = if formatted.ends_with(' ') {
+            formatted
+        } else {
+            format!("{formatted} ")
+        };
+        self.paste_text(&text);
+    }
 
     /// Insert a character at the cursor position.
     fn insert_char(&mut self, c: char) {
@@ -6580,6 +6632,83 @@ mod tests {
         app.input = "before".into();
         app.paste_text("pasted");
         assert_eq!(app.input, "before", "paste must be no-op in Thinking mode");
+    }
+
+    // ── Path picker tests (#344) ──────────────────────────────────────
+
+    #[test]
+    fn slash_at_path_token_start_queues_file_picker() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('/'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.input, "", "slash must not be inserted when picker opens");
+        assert_eq!(
+            app.pending_path_picker,
+            Some(crate::path_picker::PathPickerKind::File)
+        );
+    }
+
+    #[test]
+    fn slash_mid_token_inserts_normally() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.input = "foo".into();
+        app.cursor_pos = 3;
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('/'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.input, "foo/");
+        assert!(app.pending_path_picker.is_none());
+    }
+
+    #[test]
+    fn ctrl_shift_f_queues_file_picker() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('F'),
+            crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::SHIFT,
+        ));
+        assert_eq!(
+            app.pending_path_picker,
+            Some(crate::path_picker::PathPickerKind::File)
+        );
+    }
+
+    #[test]
+    fn ctrl_shift_d_queues_folder_picker() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('D'),
+            crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::SHIFT,
+        ));
+        assert_eq!(
+            app.pending_path_picker,
+            Some(crate::path_picker::PathPickerKind::Folder)
+        );
+    }
+
+    #[test]
+    fn insert_path_at_cursor_quotes_spaces_and_adds_trailing_space() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.insert_path_at_cursor(std::path::Path::new("/tmp/my dir"));
+        assert_eq!(app.input, "'/tmp/my dir' ");
+        app.input.clear();
+        app.cursor_pos = 0;
+        app.insert_path_at_cursor(std::path::Path::new("/tmp/a"));
+        assert_eq!(app.input, "/tmp/a ");
+    }
+
+    #[test]
+    fn take_pending_path_picker_clears_queue() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.pending_path_picker = Some(crate::path_picker::PathPickerKind::Folder);
+        assert_eq!(
+            app.take_pending_path_picker(),
+            Some(crate::path_picker::PathPickerKind::Folder)
+        );
+        assert!(app.pending_path_picker.is_none());
     }
 
     #[test]

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -12,6 +12,7 @@ pub mod confirmer;
 pub mod event;
 /// Tracing layer that mirrors WARN/ERROR log records into the chat.
 pub mod log_layer;
+pub mod path_picker;
 pub mod runner;
 pub mod terminal;
 pub mod ui;

--- a/crates/tui/src/path_picker.rs
+++ b/crates/tui/src/path_picker.rs
@@ -1,0 +1,100 @@
+//! Native file/folder picker for inserting paths into agent input (#344).
+//!
+//! Opens an OS dialog while temporarily leaving ratatui raw mode so the
+//! picker can display. Local client filesystem only — not remote SSH paths.
+
+use std::io::{self, Stdout};
+use std::path::{Path, PathBuf};
+
+use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
+use crossterm::execute;
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+
+/// Which native picker to show.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathPickerKind {
+    File,
+    Folder,
+}
+
+/// True when `/` at the cursor would start an absolute-path token (input start or after space).
+pub fn path_token_starts_at_cursor(input: &str, cursor_pos: usize) -> bool {
+    if cursor_pos == 0 {
+        return true;
+    }
+    input
+        .char_indices()
+        .nth(cursor_pos.saturating_sub(1))
+        .map(|(_, c)| c.is_whitespace())
+        .unwrap_or(false)
+}
+
+/// Format a filesystem path for insertion into the single-line input field.
+pub fn format_path_for_input(path: &Path) -> String {
+    let s = path.to_string_lossy();
+    if s.contains(' ') || s.contains('\t') {
+        let escaped = s.replace('\'', "'\\''");
+        format!("'{escaped}'")
+    } else {
+        s.into_owned()
+    }
+}
+
+/// Blockingly open the native picker (call from `spawn_blocking`).
+pub fn pick_path(kind: PathPickerKind) -> Option<PathBuf> {
+    let dialog = rfd::FileDialog::new();
+    match kind {
+        PathPickerKind::File => dialog.pick_file(),
+        PathPickerKind::Folder => dialog.pick_folder(),
+    }
+}
+
+/// Leave TUI mode so a native dialog can appear.
+pub fn suspend_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) {
+    disable_raw_mode().ok();
+    execute!(
+        io::stdout(),
+        DisableBracketedPaste,
+        crossterm::event::DisableMouseCapture,
+        LeaveAlternateScreen
+    )
+    .ok();
+    terminal.hide_cursor().ok();
+}
+
+/// Re-enter TUI mode after the native dialog closes.
+pub fn resume_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) {
+    enable_raw_mode().ok();
+    execute!(
+        io::stdout(),
+        EnterAlternateScreen,
+        crossterm::event::EnableMouseCapture,
+        EnableBracketedPaste
+    )
+    .ok();
+    terminal.clear().ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_token_start_at_beginning_or_after_space() {
+        assert!(path_token_starts_at_cursor("", 0));
+        assert!(path_token_starts_at_cursor("cd /tmp", 3));
+        assert!(!path_token_starts_at_cursor("/tmp", 1));
+        assert!(!path_token_starts_at_cursor("foo/bar", 3));
+    }
+
+    #[test]
+    fn format_path_quotes_spaces() {
+        assert_eq!(format_path_for_input(Path::new("/tmp/a")), "/tmp/a");
+        assert_eq!(
+            format_path_for_input(Path::new("/tmp/my dir")),
+            "'/tmp/my dir'"
+        );
+    }
+}

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -28,6 +28,7 @@ use tokio_util::sync::CancellationToken;
 use crate::app::{App, AppMode, SaveProgress, SessionId};
 use crate::confirmer::TuiConfirmer;
 use crate::event::TuiEvent;
+use crate::path_picker;
 use crate::terminal::TerminalModel;
 use crate::ui;
 
@@ -724,6 +725,20 @@ async fn run_app(
                         error!(error = %e, "terminal event error");
                     }
                     None => {} // stream ended
+                }
+
+                // Native file/folder picker (#344): suspend TUI, open dialog, insert path.
+                if let Some(kind) = app.take_pending_path_picker() {
+                    path_picker::suspend_terminal(&mut *terminal);
+                    let picked =
+                        tokio::task::spawn_blocking(move || path_picker::pick_path(kind)).await;
+                    path_picker::resume_terminal(&mut *terminal);
+                    match picked {
+                        Ok(Some(path)) => app.insert_path_at_cursor(&path),
+                        Ok(None) => {}
+                        Err(e) => warn!(error = %e, "path picker task panicked"),
+                    }
+                    needs_redraw = true;
                 }
 
                 // Handle mode toggle (Ctrl+T).

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -239,6 +239,24 @@ pub(crate) fn help_registry() -> Vec<HelpEntry> {
             available: |m| m == AppMode::Normal,
         },
         HelpEntry {
+            key: "/",
+            desc: "At path-token start: open file picker (local FS)",
+            section: "Input",
+            available: |m| m == AppMode::Normal,
+        },
+        HelpEntry {
+            key: "^Shift+F",
+            desc: "Open file picker (local FS)",
+            section: "Input",
+            available: |m| m == AppMode::Normal,
+        },
+        HelpEntry {
+            key: "^Shift+D",
+            desc: "Open folder picker (local FS)",
+            section: "Input",
+            available: |m| m == AppMode::Normal,
+        },
+        HelpEntry {
             key: "Up / Down",
             desc: "Browse input history",
             section: "Input",


### PR DESCRIPTION
## Summary

- Add `path_picker` module using `rfd`: suspend TUI, open native OS dialog, resume and insert formatted absolute path at cursor.
- Triggers in Normal mode: `/` at path-token start (file), `Ctrl+Shift+F` (file), `Ctrl+Shift+D` (folder).
- Paths with spaces are single-quoted; trailing space added after insert. Help overlay updated.

Closes #344

## Test plan

- [x] `cargo test -p filar-tui` — path picker unit tests (token detection, quoting, hotkey queue, insert)
- [ ] Manual smoke (agent cannot run TUI): in agent input, type `/` at start → file picker → path inserted; `Ctrl+Shift+D` → folder picker; cancel leaves input unchanged

## Notes

- Local client FS only — not remote SSH listing (zero-install).
- UX: `/` opens **file** picker (not folder); folder via `Ctrl+Shift+D`.


Made with [Cursor](https://cursor.com)