### PR TITLE
feat(tui): in-TUI path picker on active target (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   same `{host}.{topic}.{timestamp}.md` naming as manual export
   ([#350](https://github.com/devlawey/filar/issues/350)).
 
+### Changed
+
+- Agent input path picker (`/`, `Ctrl+Shift+F`, `Ctrl+Shift+D`) is now an in-TUI
+  overlay that lists directories on the **active target** (local FS or remote via
+  readonly `ls` over SSH), replacing the native OS dialog that always showed the
+  client filesystem ([#351](https://github.com/devlawey/filar/issues/351)).
+
 ## [1.0.3] - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,6 @@ dependencies = [
  "filar-transport",
  "futures",
  "ratatui",
- "rfd",
  "tokio",
  "tokio-util",
  "tracing",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5106,6 +5106,24 @@ and `toggle_explain` use `App::messages`; regression unit tests.
 
 **Next steps:** merge PR; human smoke Ctrl+S + F2 on SSH session.
 
+## Issue #351: fix(tui) — in-TUI path picker on target host
+
+**Milestone:** 1.0.4. **Branch:** `fix/351-tui-path-picker-target-host`.
+
+**Problem:** #344 native `rfd` dialog always listed local client FS; on SSH tabs
+users expected paths on the remote host.
+
+**Design:** in-TUI overlay (like F3 session select); local `read_dir`, remote
+readonly `ls` via session executor; unified picker for local + SSH tabs; removed
+`rfd` from `filar-tui`.
+
+**Done:** `path_picker.rs`, `ui/path_picker_overlay.rs`, runner async load,
+help/CHANGELOG updates, unit tests.
+
+**Public contract:** none (TUI-only).
+
+**Next steps:** manual smoke SSH + local path insert.
+
 ## Release v1.0.3 (2026-08-24)
 
 **Scope:** milestone 1.0.3 — TUI polish (Ctrl+S filename, path picker, confirm

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -19,6 +19,5 @@ alacritty_terminal = { workspace = true }
 arboard = { workspace = true }
 chrono = { workspace = true }
 tokio-util = { workspace = true }
-rfd = { workspace = true }
 # Match ratatui 0.28 (display columns for wrap/pad; #333).
 unicode-width = "0.1"

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -255,6 +255,17 @@ pub struct App {
     pub session_select_metas: Vec<SessionMeta>,
     /// Native path picker queued from Normal input (^⇧F / `/` at path start).
     pub pending_path_picker: Option<crate::path_picker::PathPickerKind>,
+    /// In-TUI path picker overlay (#351).
+    pub path_picker_visible: bool,
+    pub path_picker_kind: crate::path_picker::PathPickerKind,
+    pub path_picker_dir: String,
+    pub path_picker_entries: Vec<crate::path_picker::PathEntry>,
+    pub path_picker_index: usize,
+    pub path_picker_loading: bool,
+    pub path_picker_error: Option<String>,
+    pub path_picker_truncated: bool,
+    /// Bumped to request (re)load of `path_picker_dir` in the runner.
+    pub path_picker_load_token: u64,
 }
 
 /// Stable identifier for a session tab. Assigned once on creation, never
@@ -455,6 +466,15 @@ impl App {
             session_select_index: 0,
             session_select_metas: Vec::new(),
             pending_path_picker: None,
+            path_picker_visible: false,
+            path_picker_kind: crate::path_picker::PathPickerKind::File,
+            path_picker_dir: String::new(),
+            path_picker_entries: Vec::new(),
+            path_picker_index: 0,
+            path_picker_loading: false,
+            path_picker_error: None,
+            path_picker_truncated: false,
+            path_picker_load_token: 0,
         }
     }
 
@@ -1741,6 +1761,25 @@ impl App {
             return;
         }
 
+        // In-TUI path picker (#351): navigate directories on the active target.
+        if self.path_picker_visible {
+            let list_size = self.path_picker_entries.len();
+            match key.code {
+                KeyCode::Esc => self.close_path_picker(),
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.path_picker_index = self.path_picker_index.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if self.path_picker_index + 1 < list_size {
+                        self.path_picker_index += 1;
+                    }
+                }
+                KeyCode::Enter => self.path_picker_activate(),
+                _ => {}
+            }
+            return;
+        }
+
         // When the session-selection overlay is visible, only navigation and
         // select/cancel keys are processed; all other keys are consumed.
         if self.session_select_visible {
@@ -1771,7 +1810,7 @@ impl App {
             return;
         }
 
-        // Ctrl+Shift+F / Ctrl+Shift+D — native file/folder picker (#344).
+        // Ctrl+Shift+F / Ctrl+Shift+D — in-TUI file/folder picker (#344, #351).
         if self.mode == AppMode::Normal {
             let ctrl_shift_key = |en: char, ru: char| {
                 key.modifiers.contains(KeyModifiers::CONTROL)
@@ -3345,13 +3384,85 @@ impl App {
 
     // ----- Input editing helpers (char-index based) -----
 
-    /// Take a queued native path-picker request (handled by the runner).
+    /// Take a queued path-picker request (handled by the runner).
     pub fn take_pending_path_picker(&mut self) -> Option<crate::path_picker::PathPickerKind> {
         self.pending_path_picker.take()
     }
 
-    /// Insert a filesystem path at the input cursor (Normal / Confirming).
-    pub fn insert_path_at_cursor(&mut self, path: &std::path::Path) {
+    /// Open the in-TUI path picker overlay.
+    pub fn open_path_picker(&mut self, kind: crate::path_picker::PathPickerKind) {
+        let session = &self.sessions[self.active];
+        let is_remote = session.ssh_info.is_some();
+        self.path_picker_kind = kind;
+        self.path_picker_dir =
+            crate::path_picker::initial_picker_dir(&session.cwd, is_remote);
+        self.path_picker_index = 0;
+        self.path_picker_entries.clear();
+        self.path_picker_loading = true;
+        self.path_picker_error = None;
+        self.path_picker_truncated = false;
+        self.path_picker_visible = true;
+        self.path_picker_load_token = self.path_picker_load_token.wrapping_add(1);
+    }
+
+    pub fn close_path_picker(&mut self) {
+        self.path_picker_visible = false;
+        self.path_picker_loading = false;
+        self.path_picker_error = None;
+        self.path_picker_entries.clear();
+    }
+
+    pub fn path_picker_navigate(&mut self, dir: String) {
+        self.path_picker_dir = dir;
+        self.path_picker_index = 0;
+        self.path_picker_loading = true;
+        self.path_picker_error = None;
+        self.path_picker_load_token = self.path_picker_load_token.wrapping_add(1);
+    }
+
+    pub fn apply_path_picker_load(
+        &mut self,
+        entries: Vec<crate::path_picker::PathEntry>,
+        truncated: bool,
+        error: Option<String>,
+    ) {
+        self.path_picker_loading = false;
+        self.path_picker_truncated = truncated;
+        self.path_picker_error = error;
+        self.path_picker_entries =
+            crate::path_picker::entries_with_parent(&self.path_picker_dir, entries);
+        if self.path_picker_index >= self.path_picker_entries.len() {
+            self.path_picker_index = self.path_picker_entries.len().saturating_sub(1);
+        }
+    }
+
+    fn path_picker_activate(&mut self) {
+        let Some(entry) = self.path_picker_entries.get(self.path_picker_index).cloned() else {
+            return;
+        };
+        if entry.name == ".." {
+            if let Some(parent) = crate::path_picker::parent_path(&self.path_picker_dir) {
+                self.path_picker_navigate(parent);
+            }
+            return;
+        }
+        if entry.is_dir {
+            let path = crate::path_picker::join_path(&self.path_picker_dir, &entry.name);
+            if self.path_picker_kind == crate::path_picker::PathPickerKind::Folder {
+                self.insert_path_string_at_cursor(&path);
+                self.close_path_picker();
+            } else {
+                self.path_picker_navigate(path);
+            }
+        } else if self.path_picker_kind == crate::path_picker::PathPickerKind::File {
+            let path = crate::path_picker::join_path(&self.path_picker_dir, &entry.name);
+            self.insert_path_string_at_cursor(&path);
+            self.close_path_picker();
+        }
+    }
+
+    /// Insert a path string at the input cursor (Normal / Confirming).
+    pub fn insert_path_string_at_cursor(&mut self, path: &str) {
         if !matches!(self.mode, AppMode::Normal | AppMode::Confirming) {
             return;
         }
@@ -3365,6 +3476,11 @@ impl App {
             format!("{formatted} ")
         };
         self.paste_text(&text);
+    }
+
+    /// Insert a filesystem path at the input cursor (Normal / Confirming).
+    pub fn insert_path_at_cursor(&mut self, path: &std::path::Path) {
+        self.insert_path_string_at_cursor(&path.to_string_lossy());
     }
 
     /// Insert a character at the cursor position.
@@ -6732,6 +6848,43 @@ mod tests {
             app.pending_path_picker,
             Some(crate::path_picker::PathPickerKind::Folder)
         );
+    }
+
+    #[test]
+    fn open_path_picker_sets_remote_root() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.sessions[0].ssh_info = Some("root@host:22".into());
+        app.open_path_picker(crate::path_picker::PathPickerKind::File);
+        assert!(app.path_picker_visible);
+        assert_eq!(app.path_picker_dir, "/");
+        assert!(app.path_picker_loading);
+        assert_eq!(app.path_picker_load_token, 1);
+    }
+
+    #[test]
+    fn path_picker_file_select_inserts_absolute_path() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.path_picker_visible = true;
+        app.path_picker_kind = crate::path_picker::PathPickerKind::File;
+        app.path_picker_dir = "/etc".into();
+        app.path_picker_entries = vec![crate::path_picker::PathEntry {
+            name: "hosts".into(),
+            is_dir: false,
+        }];
+        app.path_picker_activate();
+        assert!(!app.path_picker_visible);
+        assert_eq!(app.input, "/etc/hosts ");
+    }
+
+    #[test]
+    fn path_picker_esc_cancels() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.open_path_picker(crate::path_picker::PathPickerKind::Folder);
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Esc,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(!app.path_picker_visible);
     }
 
     #[test]

--- a/crates/tui/src/path_picker.rs
+++ b/crates/tui/src/path_picker.rs
@@ -1,23 +1,29 @@
-//! Native file/folder picker for inserting paths into agent input (#344).
+//! In-TUI file/folder picker for inserting paths into agent input (#344, #351).
 //!
-//! Opens an OS dialog while temporarily leaving ratatui raw mode so the
-//! picker can display. Local client filesystem only — not remote SSH paths.
+//! Lists directories on the active target: local FS via `std::fs`, remote via
+//! readonly `ls` through the session executor (zero-install).
 
-use std::io::{self, Stdout};
 use std::path::{Path, PathBuf};
 
-use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
-use crossterm::execute;
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
-use ratatui::backend::CrosstermBackend;
-use ratatui::Terminal;
+use filar_core::{CoreError, Result};
+use filar_transport::posix_shell_quote;
 
-/// Which native picker to show.
+/// Which picker mode to show.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathPickerKind {
     File,
     Folder,
 }
+
+/// One row in the picker list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathEntry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+/// Maximum directory entries shown (extra rows trigger a warning).
+pub const MAX_ENTRIES: usize = 500;
 
 /// True when `/` at the cursor would start an absolute-path token (input start or after space).
 pub fn path_token_starts_at_cursor(input: &str, cursor_pos: usize) -> bool {
@@ -31,50 +37,161 @@ pub fn path_token_starts_at_cursor(input: &str, cursor_pos: usize) -> bool {
         .unwrap_or(false)
 }
 
-/// Format a filesystem path for insertion into the single-line input field.
-pub fn format_path_for_input(path: &Path) -> String {
-    let s = path.to_string_lossy();
-    if s.contains(' ') || s.contains('\t') {
-        let escaped = s.replace('\'', "'\\''");
+/// Format a path string for insertion into the single-line input field.
+pub fn format_path_for_input(path: &str) -> String {
+    if path.contains(' ') || path.contains('\t') {
+        let escaped = path.replace('\'', "'\\''");
         format!("'{escaped}'")
     } else {
-        s.into_owned()
+        path.to_string()
     }
 }
 
-/// Blockingly open the native picker (call from `spawn_blocking`).
-pub fn pick_path(kind: PathPickerKind) -> Option<PathBuf> {
-    let dialog = rfd::FileDialog::new();
-    match kind {
-        PathPickerKind::File => dialog.pick_file(),
-        PathPickerKind::Folder => dialog.pick_folder(),
+/// Join `base` and `name` into an absolute path string.
+pub fn join_path(base: &str, name: &str) -> String {
+    if name == ".." {
+        return parent_path(base).unwrap_or_else(|| base.to_string());
+    }
+    let base = base.trim_end_matches(['/', '\\']);
+    if base.is_empty() {
+        if name.starts_with('/') || (cfg!(windows) && name.contains(':')) {
+            name.to_string()
+        } else if cfg!(windows) {
+            format!("{name}")
+        } else {
+            format!("/{name}")
+        }
+    } else if cfg!(windows) && base.contains(':') {
+        format!("{base}\\{name}")
+    } else {
+        format!("{base}/{name}")
     }
 }
 
-/// Leave TUI mode so a native dialog can appear.
-pub fn suspend_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) {
-    disable_raw_mode().ok();
-    execute!(
-        io::stdout(),
-        DisableBracketedPaste,
-        crossterm::event::DisableMouseCapture,
-        LeaveAlternateScreen
-    )
-    .ok();
-    terminal.hide_cursor().ok();
+/// Parent directory, or `None` at filesystem root.
+pub fn parent_path(path: &str) -> Option<String> {
+    let p = Path::new(path);
+    p.parent().map(|parent| {
+        let s = parent.to_string_lossy();
+        if s.is_empty() {
+            if cfg!(windows) {
+                path.chars()
+                    .take_while(|c| *c != '\\')
+                    .chain(std::iter::once('\\'))
+                    .collect()
+            } else {
+                "/".to_string()
+            }
+        } else {
+            s.into_owned()
+        }
+    })
 }
 
-/// Re-enter TUI mode after the native dialog closes.
-pub fn resume_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) {
-    enable_raw_mode().ok();
-    execute!(
-        io::stdout(),
-        EnterAlternateScreen,
-        crossterm::event::EnableMouseCapture,
-        EnableBracketedPaste
-    )
-    .ok();
-    terminal.clear().ok();
+/// Initial directory when opening the picker for a session tab.
+pub fn initial_picker_dir(cwd: &Option<String>, is_remote: bool) -> String {
+    if is_remote {
+        if let Some(dir) = cwd.as_ref().filter(|d| d.starts_with('/')) {
+            return dir.clone();
+        }
+        return "/".to_string();
+    }
+    if let Some(dir) = cwd.as_ref().filter(|d| !d.is_empty()) {
+        return dir.clone();
+    }
+    std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| {
+            if cfg!(windows) {
+                "C:\\".to_string()
+            } else {
+                "/".to_string()
+            }
+        })
+}
+
+/// Readonly `ls` for remote listing (allowlisted, no writes).
+pub fn remote_ls_command(dir: &str) -> String {
+    let quoted = posix_shell_quote(dir);
+    format!("ls -1Ap {quoted} 2>/dev/null | head -n {MAX_ENTRIES}")
+}
+
+/// Parse `ls -1Ap` lines into entries (directories have trailing `/`).
+pub fn parse_ls_output(output: &str) -> Vec<PathEntry> {
+    let mut entries = Vec::new();
+    for line in output.lines() {
+        let line = line.trim_end();
+        if line.is_empty() || line == "." {
+            continue;
+        }
+        if line == ".." {
+            continue;
+        }
+        if line.ends_with('/') {
+            entries.push(PathEntry {
+                name: line.trim_end_matches('/').to_string(),
+                is_dir: true,
+            });
+        } else {
+            entries.push(PathEntry {
+                name: line.to_string(),
+                is_dir: false,
+            });
+        }
+    }
+    sort_entries(&mut entries);
+    entries
+}
+
+/// List a local directory. Returns `(entries, truncated)`.
+pub fn list_local_dir(dir: &str) -> Result<(Vec<PathEntry>, bool)> {
+    let path = PathBuf::from(dir);
+    let read_dir = std::fs::read_dir(&path).map_err(|e| CoreError::Other(e.to_string()))?;
+    let mut entries = Vec::new();
+    let mut truncated = false;
+    for entry in read_dir {
+        let entry = entry.map_err(|e| CoreError::Other(e.to_string()))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| CoreError::Other(e.to_string()))?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name == "." {
+            continue;
+        }
+        entries.push(PathEntry {
+            name,
+            is_dir: file_type.is_dir(),
+        });
+        if entries.len() > MAX_ENTRIES {
+            truncated = true;
+            entries.truncate(MAX_ENTRIES);
+            break;
+        }
+    }
+    sort_entries(&mut entries);
+    Ok((entries, truncated))
+}
+
+/// Build display list with optional `..` parent row at the top.
+pub fn entries_with_parent(dir: &str, mut entries: Vec<PathEntry>) -> Vec<PathEntry> {
+    if parent_path(dir).is_some() {
+        entries.insert(
+            0,
+            PathEntry {
+                name: "..".to_string(),
+                is_dir: true,
+            },
+        );
+    }
+    entries
+}
+
+fn sort_entries(entries: &mut [PathEntry]) {
+    entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
 }
 
 #[cfg(test)]
@@ -91,10 +208,29 @@ mod tests {
 
     #[test]
     fn format_path_quotes_spaces() {
-        assert_eq!(format_path_for_input(Path::new("/tmp/a")), "/tmp/a");
-        assert_eq!(
-            format_path_for_input(Path::new("/tmp/my dir")),
-            "'/tmp/my dir'"
-        );
+        assert_eq!(format_path_for_input("/tmp/a"), "/tmp/a");
+        assert_eq!(format_path_for_input("/tmp/my dir"), "'/tmp/my dir'");
+    }
+
+    #[test]
+    fn parse_ls_marks_directories() {
+        let out = "etc/\nhosts\nnginx/\n";
+        let entries = parse_ls_output(out);
+        assert_eq!(entries.len(), 3);
+        assert!(entries.iter().any(|e| e.name == "etc" && e.is_dir));
+        assert!(entries.iter().any(|e| e.name == "hosts" && !e.is_dir));
+    }
+
+    #[test]
+    fn join_and_parent_posix() {
+        assert_eq!(join_path("/etc", "nginx"), "/etc/nginx");
+        assert_eq!(parent_path("/etc/nginx").as_deref(), Some("/etc"));
+        assert_eq!(parent_path("/").as_deref(), None);
+    }
+
+    #[test]
+    fn entries_with_parent_inserts_dotdot() {
+        let entries = entries_with_parent("/etc", vec![]);
+        assert_eq!(entries[0].name, "..");
     }
 }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -28,7 +28,7 @@ use tokio_util::sync::CancellationToken;
 use crate::app::{App, AppMode, SaveProgress, SessionId};
 use crate::confirmer::TuiConfirmer;
 use crate::event::TuiEvent;
-use crate::path_picker;
+use crate::path_picker::{self, PathEntry};
 use crate::terminal::TerminalModel;
 use crate::ui;
 
@@ -493,6 +493,12 @@ async fn run_app(
     let (save_tx, mut save_rx) = tokio::sync::mpsc::unbounded_channel::<SaveProgress>();
     app.save_tx = Some(save_tx);
 
+    // Channel for in-TUI path picker directory listings (#351).
+    let (path_picker_tx, mut path_picker_rx) =
+        tokio::sync::mpsc::unbounded_channel::<(u64, PathPickerLoadResult)>();
+    let path_picker_tx_load = path_picker_tx.clone();
+    let mut path_picker_load_in_flight: Option<u64> = None;
+
     // Receiver for WARN/ERROR log lines mirrored into the chat.
     let mut log_rx = config.log_rx.take();
 
@@ -574,6 +580,21 @@ async fn run_app(
         let in_interactive = app.mode == AppMode::Interactive;
         tokio::select! {
             biased;
+
+            Some((token, result)) = path_picker_rx.recv() => {
+                path_picker_load_in_flight = None;
+                if app.path_picker_visible && app.path_picker_load_token == token {
+                    match result {
+                        Ok((entries, truncated)) => {
+                            app.apply_path_picker_load(entries, truncated, None);
+                        }
+                        Err(e) => {
+                            app.apply_path_picker_load(vec![], false, Some(e));
+                        }
+                    }
+                }
+                needs_redraw = true;
+            }
 
             // Save progress updates (Ctrl+S, #235). Must be inside the
             // select so the progress bar updates even when the user is idle.
@@ -724,18 +745,27 @@ async fn run_app(
                     None => {} // stream ended
                 }
 
-                // Native file/folder picker (#344): suspend TUI, open dialog, insert path.
+                // In-TUI path picker (#351): open overlay instead of native dialog.
                 if let Some(kind) = app.take_pending_path_picker() {
-                    path_picker::suspend_terminal(&mut *terminal);
-                    let picked =
-                        tokio::task::spawn_blocking(move || path_picker::pick_path(kind)).await;
-                    path_picker::resume_terminal(&mut *terminal);
-                    match picked {
-                        Ok(Some(path)) => app.insert_path_at_cursor(&path),
-                        Ok(None) => {}
-                        Err(e) => warn!(error = %e, "path picker task panicked"),
-                    }
+                    app.open_path_picker(kind);
                     needs_redraw = true;
+                }
+
+                // Path picker async directory listing.
+                if app.path_picker_visible && app.path_picker_loading {
+                    let token = app.path_picker_load_token;
+                    if path_picker_load_in_flight != Some(token) {
+                        path_picker_load_in_flight = Some(token);
+                        let dir = app.path_picker_dir.clone();
+                        let is_remote = app.sessions[app.active].ssh_info.is_some();
+                        let sid = app.sessions[app.active].id;
+                        let exec = executors.get(&sid).map(|e| e.executor.clone());
+                        let tx = path_picker_tx_load.clone();
+                        tokio::spawn(async move {
+                            let result = load_path_picker_dir(is_remote, &dir, exec).await;
+                            tx.send((token, result)).ok();
+                        });
+                    }
                 }
 
                 // Handle mode toggle (Ctrl+T).
@@ -1671,6 +1701,39 @@ fn spawn_agent(
         // don't need to send them again here.
         let _ = agent.run(&user_input, &history).await;
     });
+}
+
+type PathPickerLoadResult = std::result::Result<(Vec<PathEntry>, bool), String>;
+
+async fn load_path_picker_dir(
+    is_remote: bool,
+    dir: &str,
+    executor: Option<Arc<TuiExecutor>>,
+) -> PathPickerLoadResult {
+    if is_remote {
+        let exec = executor.ok_or_else(|| "No executor for remote session".to_string())?;
+        let cmd = path_picker::remote_ls_command(dir);
+        let result = exec.run(&cmd).await.map_err(|e| e.to_string())?;
+        if result.stdout.trim().is_empty() && result.exit_code != Some(0) {
+            let detail = if result.stderr.trim().is_empty() {
+                format!("ls failed (exit {:?})", result.exit_code)
+            } else {
+                result.stderr.trim().to_string()
+            };
+            return Err(detail);
+        }
+        let entries = path_picker::parse_ls_output(&result.stdout);
+        let truncated = entries.len() >= path_picker::MAX_ENTRIES
+            || result.stdout.lines().count() >= path_picker::MAX_ENTRIES;
+        Ok((entries, truncated))
+    } else {
+        let dir = dir.to_string();
+        tokio::task::spawn_blocking(move || {
+            path_picker::list_local_dir(&dir).map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
 }
 
 #[cfg(test)]

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -240,19 +240,19 @@ pub(crate) fn help_registry() -> Vec<HelpEntry> {
         },
         HelpEntry {
             key: "/",
-            desc: "At path-token start: open file picker (local FS)",
+            desc: "At path-token start: open path picker (active target)",
             section: "Input",
             available: |m| m == AppMode::Normal,
         },
         HelpEntry {
             key: "^Shift+F",
-            desc: "Open file picker (local FS)",
+            desc: "Open file picker (active target)",
             section: "Input",
             available: |m| m == AppMode::Normal,
         },
         HelpEntry {
             key: "^Shift+D",
-            desc: "Open folder picker (local FS)",
+            desc: "Open folder picker (active target)",
             section: "Input",
             available: |m| m == AppMode::Normal,
         },

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -34,6 +34,7 @@ mod confirm;
 mod help;
 mod host_select;
 mod input;
+mod path_picker_overlay;
 mod save_overlay;
 mod session_select;
 #[allow(unused_imports)]
@@ -135,6 +136,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
         session_select::render_session_select(f, app, full);
     }
 
+    // Render in-TUI path picker (#351).
+    if app.path_picker_visible {
+        let full = f.area();
+        path_picker_overlay::render_path_picker(f, app, full);
+    }
+
     // Render session-save progress overlay on top of everything if active.
     if app.save_overlay_visible {
         let full = f.area();
@@ -217,6 +224,12 @@ fn render_interactive(f: &mut Frame, app: &mut App) {
     if app.session_select_visible {
         let full = f.area();
         session_select::render_session_select(f, app, full);
+    }
+
+    // Render in-TUI path picker (#351).
+    if app.path_picker_visible {
+        let full = f.area();
+        path_picker_overlay::render_path_picker(f, app, full);
     }
 
     // Render session-save progress overlay on top of everything if active.

--- a/crates/tui/src/ui/path_picker_overlay.rs
+++ b/crates/tui/src/ui/path_picker_overlay.rs
@@ -1,0 +1,117 @@
+//! Path-picker overlay — in-TUI file/folder browser on the active target (#351).
+
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::app::App;
+use crate::path_picker::PathPickerKind;
+
+const OVERLAY_MAX_WIDTH: u16 = 72;
+const OVERLAY_H_MARGIN: u16 = 4;
+const OVERLAY_V_MARGIN: u16 = 2;
+
+/// Render the path-picker overlay on top of the current frame.
+pub(crate) fn render_path_picker(f: &mut Frame, app: &App, area: Rect) {
+    let width = OVERLAY_MAX_WIDTH.min(area.width.saturating_sub(2 * OVERLAY_H_MARGIN));
+    let list_size = app.path_picker_entries.len().max(1) as u16;
+    let content_height = list_size.saturating_add(5);
+    let height = content_height.min(area.height.saturating_sub(2 * OVERLAY_V_MARGIN));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let overlay_area = Rect::new(x, y, width, height);
+
+    f.render_widget(Clear, overlay_area);
+
+    let kind_label = match app.path_picker_kind {
+        PathPickerKind::File => "file",
+        PathPickerKind::Folder => "folder",
+    };
+    let title = format!(" Pick {kind_label} — {} ", app.path_picker_dir);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.accent))
+        .style(Style::default().bg(app.theme.bg))
+        .title(Span::styled(
+            truncate(&title, width as usize),
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ));
+
+    let mut items: Vec<ListItem> = Vec::new();
+
+    if app.path_picker_loading {
+        items.push(ListItem::new(Line::from(vec![Span::styled(
+            "  Loading…",
+            app.theme.muted(),
+        )])));
+    } else if let Some(ref err) = app.path_picker_error {
+        items.push(ListItem::new(Line::from(vec![Span::styled(
+            format!("  Error: {err}"),
+            app.theme.warning_fg(),
+        )])));
+    } else if app.path_picker_entries.is_empty() {
+        items.push(ListItem::new(Line::from(vec![Span::styled(
+            "  (empty directory)",
+            app.theme.muted(),
+        )])));
+    } else {
+        for (i, entry) in app.path_picker_entries.iter().enumerate() {
+            let cursor = if app.path_picker_index == i { "\u{25b6}" } else { " " };
+            let suffix = if entry.is_dir { "/" } else { "" };
+            items.push(ListItem::new(Line::from(vec![
+                Span::raw(format!(" {cursor} ")),
+                Span::styled(
+                    format!("{}{suffix}", entry.name),
+                    if entry.is_dir {
+                        Style::default().fg(app.theme.accent)
+                    } else {
+                        Style::default().fg(app.theme.fg)
+                    },
+                ),
+            ])));
+        }
+    }
+
+    if app.path_picker_truncated {
+        items.push(ListItem::new(Line::from(vec![Span::styled(
+            "  … listing truncated",
+            app.theme.warning_fg(),
+        )])));
+    }
+
+    let mut state = ListState::default();
+    if !app.path_picker_entries.is_empty() {
+        state.select(Some(app.path_picker_index));
+    }
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().bg(app.theme.selection_bg));
+
+    f.render_stateful_widget(list, overlay_area, &mut state);
+
+    let footer = " \u{2191}\u{2193} navigate   Enter select/open   Esc cancel ";
+    let footer_area = Rect::new(
+        overlay_area.x,
+        overlay_area.y + overlay_area.height.saturating_sub(1),
+        overlay_area.width,
+        1,
+    );
+    f.render_widget(
+        ratatui::widgets::Paragraph::new(Span::styled(footer, app.theme.muted())),
+        footer_area,
+    );
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let keep = max.saturating_sub(1).max(1);
+        s.chars().take(keep).collect::<String>() + "\u{2026}"
+    } else {
+        s.to_string()
+    }
+}

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -260,3 +260,19 @@ columnar tools (`ps`, aligned tables) stay consistent.
 | Ambiguous width (e.g. some box-drawing) | Follow unicode-width/ratatui; Terminal.app vs Windows Terminal can still differ for East-Asian Ambiguous characters — report if still visible after #333 |
 | Interactive PTY scrollback | Separate `TerminalModel` path; not changed by #333 |
 
+## TUI path picker (#351)
+
+Agent input path picker (`/`, `Ctrl+Shift+F`, `Ctrl+Shift+D`) is an in-TUI
+overlay listing the **active tab's target** filesystem:
+
+| Tab | Listing source |
+|-----|----------------|
+| Local | Client `read_dir` |
+| SSH | Readonly remote `ls -1Ap` via session executor (zero-install) |
+
+Native OS file dialogs (`rfd`) are no longer used in the TUI; the GUI launcher
+Browse button still uses `rfd` locally.
+
+Remote listing requires a live SSH executor on the tab; large directories are
+capped at 500 entries with a truncation warning.
+


### PR DESCRIPTION
## Summary

Replaces the native OS file dialog (`rfd`) with an in-TUI path picker overlay that lists directories on the **active tab target**:

- **Local tab:** `std::fs::read_dir`
- **SSH tab:** readonly `ls -1Ap` via session executor (zero-install)

Selected path is inserted into agent input (quoted when needed). Large directories capped at 500 entries.

Closes #351

## Test plan

- [x] `cargo test -p filar-tui path_picker`
- [ ] Manual local: `Ctrl+Shift+F` lists CWD, select file inserts path
- [ ] Manual SSH: `/` at path start shows remote `/etc` etc., not `C:\\Users`
- [ ] Esc cancels without breaking input mode