### PR TITLE
fix(tui): POSIX path algebra for SSH picker on Windows (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   Explain transcript path upgrades once a topic appears
   ([#358](https://github.com/devlawey/filar/issues/358)).
 
+- In-TUI path picker on SSH from a Windows client no longer mangles POSIX paths
+  (`/` + `home` → `/home`, parent of `/home` → `/`); selection cursor is ASCII
+  `>` so it does not render as `?`
+  ([#359](https://github.com/devlawey/filar/issues/359)).
+
 ## [1.0.4] - 2026-08-26
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5196,6 +5196,23 @@ message source.
 
 **Next steps:** manual smoke Ctrl+S with Russian prompt.
 
+## Issue #359: fix(tui) — path picker POSIX nav + ASCII cursor
+
+**Milestone:** 1.0.5. **Branch:** `fix/359-path-picker-posix-nav`.
+
+**Problem:** On Windows clients, SSH path picker used `cfg!(windows)` /
+`std::path` for remote paths (`/`+`home`→`home`, parent `/home`→`\\`);
+selection glyph ▶ rendered as `?`.
+
+**Design:** `join_posix`/`parent_posix` when `path_picker_remote`; local keeps
+`std::path`; cursor `>`; keep `..` on load error.
+
+**Done:** `path_picker.rs`, App wiring, overlay, PLATFORM_NOTES, tests.
+
+**Public contract:** none.
+
+**Next steps:** manual SSH smoke from Windows: `/` → home → up.
+
 ## Release v1.0.4 (2026-08-26)
 
 **Scope:** milestone 1.0.4 — export filename fix (#350), in-TUI path picker on

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -302,6 +302,8 @@ pub struct App {
     pub path_picker_loading: bool,
     pub path_picker_error: Option<String>,
     pub path_picker_truncated: bool,
+    /// Whether the picker is browsing a remote (POSIX) target (#359).
+    pub path_picker_remote: bool,
     /// Bumped to request (re)load of `path_picker_dir` in the runner.
     pub path_picker_load_token: u64,
 }
@@ -520,6 +522,7 @@ impl App {
             path_picker_loading: false,
             path_picker_error: None,
             path_picker_truncated: false,
+            path_picker_remote: false,
             path_picker_load_token: 0,
         }
     }
@@ -3520,6 +3523,7 @@ impl App {
         let session = &self.sessions[self.active];
         let is_remote = session.ssh_info.is_some();
         self.path_picker_kind = kind;
+        self.path_picker_remote = is_remote;
         self.path_picker_dir =
             crate::path_picker::initial_picker_dir(&session.cwd, is_remote);
         self.path_picker_index = 0;
@@ -3555,8 +3559,17 @@ impl App {
         self.path_picker_loading = false;
         self.path_picker_truncated = truncated;
         self.path_picker_error = error;
-        self.path_picker_entries =
-            crate::path_picker::entries_with_parent(&self.path_picker_dir, entries);
+        // On error keep a navigable `..` row when not at root (#359).
+        let entries = if self.path_picker_error.is_some() {
+            Vec::new()
+        } else {
+            entries
+        };
+        self.path_picker_entries = crate::path_picker::entries_with_parent(
+            &self.path_picker_dir,
+            entries,
+            self.path_picker_remote,
+        );
         if self.path_picker_index >= self.path_picker_entries.len() {
             self.path_picker_index = self.path_picker_entries.len().saturating_sub(1);
         }
@@ -3566,14 +3579,16 @@ impl App {
         let Some(entry) = self.path_picker_entries.get(self.path_picker_index).cloned() else {
             return;
         };
+        let remote = self.path_picker_remote;
         if entry.name == ".." {
-            if let Some(parent) = crate::path_picker::parent_path(&self.path_picker_dir) {
+            if let Some(parent) = crate::path_picker::parent_path(&self.path_picker_dir, remote) {
                 self.path_picker_navigate(parent);
             }
             return;
         }
         if entry.is_dir {
-            let path = crate::path_picker::join_path(&self.path_picker_dir, &entry.name);
+            let path =
+                crate::path_picker::join_path(&self.path_picker_dir, &entry.name, remote);
             if self.path_picker_kind == crate::path_picker::PathPickerKind::Folder {
                 self.insert_path_string_at_cursor(&path);
                 self.close_path_picker();
@@ -3581,7 +3596,8 @@ impl App {
                 self.path_picker_navigate(path);
             }
         } else if self.path_picker_kind == crate::path_picker::PathPickerKind::File {
-            let path = crate::path_picker::join_path(&self.path_picker_dir, &entry.name);
+            let path =
+                crate::path_picker::join_path(&self.path_picker_dir, &entry.name, remote);
             self.insert_path_string_at_cursor(&path);
             self.close_path_picker();
         }
@@ -6988,9 +7004,39 @@ mod tests {
     }
 
     #[test]
+    fn path_picker_enter_home_from_root_uses_posix() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.sessions[0].ssh_info = Some("root@host:22".into());
+        app.open_path_picker(crate::path_picker::PathPickerKind::File);
+        assert_eq!(app.path_picker_dir, "/");
+        assert!(app.path_picker_remote);
+        app.path_picker_loading = false;
+        app.apply_path_picker_load(
+            vec![crate::path_picker::PathEntry {
+                name: "home".into(),
+                is_dir: true,
+            }],
+            false,
+            None,
+        );
+        // Skip `..` if present — select `home`.
+        app.path_picker_index = app
+            .path_picker_entries
+            .iter()
+            .position(|e| e.name == "home")
+            .expect("home entry");
+        app.path_picker_activate();
+        assert_eq!(
+            app.path_picker_dir, "/home",
+            "SSH navigate must use POSIX join on Windows client"
+        );
+    }
+
+    #[test]
     fn path_picker_file_select_inserts_absolute_path() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.path_picker_visible = true;
+        app.path_picker_remote = true;
         app.path_picker_kind = crate::path_picker::PathPickerKind::File;
         app.path_picker_dir = "/etc".into();
         app.path_picker_entries = vec![crate::path_picker::PathEntry {

--- a/crates/tui/src/path_picker.rs
+++ b/crates/tui/src/path_picker.rs
@@ -288,6 +288,12 @@ mod tests {
     }
 
     #[test]
+    fn parent_posix_trims_trailing_slash() {
+        assert_eq!(parent_posix("/home/").as_deref(), Some("/"));
+        assert_eq!(parent_posix("/home/user/").as_deref(), Some("/home"));
+    }
+
+    #[test]
     fn selection_cursor_is_ascii() {
         assert_eq!(SELECTION_CURSOR, ">");
         assert!(SELECTION_CURSOR.is_ascii());

--- a/crates/tui/src/path_picker.rs
+++ b/crates/tui/src/path_picker.rs
@@ -1,7 +1,11 @@
-//! In-TUI file/folder picker for inserting paths into agent input (#344, #351).
+//! In-TUI file/folder picker for inserting paths into agent input (#344, #351, #359).
 //!
 //! Lists directories on the active target: local FS via `std::fs`, remote via
 //! readonly `ls` through the session executor (zero-install).
+//!
+//! Path algebra follows the **active target** style (POSIX for SSH), not the
+//! OS that compiled the TUI — Windows clients browsing remote `/home` must not
+//! go through `std::path::Path` (#359).
 
 use std::path::{Path, PathBuf};
 
@@ -25,6 +29,9 @@ pub struct PathEntry {
 /// Maximum directory entries shown (extra rows trigger a warning).
 pub const MAX_ENTRIES: usize = 500;
 
+/// ASCII selection cursor — Unicode ▶ renders as `?` on many Windows consoles (#359 / #310).
+pub const SELECTION_CURSOR: &str = ">";
+
 /// True when `/` at the cursor would start an absolute-path token (input start or after space).
 pub fn path_token_starts_at_cursor(input: &str, cursor_pos: usize) -> bool {
     if cursor_pos == 0 {
@@ -47,45 +54,84 @@ pub fn format_path_for_input(path: &str) -> String {
     }
 }
 
-/// Join `base` and `name` into an absolute path string.
-pub fn join_path(base: &str, name: &str) -> String {
+/// Join `base` and `name` using POSIX rules (SSH / remote target).
+pub fn join_posix(base: &str, name: &str) -> String {
     if name == ".." {
-        return parent_path(base).unwrap_or_else(|| base.to_string());
+        return parent_posix(base).unwrap_or_else(|| base.to_string());
     }
-    let base = base.trim_end_matches(['/', '\\']);
-    if base.is_empty() {
-        if name.starts_with('/') || (cfg!(windows) && name.contains(':')) {
-            name.to_string()
-        } else if cfg!(windows) {
-            format!("{name}")
-        } else {
-            format!("/{name}")
-        }
-    } else if cfg!(windows) && base.contains(':') {
-        format!("{base}\\{name}")
+    if name.starts_with('/') {
+        return name.to_string();
+    }
+    let base = base.trim_end_matches('/');
+    if base.is_empty() || base == "/" {
+        format!("/{name}")
     } else {
         format!("{base}/{name}")
     }
 }
 
-/// Parent directory, or `None` at filesystem root.
-pub fn parent_path(path: &str) -> Option<String> {
+/// Parent directory under POSIX rules, or `None` at `/`.
+pub fn parent_posix(path: &str) -> Option<String> {
+    if path.is_empty() || path == "/" {
+        return None;
+    }
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() || trimmed == "/" {
+        return None;
+    }
+    match trimmed.rfind('/') {
+        None => Some("/".to_string()),
+        Some(0) => Some("/".to_string()),
+        Some(i) => Some(trimmed[..i].to_string()),
+    }
+}
+
+/// Join using the local host filesystem conventions.
+pub fn join_local(base: &str, name: &str) -> String {
+    if name == ".." {
+        return parent_local(base).unwrap_or_else(|| base.to_string());
+    }
+    let base_path = Path::new(base);
+    base_path.join(name).to_string_lossy().into_owned()
+}
+
+/// Parent on the local host filesystem.
+pub fn parent_local(path: &str) -> Option<String> {
     let p = Path::new(path);
-    p.parent().map(|parent| {
-        let s = parent.to_string_lossy();
-        if s.is_empty() {
-            if cfg!(windows) {
-                path.chars()
-                    .take_while(|c| *c != '\\')
-                    .chain(std::iter::once('\\'))
-                    .collect()
-            } else {
-                "/".to_string()
+    let parent = p.parent()?;
+    let s = parent.to_string_lossy();
+    if s.is_empty() {
+        // Drive root on Windows (e.g. parent of `C:\Users` → `C:\`).
+        if cfg!(windows) {
+            let drive: String = path
+                .chars()
+                .take_while(|c| *c != '\\' && *c != '/')
+                .collect();
+            if drive.ends_with(':') {
+                return Some(format!("{drive}\\"));
             }
-        } else {
-            s.into_owned()
         }
-    })
+        return None;
+    }
+    Some(s.into_owned())
+}
+
+/// Join path for the active target style.
+pub fn join_path(base: &str, name: &str, is_remote: bool) -> String {
+    if is_remote {
+        join_posix(base, name)
+    } else {
+        join_local(base, name)
+    }
+}
+
+/// Parent path for the active target style.
+pub fn parent_path(path: &str, is_remote: bool) -> Option<String> {
+    if is_remote {
+        parent_posix(path)
+    } else {
+        parent_local(path)
+    }
 }
 
 /// Initial directory when opening the picker for a session tab.
@@ -155,7 +201,7 @@ pub fn list_local_dir(dir: &str) -> Result<(Vec<PathEntry>, bool)> {
             .file_type()
             .map_err(|e| CoreError::Other(e.to_string()))?;
         let name = entry.file_name().to_string_lossy().into_owned();
-        if name == "." {
+        if name == "." || name == ".." {
             continue;
         }
         entries.push(PathEntry {
@@ -173,8 +219,8 @@ pub fn list_local_dir(dir: &str) -> Result<(Vec<PathEntry>, bool)> {
 }
 
 /// Build display list with optional `..` parent row at the top.
-pub fn entries_with_parent(dir: &str, mut entries: Vec<PathEntry>) -> Vec<PathEntry> {
-    if parent_path(dir).is_some() {
+pub fn entries_with_parent(dir: &str, mut entries: Vec<PathEntry>, is_remote: bool) -> Vec<PathEntry> {
+    if parent_path(dir, is_remote).is_some() {
         entries.insert(
             0,
             PathEntry {
@@ -222,15 +268,28 @@ mod tests {
     }
 
     #[test]
-    fn join_and_parent_posix() {
-        assert_eq!(join_path("/etc", "nginx"), "/etc/nginx");
-        assert_eq!(parent_path("/etc/nginx").as_deref(), Some("/etc"));
-        assert_eq!(parent_path("/").as_deref(), None);
+    fn join_and_parent_posix_from_root() {
+        // Must work on Windows hosts browsing SSH (#359).
+        assert_eq!(join_posix("/", "home"), "/home");
+        assert_eq!(join_posix("/home", "user"), "/home/user");
+        assert_eq!(parent_posix("/home").as_deref(), Some("/"));
+        assert_eq!(parent_posix("/home/user").as_deref(), Some("/home"));
+        assert_eq!(parent_posix("/").as_deref(), None);
+        assert_eq!(join_path("/", "home", true), "/home");
+        assert_eq!(parent_path("/home", true).as_deref(), Some("/"));
     }
 
     #[test]
-    fn entries_with_parent_inserts_dotdot() {
-        let entries = entries_with_parent("/etc", vec![]);
+    fn entries_with_parent_inserts_dotdot_posix() {
+        let entries = entries_with_parent("/etc", vec![], true);
         assert_eq!(entries[0].name, "..");
+        let at_root = entries_with_parent("/", vec![], true);
+        assert!(at_root.iter().all(|e| e.name != ".."));
+    }
+
+    #[test]
+    fn selection_cursor_is_ascii() {
+        assert_eq!(SELECTION_CURSOR, ">");
+        assert!(SELECTION_CURSOR.is_ascii());
     }
 }

--- a/crates/tui/src/ui/path_picker_overlay.rs
+++ b/crates/tui/src/ui/path_picker_overlay.rs
@@ -60,7 +60,11 @@ pub(crate) fn render_path_picker(f: &mut Frame, app: &App, area: Rect) {
         )])));
     } else {
         for (i, entry) in app.path_picker_entries.iter().enumerate() {
-            let cursor = if app.path_picker_index == i { "\u{25b6}" } else { " " };
+            let cursor = if app.path_picker_index == i {
+                crate::path_picker::SELECTION_CURSOR
+            } else {
+                " "
+            };
             let suffix = if entry.is_dir { "/" } else { "" };
             items.push(ListItem::new(Line::from(vec![
                 Span::raw(format!(" {cursor} ")),

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -260,19 +260,22 @@ columnar tools (`ps`, aligned tables) stay consistent.
 | Ambiguous width (e.g. some box-drawing) | Follow unicode-width/ratatui; Terminal.app vs Windows Terminal can still differ for East-Asian Ambiguous characters — report if still visible after #333 |
 | Interactive PTY scrollback | Separate `TerminalModel` path; not changed by #333 |
 
-## TUI path picker (#351)
+## TUI path picker (#351, #359)
 
 Agent input path picker (`/`, `Ctrl+Shift+F`, `Ctrl+Shift+D`) is an in-TUI
 overlay listing the **active tab's target** filesystem:
 
-| Tab | Listing source |
-|-----|----------------|
-| Local | Client `read_dir` |
-| SSH | Readonly remote `ls -1Ap` via session executor (zero-install) |
+| Tab | Listing source | Path algebra |
+|-----|----------------|--------------|
+| Local | Client `read_dir` | Host-native (`std::path`) |
+| SSH | Readonly remote `ls -1Ap` via session executor (zero-install) | **POSIX string join/parent** (not Windows `Path`) |
 
 Native OS file dialogs (`rfd`) are no longer used in the TUI; the GUI launcher
 Browse button still uses `rfd` locally.
 
 Remote listing requires a live SSH executor on the tab; large directories are
 capped at 500 entries with a truncation warning.
+
+Selection cursor is ASCII `>` — Unicode ▶ rendered as `?` on many Windows
+consoles (#359, same class as #310 help glyphs).
 


### PR DESCRIPTION
## Summary

Fixes SSH path picker on Windows clients:

- Remote path join/parent use POSIX string algebra (not `std::path` / `cfg!(windows)`)
- `/` + `home` → `/home`; parent of `/home` → `/`
- Selection cursor is ASCII `>` (no more `?` for ▶)
- On load error, still show navigable `..` when not at root

Closes #359

## Test plan

- [x] `cargo test -p filar-tui path_picker`
- [ ] Manual SSH from Windows: open picker → up → enter `home` → listing appears → up works
- [ ] Local tab still browses Windows paths