### PR TITLE
fix(tui): confirm overlay on wrong tab in multi-tab mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 - Ctrl+O host switch tears down the tab's interactive PTY/`TerminalModel`
   so the previous host's shell cannot be reused after reconnect
   ([#339](https://github.com/devlawey/filar/issues/339)).
+- Confirm overlay no longer opens on the wrong tab when the agent on a
+  background session requests approval; auto-switches to the originating tab
+  ([#345](https://github.com/devlawey/filar/issues/345)).
 
 ## [1.0.2] - 2026-08-21
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5074,3 +5074,17 @@ dialog, inserts quoted path + trailing space. Local FS only (zero-install).
 **Public contract:** none.
 
 **Next steps:** human smoke native dialog on macOS (agent cannot open GUI).
+
+## Issue #345: fix(tui) — confirm overlay on wrong tab
+
+**Milestone:** 1.0.3. **Branch:** `fix/345-confirm-wrong-tab`.
+
+**Problem:** `ConfirmationRequest` had no `session_id`; confirm landed on active tab B while agent ran on A.
+
+**Design:** per-session `TuiConfirmer`; `session_id` on event; dispatch like Agent events; auto-switch active tab on confirm (no restore).
+
+**Done:** event/confirmer/runner/app + multi-tab unit test; CHANGELOG.
+
+**Public contract:** `TuiEvent::ConfirmationRequest` gains `session_id`; `TuiConfirmer::new(tx, sid)`.
+
+**Next steps:** human multi-tab smoke (agent cannot drive TUI).

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -3069,10 +3069,11 @@ impl App {
 
     /// Handle a TUI event (forwarded agent event or TUI-specific event).
     pub fn handle_agent_event(&mut self, event: TuiEvent) {
+        let is_confirm_request = matches!(&event, TuiEvent::ConfirmationRequest { .. });
         let sid = match &event {
             TuiEvent::Agent { session_id, .. } => *session_id,
             TuiEvent::Thinking => self.sessions[self.active].id,
-            TuiEvent::ConfirmationRequest { .. } => self.sessions[self.active].id,
+            TuiEvent::ConfirmationRequest { session_id, .. } => *session_id,
             TuiEvent::TransportChanged { session_id, .. } => *session_id,
             TuiEvent::CwdChanged { session_id, .. } => *session_id,
             TuiEvent::PasswordNeeded { session_id, .. } => *session_id,
@@ -3217,6 +3218,7 @@ impl App {
                 self.mode = AppMode::Thinking;
             }
             TuiEvent::ConfirmationRequest {
+                session_id: _,
                 command,
                 explanation,
                 destructive,
@@ -3264,8 +3266,10 @@ impl App {
         } else {
             self.active_session_mut().awaiting_confirmation = false;
         }
-        // Restore the original active tab.
-        self.active = orig_active;
+        // Restore the original active tab — except confirm: stay on originating tab (#345).
+        if !is_confirm_request {
+            self.active = orig_active;
+        }
     }
 
     /// Take the pending user input (called by the runner to send to the agent).
@@ -4563,6 +4567,7 @@ mod tests {
         // Simulate a new confirmation request.
         let (tx, _rx) = oneshot::channel::<bool>();
         app.handle_agent_event(TuiEvent::ConfirmationRequest {
+            session_id: app.sessions[0].id,
             command: "ls".into(),
             explanation: "list".into(),
             destructive: false,
@@ -5000,6 +5005,7 @@ mod tests {
 
         let (tx, _rx) = oneshot::channel::<bool>();
         app.handle_agent_event(TuiEvent::ConfirmationRequest {
+            session_id: app.sessions[0].id,
             command: "ls".into(),
             explanation: "list files".into(),
             destructive: false,
@@ -5008,6 +5014,35 @@ mod tests {
 
         assert!(!app.streaming);
         assert_eq!(app.mode, AppMode::Confirming);
+    }
+
+    #[test]
+    fn confirmation_request_on_background_tab_switches_active() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.new_tab();
+        let sid_a = app.sessions[0].id;
+        app.active = 1;
+        app.sessions[0].mode = AppMode::Thinking;
+        app.sessions[0].agent_running = true;
+
+        let (tx, mut rx) = oneshot::channel();
+        app.handle_agent_event(TuiEvent::ConfirmationRequest {
+            session_id: sid_a,
+            command: "rm x".into(),
+            explanation: "cleanup".into(),
+            destructive: true,
+            respond_to: tx,
+        });
+
+        assert_eq!(app.active, 0, "must auto-switch to originating tab");
+        assert_eq!(app.sessions[0].mode, AppMode::Confirming);
+        assert_eq!(app.sessions[1].mode, AppMode::Normal);
+        assert!(app.sessions[0].pending_confirm.is_some());
+        assert!(app.sessions[1].pending_confirm.is_none());
+
+        app.handle_key(key_event(crossterm::event::KeyCode::Char('a')));
+        assert_eq!(app.sessions[0].mode, AppMode::Thinking);
+        assert_eq!(rx.try_recv(), Ok(true));
     }
 
     #[test]

--- a/crates/tui/src/confirmer.rs
+++ b/crates/tui/src/confirmer.rs
@@ -10,17 +10,22 @@ use tracing::debug;
 use filar_agent::CommandConfirmer;
 use filar_core::{CoreError, Result};
 
+use crate::app::SessionId;
 use crate::event::TuiEvent;
 
 /// A [`CommandConfirmer`] that delegates to the TUI via channels.
 pub struct TuiConfirmer {
     event_tx: mpsc::UnboundedSender<TuiEvent>,
+    session_id: SessionId,
 }
 
 impl TuiConfirmer {
-    /// Create a new TUI confirmer that sends events to the given channel.
-    pub fn new(event_tx: mpsc::UnboundedSender<TuiEvent>) -> Self {
-        Self { event_tx }
+    /// Create a confirmer bound to one session tab.
+    pub fn new(event_tx: mpsc::UnboundedSender<TuiEvent>, session_id: SessionId) -> Self {
+        Self {
+            event_tx,
+            session_id,
+        }
     }
 }
 
@@ -38,6 +43,7 @@ impl CommandConfirmer for TuiConfirmer {
 
         self.event_tx
             .send(TuiEvent::ConfirmationRequest {
+                session_id: self.session_id,
                 command: command.to_string(),
                 explanation: explanation.to_string(),
                 destructive,

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -32,6 +32,7 @@ pub enum TuiEvent {
     /// The UI must respond via the included [`oneshot::Sender`]:
     /// `true` = approve, `false` = deny.
     ConfirmationRequest {
+        session_id: SessionId,
         command: String,
         explanation: String,
         destructive: bool,
@@ -67,6 +68,24 @@ pub enum TuiEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn confirmation_request_carries_session_id() {
+        let sid = SessionId(99);
+        let (_tx, _rx) = oneshot::channel();
+        let event = TuiEvent::ConfirmationRequest {
+            session_id: sid,
+            command: "ls".into(),
+            explanation: "list".into(),
+            destructive: false,
+            respond_to: _tx,
+        };
+        if let TuiEvent::ConfirmationRequest { session_id, .. } = event {
+            assert_eq!(session_id, SessionId(99));
+        } else {
+            panic!("expected ConfirmationRequest");
+        }
+    }
 
     #[test]
     fn transport_changed_carries_session_id() {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -496,9 +496,6 @@ async fn run_app(
     // Receiver for WARN/ERROR log lines mirrored into the chat.
     let mut log_rx = config.log_rx.take();
 
-    // Create the TUI confirmer.
-    let confirmer = Arc::new(TuiConfirmer::new(agent_tx.clone()));
-
     // Per-session executors. The initial executor (from main.rs) is stored
     // for the start-up session; new tabs get a LocalExecutor created on demand.
     let initial_tui = Arc::new(TuiExecutor {
@@ -957,7 +954,6 @@ async fn run_app(
                         spawn_agent(
                             session_llm,
                             agent_exec,
-                            confirmer.clone(),
                             app.confirm_mode,
                             user_input,
                             app.messages.clone(),
@@ -1592,7 +1588,6 @@ pub fn resize_all_models(app: &mut App, cols: u16, rows: u16) {
 fn spawn_agent(
     llm: Arc<dyn LlmClient>,
     executor: Arc<dyn CommandExecutor>,
-    confirmer: Arc<dyn CommandConfirmer>,
     confirm_mode: CommandConfirmMode,
     user_input: String,
     chat_history: Vec<ChatBlock>,
@@ -1604,6 +1599,7 @@ fn spawn_agent(
     sid: SessionId,
 ) {
     let tx = event_tx.clone();
+    let confirmer = Arc::new(TuiConfirmer::new(event_tx.clone(), sid)) as Arc<dyn CommandConfirmer>;
 
     tokio::spawn(async move {
         let _ = tx.send(TuiEvent::Thinking);


### PR DESCRIPTION
## Summary

- Add `session_id` to `TuiEvent::ConfirmationRequest`; `TuiConfirmer` is created per agent spawn with that tab's id.
- `handle_agent_event` routes confirm to the originating session (like `Agent` events) and auto-switches the active tab instead of restoring the previous one.

Closes #345

## Test plan

- [x] `cargo test -p filar-tui` — 381 tests including `confirmation_request_on_background_tab_switches_active`
- [ ] Manual smoke (agent cannot drive TUI): two tabs, agent on A needs confirm while viewing B → UI switches to A with confirm modal; Approve/Deny reaches agent A

## UX choice

Auto-switch active tab to the originating session when confirm arrives (preferred in issue).


Made with [Cursor](https://cursor.com)