### PR TITLE
feat(agent): independent command arbiter (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Added
+
+- Independent command arbiter: a second LLM audits each command awaiting
+  confirmation, checking whether the explanation matches the command. Verdict
+  is shown in the confirm dialog; user approval is unchanged. Config:
+  `arbiter_profile` (optional) and `arbiter_enabled` (default `true`; runs only
+  on `NeedsConfirmation`). Arbiter token usage appears separately in the F1 help
+  overlay ([#353](https://github.com/devlawey/filar/issues/353)).
+
 ### Fixed
 
 - Ctrl+S and F2 Explain Markdown exports now take topic slug from live chat

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5124,6 +5124,28 @@ help/CHANGELOG updates, unit tests.
 
 **Next steps:** manual smoke SSH + local path insert.
 
+## Issue #353: feat(agent) — independent command arbiter
+
+**Milestone:** 1.0.4. **Branch:** `feat/353-command-arbiter`.
+
+**Problem:** In Explain mode the same model writes both the command and its
+explanation — a coherent but wrong rationale can mislead the operator.
+
+**Design:** Before `CommandConfirmer::confirm`, a second LLM (configurable
+`arbiter_profile`, fallback session profile) audits command vs explanation +
+recent history tail. Emits `AgentEvent::CommandAudited`; TUI merges into confirm
+modal. Never auto-approve/deny; 12s timeout; secrets redacted from history.
+
+**Done:** `crates/agent/src/arbiter.rs`, config `arbiter_profile` /
+`arbiter_enabled`, GUI arbiter dropdown, F1 usage line for arbiter tokens, unit
++ agent tests.
+
+**Public contract:** `AgentEvent::CommandAudited`, `TokenUsage { arbiter }`,
+`Config::arbiter_*`.
+
+**Next steps:** merge PR; **eval-smoke required** (new system prompt in arbiter);
+manual smoke 10+ confirmable commands, note objection rate in PR.
+
 ## Release v1.0.3 (2026-08-24)
 
 **Scope:** milestone 1.0.3 — TUI polish (Ctrl+S filename, path picker, confirm

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -17,6 +17,7 @@ use filar_core::{CommandConfirmMode, CoreError, Result, SecretProvider};
 use filar_transport::{CommandExecutor, SecretSubstitutingExecutor};
 
 use crate::{
+    arbiter::{self, ArbiterContext, ARBITER_TIMEOUT_SECS, HISTORY_TAIL_EXCHANGES},
     events::{AgentEvent, EventSink},
     security::{self, CommandConfirmer, ConfirmDecision},
     tools::{self},
@@ -160,6 +161,14 @@ pub struct Agent {
     /// during `build()` if this is set.
     #[allow(dead_code)]
     secret_provider: Option<Arc<dyn SecretProvider>>,
+    /// Optional LLM client for the independent command arbiter.
+    arbiter_llm: Option<Arc<dyn LlmClient>>,
+    /// When false, skip arbiter audits even if `arbiter_llm` is set.
+    arbiter_enabled: bool,
+    /// Execution context passed to the arbiter (local vs remote).
+    arbiter_context: ArbiterContext,
+    /// Display name of the arbiter profile (for events / TUI).
+    arbiter_model_name: String,
 }
 
 /// Builder for [`Agent`].
@@ -177,6 +186,10 @@ pub struct AgentBuilder {
     confirm_timeout: Option<Duration>,
     command_timeout: Option<Duration>,
     secret_provider: Option<Arc<dyn SecretProvider>>,
+    arbiter_llm: Option<Arc<dyn LlmClient>>,
+    arbiter_enabled: bool,
+    arbiter_context: Option<ArbiterContext>,
+    arbiter_model_name: Option<String>,
 }
 
 impl AgentBuilder {
@@ -196,6 +209,10 @@ impl AgentBuilder {
             confirm_timeout: None,
             command_timeout: None,
             secret_provider: None,
+            arbiter_llm: None,
+            arbiter_enabled: true,
+            arbiter_context: None,
+            arbiter_model_name: None,
         }
     }
 
@@ -300,6 +317,46 @@ impl AgentBuilder {
         self
     }
 
+    /// Set the LLM client used for independent command audits.
+    pub fn arbiter_llm(mut self, llm: Option<Arc<dyn LlmClient>>) -> Self {
+        self.arbiter_llm = llm;
+        self
+    }
+
+    /// Enable or disable the command arbiter (default: enabled).
+    pub fn arbiter_enabled(mut self, enabled: bool) -> Self {
+        self.arbiter_enabled = enabled;
+        self
+    }
+
+    /// Set execution context for arbiter prompts (local vs SSH target).
+    pub fn arbiter_context(mut self, ctx: ArbiterContext) -> Self {
+        self.arbiter_context = Some(ctx);
+        self
+    }
+
+    /// Set the display name of the arbiter profile (shown in the TUI).
+    pub fn arbiter_model_name(mut self, name: impl Into<String>) -> Self {
+        self.arbiter_model_name = Some(name.into());
+        self
+    }
+
+    /// Convenience: set arbiter context for local execution.
+    pub fn arbiter_local_context(self) -> Self {
+        self.arbiter_context(ArbiterContext {
+            is_local: true,
+            ssh_info: None,
+        })
+    }
+
+    /// Convenience: set arbiter context for SSH remote execution.
+    pub fn arbiter_ssh_context(self, ssh_info: Option<String>) -> Self {
+        self.arbiter_context(ArbiterContext {
+            is_local: false,
+            ssh_info,
+        })
+    }
+
     /// Convenience: set the system prompt for local execution.
     pub fn local_mode(self) -> Self {
         self.system_prompt(build_system_prompt(true, None, cfg!(windows)))
@@ -341,6 +398,15 @@ impl AgentBuilder {
             confirm_timeout: self.confirm_timeout,
             command_timeout: self.command_timeout,
             secret_provider,
+            arbiter_llm: self.arbiter_llm,
+            arbiter_enabled: self.arbiter_enabled,
+            arbiter_context: self.arbiter_context.unwrap_or(ArbiterContext {
+                is_local: false,
+                ssh_info: None,
+            }),
+            arbiter_model_name: self
+                .arbiter_model_name
+                .unwrap_or_else(|| "session profile".into()),
         })
     }
 }
@@ -383,6 +449,63 @@ impl Agent {
     fn emit(&self, event: AgentEvent) {
         if let Some(ref sink) = self.event_sink {
             sink(event);
+        }
+    }
+
+    /// Run the independent command arbiter when enabled. Never blocks confirmation.
+    async fn run_command_audit(
+        &self,
+        command: &str,
+        explanation: &str,
+        destructive: bool,
+        conversation: &[ChatMessage],
+    ) {
+        if !self.arbiter_enabled || self.confirm_mode == CommandConfirmMode::Never {
+            return;
+        }
+        let Some(ref arbiter_llm) = self.arbiter_llm else {
+            return;
+        };
+
+        let target_desc = arbiter::target_description(&self.arbiter_context);
+        let history_tail =
+            arbiter::history_tail_from_messages(conversation, HISTORY_TAIL_EXCHANGES);
+        let messages = arbiter::build_audit_messages(
+            command,
+            explanation,
+            destructive,
+            &target_desc,
+            &history_tail,
+        );
+
+        let audit = arbiter::run_audit(
+            arbiter_llm.as_ref(),
+            messages,
+            Duration::from_secs(ARBITER_TIMEOUT_SECS),
+            self.cancellation.as_ref(),
+        )
+        .await;
+
+        let model_display = audit
+            .model
+            .clone()
+            .unwrap_or_else(|| self.arbiter_model_name.clone());
+
+        self.emit(AgentEvent::CommandAudited {
+            verdict: audit.verdict.label().to_string(),
+            reason: audit.reason.clone(),
+            arbiter_model: Some(model_display),
+            unavailable: audit.unavailable,
+        });
+
+        if audit.tokens_in > 0 || audit.tokens_out > 0 {
+            self.emit(AgentEvent::TokenUsage {
+                tokens_in: audit.tokens_in,
+                tokens_out: audit.tokens_out,
+                cost: audit.cost,
+                model: audit.model,
+                arbiter: true,
+            });
         }
     }
 
@@ -468,6 +591,7 @@ impl Agent {
                     tokens_out: u.completion_tokens.unwrap_or(0),
                     cost: u.cost,
                     model: response.model.clone(),
+                    arbiter: false,
                 });
             }
 
@@ -513,7 +637,7 @@ impl Agent {
 
                 // Process each tool call.
                 for tc in &tool_calls {
-                    let result = self.process_tool_call(tc).await?;
+                    let result = self.process_tool_call(tc, &messages).await?;
                     messages.push(result);
                 }
             } else {
@@ -535,7 +659,11 @@ impl Agent {
     ///
     /// Emits [`AgentEvent::CommandProposed`] before confirmation and
     /// [`AgentEvent::CommandFinished`] after execution (or denial).
-    async fn process_tool_call(&self, tc: &ToolCall) -> Result<ChatMessage> {
+    async fn process_tool_call(
+        &self,
+        tc: &ToolCall,
+        conversation: &[ChatMessage],
+    ) -> Result<ChatMessage> {
         // Parse the tool call.
         let parsed = match tools::parse_tool_call(&tc.id, &tc.name, &tc.arguments) {
             Ok(p) => p,
@@ -595,6 +723,14 @@ impl Agent {
                 info!(command = %parsed.command, "command auto-approved");
             }
             ConfirmDecision::NeedsConfirmation => {
+                self.run_command_audit(
+                    &parsed.command,
+                    &parsed.explanation,
+                    destructive,
+                    conversation,
+                )
+                .await;
+
                 let confirm_fut = self
                     .confirmer
                     .confirm(&parsed.command, &parsed.explanation, destructive);
@@ -1671,6 +1807,141 @@ mod tests {
         assert!(
             err.contains("explanation"),
             "error should mention missing explanation, got: {err}"
+        );
+    }
+
+    // ── Command arbiter tests (#353) ────────────────────────────────────
+
+    struct StaticArbiterLlm {
+        text: String,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for StaticArbiterLlm {
+        async fn chat(&self, _request: &ChatRequest) -> Result<ChatResponse> {
+            Ok(ChatResponse::text(self.text.clone()))
+        }
+    }
+
+    fn tool_call_echo() -> ChatResponse {
+        ChatResponse::tool_calls("", vec![ToolCall {
+            id: "call_1".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({
+                "command": "echo hello",
+                "explanation": "Print hello"
+            }),
+        }])
+    }
+
+    #[tokio::test]
+    async fn arbiter_unavailable_does_not_block_confirm() {
+        use std::sync::Mutex;
+
+        let llm = Arc::new(MockLlm::new(vec![
+            tool_call_echo(),
+            ChatResponse::text("Done."),
+        ]));
+        let executor = Arc::new(MockExecutor {
+            last_command: Mutex::new(String::new()),
+        });
+        let confirmer = Arc::new(MockConfirmer { approve: true });
+        let arbiter = Arc::new(StaticArbiterLlm {
+            text: "not valid json".into(),
+        });
+
+        let events: Arc<Mutex<Vec<AgentEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let sink: EventSink = Arc::new(move |event: AgentEvent| {
+            events_clone.lock().unwrap().push(event);
+        });
+
+        let agent = Agent::builder()
+            .llm(llm)
+            .executor(executor.clone())
+            .confirmer(confirmer)
+            .confirm_mode(CommandConfirmMode::Always)
+            .event_sink(sink)
+            .arbiter_llm(Some(arbiter))
+            .arbiter_enabled(true)
+            .arbiter_local_context()
+            .build()
+            .unwrap();
+
+        let _ = agent.run("say hello", &[]).await.unwrap();
+        assert_eq!(
+            *executor.last_command.lock().unwrap(),
+            "echo hello",
+            "command must execute when arbiter is unavailable"
+        );
+
+        let received = events.lock().unwrap();
+        assert!(
+            received.iter().any(|e| matches!(
+                e,
+                AgentEvent::CommandAudited { unavailable: true, .. }
+            )),
+            "expected CommandAudited unavailable, got {received:?}"
+        );
+        assert!(
+            received.iter().any(|e| matches!(
+                e,
+                AgentEvent::CommandFinished { denied: false, .. }
+            )),
+            "command must not be auto-denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn arbiter_mismatch_does_not_auto_deny() {
+        use std::sync::Mutex;
+
+        let llm = Arc::new(MockLlm::new(vec![
+            tool_call_echo(),
+            ChatResponse::text("Done."),
+        ]));
+        let executor = Arc::new(MockExecutor {
+            last_command: Mutex::new(String::new()),
+        });
+        let confirmer = Arc::new(MockConfirmer { approve: true });
+        let arbiter = Arc::new(StaticArbiterLlm {
+            text: r#"{"verdict":"MISMATCH","reason":"Command prints hello but explanation claims goodbye."}"#
+                .into(),
+        });
+
+        let events: Arc<Mutex<Vec<AgentEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let sink: EventSink = Arc::new(move |event: AgentEvent| {
+            events_clone.lock().unwrap().push(event);
+        });
+
+        let agent = Agent::builder()
+            .llm(llm)
+            .executor(executor.clone())
+            .confirmer(confirmer)
+            .confirm_mode(CommandConfirmMode::Always)
+            .event_sink(sink)
+            .arbiter_llm(Some(arbiter))
+            .arbiter_enabled(true)
+            .arbiter_local_context()
+            .build()
+            .unwrap();
+
+        let _ = agent.run("say hello", &[]).await.unwrap();
+        assert_eq!(
+            *executor.last_command.lock().unwrap(),
+            "echo hello",
+            "MISMATCH verdict must not auto-deny the command"
+        );
+
+        let received = events.lock().unwrap();
+        assert!(
+            received.iter().any(|e| matches!(
+                e,
+                AgentEvent::CommandAudited { verdict, unavailable: false, .. }
+                    if verdict == "MISMATCH"
+            )),
+            "expected MISMATCH CommandAudited, got {received:?}"
         );
     }
 }

--- a/crates/agent/src/arbiter.rs
+++ b/crates/agent/src/arbiter.rs
@@ -1,0 +1,396 @@
+//! Independent command arbiter — a second LLM opinion before user confirmation.
+//!
+//! The arbiter checks whether a proposed command matches its explanation. It
+//! never blocks or auto-approves commands; failures degrade to "unavailable".
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+use crate::{ChatMessage, ChatRequest, LlmClient, MessageRole};
+
+/// Default audit timeout (seconds).
+pub const ARBITER_TIMEOUT_SECS: u64 = 12;
+
+/// Number of recent conversation exchanges included in the audit context.
+pub const HISTORY_TAIL_EXCHANGES: usize = 4;
+
+/// System prompt for the arbiter model (verbatim from product spec).
+pub const ARBITER_SYSTEM_PROMPT: &str = r#"You are auditing a single command that an AI system-administration agent is about to
+propose to a human operator. You are NOT solving the operator's problem and you are NOT
+suggesting a better command. You check one thing: whether this command is what its own
+explanation claims it is.
+
+You are given the proposed command, the explanation the agent wrote for it, and the last
+few exchanges of the session including previous command output.
+
+Report a concern only when you find a concrete, checkable discrepancy:
+
+- MISMATCH — the command does something materially different from what the explanation
+  says. Example: the explanation says it inspects a config, the command rewrites it.
+- UNDERSTATED_RISK — the command is more destructive or has a wider blast radius than the
+  explanation admits. Example: a wildcard, a recursive delete, a restart of a shared
+  service, an operation on the wrong path.
+- CONTRADICTS_EVIDENCE — the stated reasoning conflicts with what is visible in the
+  session. Example: the explanation says a service is down, but earlier output shows it
+  running.
+
+Otherwise report AGREE.
+
+Rules:
+- Default to AGREE. You are read by a human on every single command; if you object
+  routinely, you will be ignored and you will have made the system less safe, not more.
+- Never object to style, efficiency, or a command you would have written differently.
+- Never object on the basis of information you do not have. If you cannot verify
+  something, that is not a finding.
+- Your reason must be one sentence, concrete, and checkable by the operator at a glance.
+
+Respond with JSON only, no prose and no code fences:
+{"verdict": "AGREE" | "MISMATCH" | "UNDERSTATED_RISK" | "CONTRADICTS_EVIDENCE",
+ "reason": "one sentence, empty string when verdict is AGREE"}"#;
+
+/// Arbiter verdict on a proposed command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbiterVerdict {
+    /// Command matches its explanation.
+    Agree,
+    /// Command does something different from the explanation.
+    Mismatch,
+    /// Command is more dangerous than the explanation admits.
+    UnderstatedRisk,
+    /// Explanation conflicts with visible session evidence.
+    ContradictsEvidence,
+    /// Audit could not be completed (error, timeout, bad JSON).
+    Unavailable,
+}
+
+impl ArbiterVerdict {
+    /// Parse a verdict string from the LLM JSON response.
+    pub fn parse_str(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_uppercase().as_str() {
+            "AGREE" => Some(Self::Agree),
+            "MISMATCH" => Some(Self::Mismatch),
+            "UNDERSTATED_RISK" => Some(Self::UnderstatedRisk),
+            "CONTRADICTS_EVIDENCE" => Some(Self::ContradictsEvidence),
+            _ => None,
+        }
+    }
+
+    /// Human-readable label for the TUI.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Agree => "AGREE",
+            Self::Mismatch => "MISMATCH",
+            Self::UnderstatedRisk => "UNDERSTATED RISK",
+            Self::ContradictsEvidence => "CONTRADICTS EVIDENCE",
+            Self::Unavailable => "UNAVAILABLE",
+        }
+    }
+}
+
+/// Parsed arbiter JSON payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedArbiterResponse {
+    pub verdict: ArbiterVerdict,
+    pub reason: String,
+}
+
+#[derive(Deserialize)]
+struct RawArbiterResponse {
+    verdict: String,
+    #[serde(default)]
+    reason: String,
+}
+
+/// Parse the arbiter LLM response text into a structured verdict.
+///
+/// Returns `Unavailable` on empty input, invalid JSON, or unknown verdict strings.
+pub fn parse_arbiter_response(text: &str) -> ParsedArbiterResponse {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return ParsedArbiterResponse {
+            verdict: ArbiterVerdict::Unavailable,
+            reason: String::new(),
+        };
+    }
+
+    // Strip optional markdown code fences if the model ignored instructions.
+    let json_text = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .map(|s| s.strip_suffix("```").unwrap_or(s).trim())
+        .unwrap_or(trimmed);
+
+    let raw: RawArbiterResponse = match serde_json::from_str(json_text) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "failed to parse arbiter JSON");
+            return ParsedArbiterResponse {
+                verdict: ArbiterVerdict::Unavailable,
+                reason: String::new(),
+            };
+        }
+    };
+
+    match ArbiterVerdict::parse_str(&raw.verdict) {
+        Some(v) => ParsedArbiterResponse {
+            verdict: v,
+            reason: raw.reason.trim().to_string(),
+        },
+        None => {
+            warn!(verdict = %raw.verdict, "unknown arbiter verdict");
+            ParsedArbiterResponse {
+                verdict: ArbiterVerdict::Unavailable,
+                reason: String::new(),
+            }
+        }
+    }
+}
+
+/// Target execution context for the arbiter prompt.
+#[derive(Debug, Clone)]
+pub struct ArbiterContext {
+    pub is_local: bool,
+    pub ssh_info: Option<String>,
+}
+
+/// Build chat messages for the arbiter LLM call.
+pub fn build_audit_messages(
+    command: &str,
+    explanation: &str,
+    destructive: bool,
+    target_desc: &str,
+    history_tail: &str,
+) -> Vec<ChatMessage> {
+    let user_body = format!(
+        "Target: {target_desc}\nDestructive flag: {destructive}\n\n\
+         Proposed command:\n{command}\n\n\
+         Agent explanation:\n{explanation}\n\n\
+         Recent session context:\n{history_tail}"
+    );
+    vec![
+        ChatMessage::system(ARBITER_SYSTEM_PROMPT),
+        ChatMessage::user(user_body),
+    ]
+}
+
+/// Human-readable target description for the audit prompt.
+pub fn target_description(ctx: &ArbiterContext) -> String {
+    if ctx.is_local {
+        "local machine".to_string()
+    } else {
+        ctx.ssh_info
+            .clone()
+            .map(|s| format!("remote SSH ({s})"))
+            .unwrap_or_else(|| "remote SSH".to_string())
+    }
+}
+
+/// Extract and sanitize the last N conversation exchanges for arbiter input.
+///
+/// Secret placeholders and password-entry content are redacted or omitted.
+pub fn history_tail_from_messages(messages: &[ChatMessage], max_exchanges: usize) -> String {
+    let mut tail: Vec<String> = Vec::new();
+
+    for msg in messages.iter().rev() {
+        if tail.len() >= max_exchanges {
+            break;
+        }
+        if msg.role == MessageRole::System {
+            continue;
+        }
+        if is_password_or_secret_content(&msg.content) {
+            continue;
+        }
+        let role = match msg.role {
+            MessageRole::User => "User",
+            MessageRole::Assistant => "Assistant",
+            MessageRole::Tool => "Tool output",
+            MessageRole::System => "System",
+        };
+        tail.push(format!("{role}: {}", redact_secrets(&msg.content)));
+    }
+
+    tail.reverse();
+    if tail.is_empty() {
+        "(no prior context)".to_string()
+    } else {
+        tail.join("\n\n")
+    }
+}
+
+fn is_password_or_secret_content(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    lower.contains("enter ssh password")
+        || lower.contains("type password, press enter")
+        || lower.contains("password input mode")
+}
+
+fn redact_secrets(content: &str) -> String {
+    let mut out = content.to_string();
+    // Redact $FILAR_SECRET_N placeholders and anything that looks like a bare secret var.
+    let mut i = 0;
+    while let Some(start) = out[i..].find("$FILAR_SECRET_") {
+        let abs = i + start;
+        let rest = &out[abs + "$FILAR_SECRET_".len()..];
+        let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+        if digits > 0 {
+            let end = abs + "$FILAR_SECRET_".len() + digits;
+            out.replace_range(abs..end, "[secret redacted]");
+            i = abs + "[secret redacted]".len();
+        } else {
+            i = abs + 1;
+        }
+    }
+    out
+}
+
+/// Result of an arbiter audit call.
+#[derive(Debug, Clone)]
+pub struct AuditResult {
+    pub verdict: ArbiterVerdict,
+    pub reason: String,
+    pub model: Option<String>,
+    pub unavailable: bool,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    pub cost: Option<f64>,
+}
+
+impl AuditResult {
+    fn unavailable() -> Self {
+        Self {
+            verdict: ArbiterVerdict::Unavailable,
+            reason: String::new(),
+            model: None,
+            unavailable: true,
+            tokens_in: 0,
+            tokens_out: 0,
+            cost: None,
+        }
+    }
+}
+
+/// Run the arbiter audit. Never propagates errors — returns `Unavailable` instead.
+pub async fn run_audit(
+    llm: &dyn LlmClient,
+    messages: Vec<ChatMessage>,
+    timeout: Duration,
+    cancellation: Option<&CancellationToken>,
+) -> AuditResult {
+    let request = ChatRequest {
+        messages,
+        tools: Vec::new(),
+    };
+
+    let chat_fut = llm.chat(&request);
+    let response = match cancellation {
+        Some(token) => {
+            tokio::select! {
+                result = chat_fut => result,
+                _ = token.cancelled() => {
+                    warn!("arbiter audit cancelled");
+                    return AuditResult::unavailable();
+                }
+            }
+        }
+        None => chat_fut.await,
+    };
+    let response = match tokio::time::timeout(timeout, async { response }).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            warn!(error = %e, "arbiter LLM request failed");
+            return AuditResult::unavailable();
+        }
+        Err(_) => {
+            warn!("arbiter audit timed out");
+            return AuditResult::unavailable();
+        }
+    };
+
+    let parsed = parse_arbiter_response(&response.text);
+    let unavailable = parsed.verdict == ArbiterVerdict::Unavailable;
+
+    AuditResult {
+        verdict: parsed.verdict,
+        reason: parsed.reason,
+        model: response.model,
+        unavailable,
+        tokens_in: response.usage.as_ref().and_then(|u| u.prompt_tokens).unwrap_or(0),
+        tokens_out: response
+            .usage
+            .as_ref()
+            .and_then(|u| u.completion_tokens)
+            .unwrap_or(0),
+        cost: response.usage.as_ref().and_then(|u| u.cost),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_agree() {
+        let r = parse_arbiter_response(r#"{"verdict":"AGREE","reason":""}"#);
+        assert_eq!(r.verdict, ArbiterVerdict::Agree);
+        assert!(r.reason.is_empty());
+    }
+
+    #[test]
+    fn parse_valid_mismatch() {
+        let r = parse_arbiter_response(
+            r#"{"verdict":"MISMATCH","reason":"Command rewrites the file instead of reading it."}"#,
+        );
+        assert_eq!(r.verdict, ArbiterVerdict::Mismatch);
+        assert!(r.reason.contains("rewrites"));
+    }
+
+    #[test]
+    fn parse_garbage_returns_unavailable() {
+        let r = parse_arbiter_response("not json at all");
+        assert_eq!(r.verdict, ArbiterVerdict::Unavailable);
+    }
+
+    #[test]
+    fn parse_empty_returns_unavailable() {
+        let r = parse_arbiter_response("");
+        assert_eq!(r.verdict, ArbiterVerdict::Unavailable);
+    }
+
+    #[test]
+    fn parse_unknown_verdict_returns_unavailable() {
+        let r = parse_arbiter_response(r#"{"verdict":"MAYBE","reason":"hmm"}"#);
+        assert_eq!(r.verdict, ArbiterVerdict::Unavailable);
+    }
+
+    #[test]
+    fn history_tail_redacts_secrets() {
+        let msgs = vec![ChatMessage::assistant(
+            "Command: sudo ls\nOutput: used $FILAR_SECRET_1",
+        )];
+        let tail = history_tail_from_messages(&msgs, 4);
+        assert!(tail.contains("[secret redacted]"));
+        assert!(!tail.contains("$FILAR_SECRET_1"));
+    }
+
+    #[test]
+    fn history_tail_skips_password_prompts() {
+        let msgs = vec![ChatMessage::system(
+            "Enter SSH password for root@host:22",
+        )];
+        let tail = history_tail_from_messages(&msgs, 4);
+        assert_eq!(tail, "(no prior context)");
+    }
+
+    #[test]
+    fn build_audit_messages_includes_command_and_explanation() {
+        let msgs = build_audit_messages("rm -rf /tmp/x", "Remove temp dir", true, "local machine", "ctx");
+        assert_eq!(msgs.len(), 2);
+        assert!(msgs[1].content.contains("rm -rf /tmp/x"));
+        assert!(msgs[1].content.contains("Remove temp dir"));
+        assert!(msgs[0].content.contains("auditing a single command"));
+    }
+}

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -39,6 +39,22 @@ pub enum AgentEvent {
         destructive: bool,
     },
 
+    /// Independent arbiter verdict on a command awaiting confirmation.
+    ///
+    /// Emitted after [`CommandProposed`] and **before** the confirmer runs.
+    /// The arbiter never auto-approves or auto-denies — this is advisory only.
+    CommandAudited {
+        /// Verdict label: `AGREE`, `MISMATCH`, `UNDERSTATED_RISK`,
+        /// `CONTRADICTS_EVIDENCE`, or `UNAVAILABLE`.
+        verdict: String,
+        /// One-sentence reason (empty when `AGREE`).
+        reason: String,
+        /// Display name / slug of the arbiter model (if known).
+        arbiter_model: Option<String>,
+        /// `true` when the audit could not be completed (timeout, error, bad JSON).
+        unavailable: bool,
+    },
+
     /// A command was executed (or denied by the user).
     CommandFinished {
         /// The command that was processed.
@@ -62,6 +78,8 @@ pub enum AgentEvent {
         cost: Option<f64>,
         /// The actually served model slug. None when not reported.
         model: Option<String>,
+        /// `true` when this usage is from the command arbiter, not the main agent loop.
+        arbiter: bool,
     },
 
     /// The agent encountered an error (network, LLM, transport).

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -7,6 +7,7 @@
 //! - Security layer: confirmation, destructive command detection (Stage 5).
 
 pub mod agent;
+pub mod arbiter;
 pub mod events;
 pub mod long_wait;
 pub mod openai_compat;
@@ -16,6 +17,7 @@ pub mod tools;
 
 // Re-export key types for convenience.
 pub use agent::{Agent, AgentBuilder};
+pub use arbiter::{ArbiterContext, ArbiterVerdict, ARBITER_TIMEOUT_SECS};
 pub use events::{AgentEvent, EventSink};
 pub use openai_compat::OpenAiCompatClient;
 pub use security::{CliConfirmer, CommandConfirmer, ConfirmDecision};

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -637,6 +637,8 @@ async fn run() -> anyhow::Result<()> {
         ssh_targets: launch_ssh_targets,
         save_dir: launch_save_dir,
         command_timeout,
+        arbiter_enabled: config.arbiter_enabled,
+        arbiter_profile: config.arbiter_profile.clone(),
     };
 
     info!("launching TUI");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -41,6 +41,18 @@ pub struct Config {
     /// `None` means the process working directory at startup.
     #[serde(default)]
     pub save_dir: Option<PathBuf>,
+
+    /// Optional named LLM profile used as the command arbiter.
+    /// When unset or invalid, the session profile is used instead.
+    #[serde(default)]
+    pub arbiter_profile: Option<String>,
+
+    /// When `true`, run the independent command arbiter before each confirmation
+    /// gate (`NeedsConfirmation`). Defaults to `true`; the arbiter only runs when
+    /// a command actually needs confirmation (not in `Never` mode or allowlist
+    /// auto-approve paths).
+    #[serde(default = "default_arbiter_enabled")]
+    pub arbiter_enabled: bool,
 }
 
 impl Default for Config {
@@ -52,8 +64,14 @@ impl Default for Config {
             timeouts: TimeoutConfig::default(),
             confirm_mode: CommandConfirmMode::Allowlist,
             save_dir: None,
+            arbiter_profile: None,
+            arbiter_enabled: default_arbiter_enabled(),
         }
     }
+}
+
+fn default_arbiter_enabled() -> bool {
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -370,6 +388,36 @@ impl Config {
         Ok(cfg)
     }
 
+    /// Resolve the effective arbiter profile name.
+    ///
+    /// When `arbiter_profile` is unset, returns `session_profile`. When set but
+    /// not found in `profiles`, falls back to `session_profile` and returns a
+    /// human-readable warning for the UI.
+    pub fn resolve_arbiter_profile<'a>(
+        &'a self,
+        session_profile: &'a str,
+        profiles: &'a [LlmProfile],
+    ) -> (&'a str, Option<String>) {
+        let requested = match &self.arbiter_profile {
+            None => {
+                return (session_profile, None);
+            }
+            Some(name) if name.trim().is_empty() => {
+                return (session_profile, None);
+            }
+            Some(name) => name.as_str(),
+        };
+
+        if profiles.iter().any(|p| p.name == requested) {
+            return (requested, None);
+        }
+
+        let warning = format!(
+            "Arbiter profile '{requested}' not found — using session profile '{session_profile}' for command audits."
+        );
+        (session_profile, Some(warning))
+    }
+
     /// Convenience: load from `config.toml`.
     ///
     /// Search order:
@@ -474,6 +522,39 @@ api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
         assert_eq!(cfg.confirm_mode, CommandConfirmMode::Explain);
+    }
+
+    #[test]
+    fn parse_config_arbiter_defaults() {
+        let toml = r#"
+[llm]
+model = "glm-5.1"
+api_base_url = "https://open.bigmodel.cn/api/paas/v4"
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(cfg.arbiter_enabled);
+        assert!(cfg.arbiter_profile.is_none());
+    }
+
+    #[test]
+    fn resolve_arbiter_profile_falls_back_when_missing() {
+        let cfg = Config {
+            arbiter_profile: Some("missing".into()),
+            ..Config::default()
+        };
+        let profiles = vec![LlmProfile {
+            name: "session".into(),
+            model: "m".into(),
+            api_base_url: "http://localhost".into(),
+            key_env: String::new(),
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+        }];
+        let (name, warn) = cfg.resolve_arbiter_profile("session", &profiles);
+        assert_eq!(name, "session");
+        assert!(warn.is_some());
     }
 
     #[test]

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -341,6 +341,9 @@ struct Settings {
     /// Directory for Ctrl+S session exports (`None` = CWD).
     #[serde(default)]
     save_dir: Option<std::path::PathBuf>,
+    /// Optional LLM profile name for the command arbiter (`None` = session profile).
+    #[serde(default)]
+    arbiter_profile: Option<String>,
 }
 
 impl Settings {
@@ -465,6 +468,7 @@ fn save_config_toml(settings: &Settings) {
     if !settings.extra_body.is_empty() {
         config.llm.extra_body = serde_json::from_str(&settings.extra_body).ok();
     }
+    config.arbiter_profile = settings.arbiter_profile.clone();
     // The primary `[llm]` section above is the ONLY section the GUI still
     // writes to config.toml (backward-compat). Launch-specific sections
     // (llm_profiles, ssh_targets, save_dir) are intentionally left untouched:
@@ -548,6 +552,8 @@ struct LauncherApp {
     show_ssh_password: bool,
     /// Reveal API key field (not persisted).
     show_api_key: bool,
+    /// Arbiter profile selection (`None` = same as session profile).
+    arbiter_profile: Option<String>,
 }
 
 /// Local copy of an LLM profile for GUI editing.
@@ -892,6 +898,39 @@ impl LauncherApp {
                 .desired_rows(2).desired_width(f32::INFINITY));
         }
         self.show_api_key = show_api_key;
+
+        ui.separator();
+        ui.label("Arbiter profile (optional — independent command audit before confirm):");
+        let mut arbiter_choice = self.arbiter_profile.clone().unwrap_or_default();
+        let same_label = "(same as session profile)";
+        egui::ComboBox::from_label("Arbiter")
+            .selected_text(if arbiter_choice.is_empty() {
+                same_label
+            } else {
+                &arbiter_choice
+            })
+            .show_ui(ui, |ui| {
+                if ui.selectable_label(arbiter_choice.is_empty(), same_label).clicked() {
+                    arbiter_choice.clear();
+                }
+                for name in &profile_names {
+                    if ui.selectable_label(arbiter_choice == *name, name).clicked() {
+                        arbiter_choice = name.clone();
+                    }
+                }
+            });
+        self.arbiter_profile = if arbiter_choice.is_empty() {
+            None
+        } else {
+            Some(arbiter_choice)
+        };
+        ui.label(
+            egui::RichText::new(
+                "Tip: a different vendor catches mismatches between command and explanation.",
+            )
+            .small()
+            .weak(),
+        );
     }
 
     /// Folder picker for the Ctrl+S session export directory.
@@ -935,6 +974,7 @@ impl LauncherApp {
             }).collect(),
             selected_profile: self.selected_profile,
             save_dir: self.save_dir.clone(),
+            arbiter_profile: self.arbiter_profile.clone(),
         }.save();
     }
 
@@ -1001,6 +1041,7 @@ impl LauncherApp {
             }).collect(),
             selected_profile: self.selected_profile,
             save_dir: self.save_dir.clone(),
+            arbiter_profile: self.arbiter_profile.clone(),
         };
         settings.save();
         save_config_toml(&settings);
@@ -1162,6 +1203,7 @@ pub fn run_launcher(config: &Config) {
             }).collect(),
             selected_profile: settings.selected_profile.min(profiles.len().saturating_sub(1)),
             save_dir: settings.save_dir.clone(),
+            arbiter_profile: settings.arbiter_profile.clone(),
         }.save();
         tracing::info!("persisted deduplicated profile config on startup");
     }
@@ -1183,6 +1225,7 @@ pub fn run_launcher(config: &Config) {
         save_dir: settings.save_dir.clone(),
         show_ssh_password: false,
         show_api_key: false,
+        arbiter_profile: settings.arbiter_profile.clone(),
     };
 
     let options = eframe::NativeOptions {
@@ -1379,6 +1422,7 @@ mod tests {
             profiles: vec![],
             selected_profile: 0,
             save_dir: None,
+            arbiter_profile: None,
         };
         std::fs::write(&file, serde_json::to_string_pretty(&s).unwrap()).unwrap();
 
@@ -1579,6 +1623,7 @@ mod tests {
             save_dir: None,
             show_ssh_password: false,
             show_api_key: false,
+            arbiter_profile: None,
         }
     }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -157,6 +157,44 @@ pub struct PendingConfirm {
     pub explanation: String,
     pub destructive: bool,
     pub respond_to: oneshot::Sender<bool>,
+    /// Arbiter verdict label (`AGREE`, `MISMATCH`, …) when audit completed.
+    pub audit_verdict: Option<String>,
+    /// One-sentence arbiter reason (empty when `AGREE`).
+    pub audit_reason: String,
+    /// Model that produced the arbiter verdict.
+    pub audit_model: Option<String>,
+    /// `true` when the arbiter audit was unavailable.
+    pub audit_unavailable: bool,
+}
+
+/// Pending arbiter audit result, stored until `ConfirmationRequest` merges it.
+#[derive(Debug, Clone)]
+pub struct PendingAudit {
+    pub verdict: String,
+    pub reason: String,
+    pub arbiter_model: Option<String>,
+    pub unavailable: bool,
+}
+
+impl PendingConfirm {
+    /// Create a pending confirmation (audit fields default to empty/unavailable).
+    pub fn new(
+        command: String,
+        explanation: String,
+        destructive: bool,
+        respond_to: oneshot::Sender<bool>,
+    ) -> Self {
+        Self {
+            command,
+            explanation,
+            destructive,
+            respond_to,
+            audit_verdict: None,
+            audit_reason: String::new(),
+            audit_model: None,
+            audit_unavailable: false,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +374,8 @@ pub struct Session {
     pub streaming: bool,
     /// Pending command proposal metadata from `CommandProposed`.
     pub pending_proposal: Option<(String, String)>,
+    /// Arbiter audit received before the confirmation dialog opens.
+    pub pending_audit: Option<PendingAudit>,
     /// Spinner animation tick counter — incremented each render frame.
     pub tick: u64,
     /// Clickable help-bar zones: (rect, action) filled during render.
@@ -400,6 +440,12 @@ pub struct Session {
     /// Used to attribute the response to the correct profile even if the
     /// user pressed Ctrl+L before the response arrived.
     pub pending_llm_profile: Option<String>,
+    /// Cumulative arbiter input tokens for this session.
+    pub arbiter_tokens_in: u64,
+    /// Cumulative arbiter output tokens for this session.
+    pub arbiter_tokens_out: u64,
+    /// Cumulative arbiter cost in USD.
+    pub arbiter_cost_usd: Option<f64>,
     /// Command confirmation mode for this tab (per-session, toggled via F2).
     pub confirm_mode: CommandConfirmMode,
     /// Previous confirm mode (to toggle back from Explain via F2).
@@ -693,6 +739,7 @@ impl Session {
             cancellation: None,
             streaming: false,
             pending_proposal: None,
+            pending_audit: None,
             tick: 0,
             helpbar_zones: Vec::new(),
             input_scroll_offset: 0,
@@ -716,6 +763,9 @@ impl Session {
             last_served_model: None,
             model_per_profile: HashMap::new(),
             pending_llm_profile: None,
+            arbiter_tokens_in: 0,
+            arbiter_tokens_out: 0,
+            arbiter_cost_usd: None,
             confirm_mode,
             prev_confirm_mode: CommandConfirmMode::Allowlist,
             transcript_path: None,
@@ -1342,7 +1392,7 @@ impl App {
     /// All mutations of `messages` must go through this method (or explicitly
     /// bump `message_rev`) so that [`layout_cache`](Self::layout_cache)
     /// invalidates correctly.
-    fn push_message(&mut self, msg: ChatBlock) {
+    pub(crate) fn push_message(&mut self, msg: ChatBlock) {
         self.messages.push(msg);
         self.message_rev = self.message_rev.wrapping_add(1);
         // New message invalidates line indices — clear any active selection.
@@ -3165,6 +3215,19 @@ impl App {
                 filar_agent::AgentEvent::CommandProposed { command, explanation, .. } => {
                     self.pending_proposal = Some((command, explanation));
                 }
+                filar_agent::AgentEvent::CommandAudited {
+                    verdict,
+                    reason,
+                    arbiter_model,
+                    unavailable,
+                } => {
+                    self.pending_audit = Some(PendingAudit {
+                        verdict,
+                        reason,
+                        arbiter_model,
+                        unavailable,
+                    });
+                }
                 filar_agent::AgentEvent::CommandFinished { command, output, denied } => {
                     if !denied {
                         self.streaming = false;
@@ -3226,24 +3289,33 @@ impl App {
                     self.cancellation = None;
                     self.active_session_mut().background_activity = false;
                 }
-                filar_agent::AgentEvent::TokenUsage { tokens_in, tokens_out, cost, model } => {
+                filar_agent::AgentEvent::TokenUsage { tokens_in, tokens_out, cost, model, arbiter } => {
                     if let Some(s) = self.sessions.iter_mut().find(|s| s.id == session_id) {
-                        s.tokens_in += tokens_in;
-                        s.tokens_out += tokens_out;
-                        if let Some(c) = cost {
-                            let total = s.cost_usd.unwrap_or(0.0) + c;
-                            s.cost_usd = Some((total * 10000.0).round() / 10000.0);
-                        }
-                        let profile_key = s.pending_llm_profile.clone().unwrap_or_else(|| {
-                            warn!("pending_llm_profile is None — usage attributed to default profile");
-                            self.default_profile_name.clone()
-                        });
-                        let pu = s.per_profile.entry(profile_key.clone()).or_default();
-                        pu.tokens_in += tokens_in;
-                        pu.tokens_out += tokens_out;
-                        if let Some(m) = model {
-                            s.last_served_model = Some(m.clone());
-                            s.model_per_profile.insert(profile_key, m);
+                        if arbiter {
+                            s.arbiter_tokens_in += tokens_in;
+                            s.arbiter_tokens_out += tokens_out;
+                            if let Some(c) = cost {
+                                let total = s.arbiter_cost_usd.unwrap_or(0.0) + c;
+                                s.arbiter_cost_usd = Some((total * 10000.0).round() / 10000.0);
+                            }
+                        } else {
+                            s.tokens_in += tokens_in;
+                            s.tokens_out += tokens_out;
+                            if let Some(c) = cost {
+                                let total = s.cost_usd.unwrap_or(0.0) + c;
+                                s.cost_usd = Some((total * 10000.0).round() / 10000.0);
+                            }
+                            let profile_key = s.pending_llm_profile.clone().unwrap_or_else(|| {
+                                warn!("pending_llm_profile is None — usage attributed to default profile");
+                                self.default_profile_name.clone()
+                            });
+                            let pu = s.per_profile.entry(profile_key.clone()).or_default();
+                            pu.tokens_in += tokens_in;
+                            pu.tokens_out += tokens_out;
+                            if let Some(m) = model {
+                                s.last_served_model = Some(m.clone());
+                                s.model_per_profile.insert(profile_key, m);
+                            }
                         }
                     }
                 }
@@ -3276,12 +3348,20 @@ impl App {
                 // Finalize any streaming text before showing the dialog.
                 self.streaming = false;
                 auto_scroll = self.scroll == 0;
-                self.pending_confirm = Some(PendingConfirm {
-                    command: command.clone(),
-                    explanation: explanation.clone(),
+                let audit = self.pending_audit.take();
+                let mut pending = PendingConfirm::new(
+                    command.clone(),
+                    explanation.clone(),
                     destructive,
                     respond_to,
-                });
+                );
+                if let Some(a) = audit {
+                    pending.audit_verdict = Some(a.verdict);
+                    pending.audit_reason = a.reason;
+                    pending.audit_model = a.arbiter_model;
+                    pending.audit_unavailable = a.unavailable;
+                }
+                self.pending_confirm = Some(pending);
                 self.mode = AppMode::Confirming;
                 // Reset selection to safe default (Deny).
                 self.confirm_selected = false;
@@ -4041,12 +4121,12 @@ mod tests {
     fn confirmation_response_bumps_message_rev() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let (tx, _rx) = oneshot::channel();
-        app.pending_confirm = Some(PendingConfirm {
-            command: "rm -rf /tmp/test".into(),
-            explanation: "cleanup".into(),
-            destructive: false,
-            respond_to: tx,
-        });
+        app.pending_confirm = Some(PendingConfirm::new(
+            "rm -rf /tmp/test".into(),
+            "cleanup".into(),
+            false,
+            tx,
+        ));
         app.mode = AppMode::Confirming;
         let rev_before = app.message_rev;
 
@@ -4245,12 +4325,12 @@ mod tests {
     fn end_key_resets_scroll_in_confirming_mode() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let (tx, _rx) = oneshot::channel();
-        app.pending_confirm = Some(PendingConfirm {
-            command: "ls".into(),
-            explanation: "test".into(),
-            destructive: false,
-            respond_to: tx,
-        });
+        app.pending_confirm = Some(PendingConfirm::new(
+            "ls".into(),
+            "test".into(),
+            false,
+            tx,
+        ));
         app.mode = AppMode::Confirming;
         app.scroll = 12;
         app.handle_key(crossterm::event::KeyEvent::new(
@@ -4523,12 +4603,12 @@ mod tests {
         // but for tests we just check mode/message changes.
         // Use a fresh sender that we drop to simulate a real channel.
         let (tx, _rx2) = oneshot::channel::<bool>();
-        app.pending_confirm = Some(PendingConfirm {
-            command: "rm -rf /tmp/test".into(),
-            explanation: "cleanup".into(),
+        app.pending_confirm = Some(PendingConfirm::new(
+            "rm -rf /tmp/test".into(),
+            "cleanup".into(),
             destructive,
-            respond_to: tx,
-        });
+            tx,
+        ));
         app.mode = AppMode::Confirming;
         app.confirm_selected = false; // safe default
         app
@@ -5308,12 +5388,12 @@ mod tests {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let (tx, mut rx) = tokio::sync::oneshot::channel();
         app.mode = AppMode::Confirming;
-        app.pending_confirm = Some(PendingConfirm {
-            command: "ls".into(),
-            explanation: "list".into(),
-            destructive: false,
-            respond_to: tx,
-        });
+        app.pending_confirm = Some(PendingConfirm::new(
+            "ls".into(),
+            "list".into(),
+            false,
+            tx,
+        ));
         app.execute_help_action(HelpAction::Approve);
         assert_eq!(app.mode, AppMode::Thinking);
         assert!(rx.try_recv().unwrap());
@@ -5324,12 +5404,12 @@ mod tests {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         let (tx, mut rx) = tokio::sync::oneshot::channel();
         app.mode = AppMode::Confirming;
-        app.pending_confirm = Some(PendingConfirm {
-            command: "rm".into(),
-            explanation: "remove".into(),
-            destructive: true,
-            respond_to: tx,
-        });
+        app.pending_confirm = Some(PendingConfirm::new(
+            "rm".into(),
+            "remove".into(),
+            true,
+            tx,
+        ));
         app.execute_help_action(HelpAction::Deny);
         assert_eq!(app.mode, AppMode::Thinking);
         assert!(!rx.try_recv().unwrap());
@@ -6951,7 +7031,7 @@ mod tests {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.handle_agent_event(TuiEvent::Agent {
             session_id: app.sessions[0].id,
-            event: filar_agent::AgentEvent::TokenUsage { tokens_in: 10, tokens_out: 20, cost: None, model: None },
+            event: filar_agent::AgentEvent::TokenUsage { tokens_in: 10, tokens_out: 20, cost: None, model: None, arbiter: false },
         });
         assert_eq!(app.sessions[0].tokens_in, 10);
         app.new_tab();
@@ -6969,7 +7049,7 @@ mod tests {
         app.handle_agent_event(TuiEvent::Agent {
             session_id: app.sessions[0].id,
             event: filar_agent::AgentEvent::TokenUsage {
-                tokens_in: 100, tokens_out: 200, cost: Some(0.0015), model: None,
+                tokens_in: 100, tokens_out: 200, cost: Some(0.0015), model: None, arbiter: false,
             },
         });
         assert_eq!(app.sessions[0].tokens_in, 100);
@@ -6981,7 +7061,7 @@ mod tests {
         app.handle_agent_event(TuiEvent::Agent {
             session_id: app.sessions[0].id,
             event: filar_agent::AgentEvent::TokenUsage {
-                tokens_in: 50, tokens_out: 100, cost: Some(0.0030), model: Some("cohere/command-r".into()),
+                tokens_in: 50, tokens_out: 100, cost: Some(0.0030), model: Some("cohere/command-r".into()), arbiter: false,
             },
         });
         assert_eq!(app.sessions[0].tokens_in, 150);
@@ -7032,7 +7112,7 @@ mod tests {
         app.handle_agent_event(TuiEvent::Agent {
             session_id: app.sessions[0].id,
             event: filar_agent::AgentEvent::TokenUsage {
-                tokens_in: 10, tokens_out: 20, cost: None, model: Some("served-glm".into()),
+                tokens_in: 10, tokens_out: 20, cost: None, model: Some("served-glm".into()), arbiter: false,
             },
         });
         assert_eq!(app.sessions[0].per_profile["glm"].tokens_in, 10);
@@ -7051,7 +7131,7 @@ mod tests {
         app.handle_agent_event(TuiEvent::Agent {
             session_id: app.sessions[0].id,
             event: filar_agent::AgentEvent::TokenUsage {
-                tokens_in: 10, tokens_out: 20, cost: None, model: None,
+                tokens_in: 10, tokens_out: 20, cost: None, model: None, arbiter: false,
             },
         });
         let pu = app.sessions[0].per_profile.get("fallback-profile").unwrap();
@@ -7900,12 +7980,12 @@ mod tests {
     fn f2_aborts_pending_confirm() {
         let mut app = App::new("test".into(), CommandConfirmMode::Allowlist);
         let (tx, mut rx) = tokio::sync::oneshot::channel();
-        app.pending_confirm = Some(PendingConfirm {
-            command: "ls".into(),
-            explanation: "list".into(),
-            destructive: false,
-            respond_to: tx,
-        });
+        app.pending_confirm = Some(PendingConfirm::new(
+            "ls".into(),
+            "list".into(),
+            false,
+            tx,
+        ));
         app.mode = AppMode::Confirming;
         app.awaiting_confirmation = true;
         app.confirm_button_areas = vec![(Rect::new(0, 0, 10, 3), true), (Rect::new(0, 0, 10, 3), false)];

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -375,6 +375,10 @@ pub struct TuiConfig {
     /// Per-command execution timeout from `[timeouts].command_secs`.
     /// Applied to SSH marker wait and local subprocess execution.
     pub command_timeout: Duration,
+    /// When true, run the command arbiter before each confirmation gate.
+    pub arbiter_enabled: bool,
+    /// Optional named profile for the arbiter (`None` = session profile).
+    pub arbiter_profile: Option<String>,
 }
 
 /// SSH transport tunables with the app-configured command timeout.
@@ -960,11 +964,12 @@ async fn run_app(
                         let cancel_token = CancellationToken::new();
                         app.cancellation = Some(cancel_token.clone());
                         // Resolve the LLM client for this session's profile.
+                        let profile_name = app.sessions[app.active]
+                            .llm_profile
+                            .as_deref()
+                            .unwrap_or(&app.default_profile_name)
+                            .to_string();
                         let session_llm = {
-                            let profile_name = app.sessions[app.active]
-                                .llm_profile
-                                .as_deref()
-                                .unwrap_or(&app.default_profile_name);
                             let profile = app.profiles.iter()
                                 .find(|p| p.name == profile_name);
                             match profile {
@@ -981,8 +986,38 @@ async fn run_app(
                                 }
                             }
                         };
+                        let arbiter_cfg = filar_core::Config {
+                            arbiter_profile: config.arbiter_profile.clone(),
+                            arbiter_enabled: config.arbiter_enabled,
+                            ..Default::default()
+                        };
+                        let (arbiter_profile_name, fallback_msg) = arbiter_cfg
+                            .resolve_arbiter_profile(&profile_name, &app.profiles);
+                        let arbiter_profile_name = arbiter_profile_name.to_string();
+                        if let Some(msg) = fallback_msg {
+                            app.push_message(ChatBlock::System(msg));
+                        }
+                        let (arbiter_llm, arbiter_model_name) = if config.arbiter_enabled {
+                            match app.profiles.iter().find(|p| p.name == arbiter_profile_name) {
+                                Some(p) => match (config.llm_factory)(p, &config.secret_provider) {
+                                    Ok(c) => (Some(c), p.name.clone()),
+                                    Err(e) => {
+                                        app.push_message(ChatBlock::System(format!(
+                                            "Arbiter LLM unavailable ({e}) — confirmation proceeds without audit."
+                                        )));
+                                        (None, arbiter_profile_name.clone())
+                                    }
+                                },
+                                None => (None, profile_name.clone()),
+                            }
+                        } else {
+                            (None, profile_name.clone())
+                        };
                         spawn_agent(
                             session_llm,
+                            arbiter_llm,
+                            config.arbiter_enabled,
+                            arbiter_model_name,
                             agent_exec,
                             app.confirm_mode,
                             user_input,
@@ -1617,6 +1652,9 @@ pub fn resize_all_models(app: &mut App, cols: u16, rows: u16) {
 #[allow(clippy::too_many_arguments)]
 fn spawn_agent(
     llm: Arc<dyn LlmClient>,
+    arbiter_llm: Option<Arc<dyn LlmClient>>,
+    arbiter_enabled: bool,
+    arbiter_model_name: String,
     executor: Arc<dyn CommandExecutor>,
     confirm_mode: CommandConfirmMode,
     user_input: String,
@@ -1677,11 +1715,14 @@ fn spawn_agent(
             .confirm_mode(confirm_mode)
             .event_sink(sink)
             .cancellation(cancellation)
-            .secret_provider(secret_provider);
+            .secret_provider(secret_provider)
+            .arbiter_enabled(arbiter_enabled)
+            .arbiter_llm(arbiter_llm)
+            .arbiter_model_name(arbiter_model_name);
         if is_local {
-            builder = builder.local_mode();
+            builder = builder.local_mode().arbiter_local_context();
         } else {
-            builder = builder.ssh_mode(ssh_info.as_deref());
+            builder = builder.ssh_mode(ssh_info.as_deref()).arbiter_ssh_context(ssh_info.clone());
         }
 
         let agent = match builder.build() {

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -51,6 +51,10 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     let explanation = confirm.explanation.clone();
     let command = confirm.command.clone();
     let destructive = confirm.destructive;
+    let audit_verdict = confirm.audit_verdict.clone();
+    let audit_reason = confirm.audit_reason.clone();
+    let audit_model = confirm.audit_model.clone();
+    let audit_unavailable = confirm.audit_unavailable;
 
     // --- Estimate modal dimensions ---
     // Minimum width 32 so buttons fit inside borders (30 chars + 2 borders).
@@ -63,11 +67,17 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     } else {
         0
     };
+    let audit_rows = audit_display_rows(
+        audit_unavailable,
+        audit_verdict.as_deref(),
+        &audit_reason,
+        audit_model.as_deref(),
+    );
     let warning_rows = if destructive { 1 } else { 0 };
     let command_rows = estimate_wrapped_rows(&command_text, inner_width);
     let empty_rows = 1; // separator line before buttons
 
-    let natural_content = (explanation_rows + warning_rows + command_rows + empty_rows) as u16;
+    let natural_content = (explanation_rows + audit_rows + warning_rows + command_rows + empty_rows) as u16;
     // +2 borders +1 buttons
     let natural_height = natural_content.saturating_add(3);
 
@@ -79,10 +89,16 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
         &explanation,
         &command_text,
         destructive,
+        audit_unavailable,
+        audit_verdict.as_deref(),
+        &audit_reason,
+        audit_model.as_deref(),
         app.theme.fg_style(),
         app.theme.danger_fg(),
         app.theme.warning_fg(),
         app.theme.muted(),
+        app.theme.success_fg(),
+        app.theme.accent,
         inner_width,
         max_content_rows,
     );
@@ -142,15 +158,47 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     render_buttons(f, app, chunks[1]);
 }
 
+/// Estimate rows used by the arbiter audit block.
+fn audit_display_rows(
+    unavailable: bool,
+    verdict: Option<&str>,
+    reason: &str,
+    model: Option<&str>,
+) -> usize {
+    if unavailable {
+        return 1;
+    }
+    let Some(verdict) = verdict else {
+        return 0;
+    };
+    if verdict.eq_ignore_ascii_case("AGREE") {
+        return 1;
+    }
+    let mut rows = 1; // verdict header
+    if !reason.is_empty() {
+        rows += 1;
+    }
+    if model.is_some() {
+        rows += 1;
+    }
+    rows
+}
+
 /// Build modal body lines, truncating so wrapped height ≤ `max_rows`.
 fn build_modal_lines(
     explanation: &str,
     command_text: &str,
     destructive: bool,
+    audit_unavailable: bool,
+    audit_verdict: Option<&str>,
+    audit_reason: &str,
+    audit_model: Option<&str>,
     fg: Style,
     danger: Style,
     warning: Style,
     muted: Style,
+    success: Style,
+    accent: ratatui::style::Color,
     inner_width: usize,
     max_rows: usize,
 ) -> Vec<Line<'static>> {
@@ -180,6 +228,23 @@ fn build_modal_lines(
             )));
             used = used.saturating_add(1).min(max_rows);
         }
+    }
+
+    if used < max_rows {
+        append_audit_lines(
+            &mut lines,
+            &mut used,
+            max_rows,
+            inner_width,
+            audit_unavailable,
+            audit_verdict,
+            audit_reason,
+            audit_model,
+            muted,
+            success,
+            danger,
+            accent,
+        );
     }
 
     if destructive && used < max_rows {
@@ -213,6 +278,97 @@ fn build_modal_lines(
     }
 
     lines
+}
+
+fn append_audit_lines(
+    lines: &mut Vec<Line<'static>>,
+    used: &mut usize,
+    max_rows: usize,
+    inner_width: usize,
+    unavailable: bool,
+    verdict: Option<&str>,
+    reason: &str,
+    model: Option<&str>,
+    muted: Style,
+    success: Style,
+    danger: Style,
+    accent: ratatui::style::Color,
+) {
+    if *used >= max_rows {
+        return;
+    }
+    if unavailable {
+        let _ = push_line(
+            lines,
+            used,
+            max_rows,
+            inner_width,
+            "Audit: check unavailable — decide from the explanation.".to_string(),
+            muted,
+        );
+        return;
+    }
+    let Some(verdict) = verdict else {
+        return;
+    };
+    if verdict.eq_ignore_ascii_case("AGREE") {
+        let model_note = model
+            .map(|m| format!(" (checked by {m})"))
+            .unwrap_or_default();
+        let _ = push_line(
+            lines,
+            used,
+            max_rows,
+            inner_width,
+            format!("Audit: agree{model_note}"),
+            success,
+        );
+        return;
+    }
+    let header = format!("Audit: {verdict}");
+    let _ = push_line(lines, used, max_rows, inner_width, header, Style::default().fg(accent).add_modifier(Modifier::BOLD));
+    if !reason.is_empty() && *used < max_rows {
+        let _ = push_line(
+            lines,
+            used,
+            max_rows,
+            inner_width,
+            reason.to_string(),
+            danger,
+        );
+    }
+    if let Some(m) = model {
+        if *used < max_rows {
+            let _ = push_line(
+                lines,
+                used,
+                max_rows,
+                inner_width,
+                format!("— {m}"),
+                muted,
+            );
+        }
+    }
+}
+
+fn push_line(
+    lines: &mut Vec<Line<'static>>,
+    used: &mut usize,
+    max_rows: usize,
+    inner_width: usize,
+    text: String,
+    style: Style,
+) -> bool {
+    if *used >= max_rows {
+        return false;
+    }
+    let rows = estimate_wrapped_rows(&text, inner_width);
+    if *used + rows > max_rows {
+        return false;
+    }
+    lines.push(Line::from(Span::styled(text, style)));
+    *used += rows;
+    true
 }
 
 /// Truncate `text` so its wrapped row count is ≤ `max_rows`.
@@ -429,12 +585,12 @@ mod tests {
 
     fn pending(command: &str, destructive: bool) -> PendingConfirm {
         let (tx, _rx) = oneshot::channel();
-        PendingConfirm {
-            command: command.to_string(),
-            explanation: "long command".into(),
+        PendingConfirm::new(
+            command.to_string(),
+            "long command".into(),
             destructive,
-            respond_to: tx,
-        }
+            tx,
+        )
     }
 
     #[test]

--- a/crates/tui/src/ui/help.rs
+++ b/crates/tui/src/ui/help.rs
@@ -338,6 +338,8 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
         lines.push(line);
     }
 
+    append_usage_summary(&mut lines, app);
+
     let inner = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(app.theme.accent))
@@ -367,6 +369,59 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App, area: Rect) {
         .wrap(Wrap { trim: false });
 
     f.render_widget(paragraph, overlay_area);
+}
+
+/// Append session token usage summary (including arbiter) to the help overlay.
+fn append_usage_summary(lines: &mut Vec<Line>, app: &App) {
+    let active = app
+        .llm_profile
+        .clone()
+        .unwrap_or_else(|| app.default_profile_name.clone());
+    let profile_usage = app.per_profile.get(&active);
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(Span::styled(
+        " Usage ",
+        Style::default()
+            .fg(app.theme.accent)
+            .add_modifier(Modifier::BOLD),
+    )));
+
+    if let Some(pu) = profile_usage {
+        if pu.tokens_in > 0 || pu.tokens_out > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("  Session ({active}): {}↑ {}↓", pu.tokens_in, pu.tokens_out),
+                app.theme.fg_style(),
+            )));
+        }
+    } else if app.tokens_in > 0 || app.tokens_out > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("  Session: {}↑ {}↓", app.tokens_in, app.tokens_out),
+            app.theme.fg_style(),
+        )));
+    }
+
+    if app.arbiter_tokens_in > 0 || app.arbiter_tokens_out > 0 {
+        let mut arb = format!(
+            "  Arbiter: {}↑ {}↓",
+            app.arbiter_tokens_in, app.arbiter_tokens_out
+        );
+        if let Some(cost) = app.arbiter_cost_usd {
+            if cost > 0.0 {
+                arb.push_str(&format!(" ${cost:.4}"));
+            }
+        }
+        lines.push(Line::from(Span::styled(arb, app.theme.dim())));
+    }
+
+    if let Some(cost) = app.cost_usd {
+        if cost > 0.0 {
+            lines.push(Line::from(Span::styled(
+                format!("  Total cost: ${cost:.4}"),
+                app.theme.muted(),
+            )));
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds an independent command arbiter: before each `NeedsConfirmation` gate, a second LLM audits whether the proposed command matches its explanation (12s timeout, never blocks approval/denial).
- Config: `arbiter_profile` (optional, GUI dropdown) and `arbiter_enabled` (default `true`; only runs when confirmation is actually required, not on allowlist auto-approve or `Never` mode).
- TUI confirm modal shows AGREE subtly or objection prominently with model name; F1 help overlay lists arbiter token usage separately.
- Emits `AgentEvent::CommandAudited` and `TokenUsage { arbiter: true }` without changing `CommandConfirmer`.

Closes #353

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo test --workspace` — green (113+ agent tests incl. arbiter parse + no auto-deny)
- [ ] **eval-smoke required** — new `ARBITER_SYSTEM_PROMPT` constant (not in eval snapshot yet; run eval per AGENTS.md)
- [ ] Manual: 10+ confirmable commands in Explain mode — count arbiter objections (target ≤⅓; if higher, prompt needs tightening)
- [ ] Manual: unset arbiter profile → confirm shows same session model as checker
- [ ] Manual: set arbiter to different profile → verdict shows that model name
- [ ] Manual: invalid/missing arbiter profile → system message + fallback to session profile
- [ ] Manual: disable arbiter network → "check unavailable", confirm still works
- [ ] Manual: artificially mismatched explanation → arbiter flags MISMATCH

## Notes

- `arbiter_enabled` defaults to `true` globally but the arbiter only executes on the `NeedsConfirmation` path (not auto-approved allowlist commands, not `Never` mode).
- New unit/agent tests fail on pre-353 code (CommandAudited event, arbiter parse module).