### PR TITLE
fix(gui/agent): pass arbiter profile through pending_launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   `>` so it does not render as `?`
   ([#359](https://github.com/devlawey/filar/issues/359)).
 
+- Arbiter profile chosen in the GUI launcher is passed through `pending_launch.json`
+  into the TUI (was ignored; CWD `config.toml` always fell back to the session
+  profile). Confirm overlay labels same-vs-independent arbiter clearly
+  ([#360](https://github.com/devlawey/filar/issues/360)).
+
 ## [1.0.4] - 2026-08-26
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5223,9 +5223,10 @@ selection glyph ▶ rendered as `?`.
 **Design:** `LaunchConfig.arbiter_profile` → main → `TuiConfig`; confirm overlay
 distinguishes same vs independent profile.
 
-**Done:** GUI + main wiring (`LaunchConfig` → `TuiConfig`, fall back to
-`config.arbiter_profile`), confirm copy (same vs independent + session name),
-`CommandAudited` always labels by arbiter **profile** name, round-trip test.
+**Done:** GUI + main wiring (`LaunchConfig.arbiter_profile` as-is → `TuiConfig`;
+no config.toml fallback that would override explicit same-as-session), confirm
+copy (same vs independent + session name), `CommandAudited` labels by arbiter
+**profile** name (`arbiter_model_name` = `LlmProfile.name`), round-trip test.
 
 **Public contract:** `LaunchConfig` gains `arbiter_profile`.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5213,6 +5213,24 @@ selection glyph ▶ rendered as `?`.
 
 **Next steps:** manual SSH smoke from Windows: `/` → home → up.
 
+## Issue #360: fix(gui/agent) — arbiter profile launch handoff
+
+**Milestone:** 1.0.5. **Branch:** `fix/360-arbiter-launch-handoff`.
+
+**Problem:** Launcher arbiter dropdown saved to settings/config but not
+`LaunchConfig` / pending_launch; TUI always resolved session profile.
+
+**Design:** `LaunchConfig.arbiter_profile` → main → `TuiConfig`; confirm overlay
+distinguishes same vs independent profile.
+
+**Done:** GUI + main wiring (`LaunchConfig` → `TuiConfig`, fall back to
+`config.arbiter_profile`), confirm copy (same vs independent + session name),
+`CommandAudited` always labels by arbiter **profile** name, round-trip test.
+
+**Public contract:** `LaunchConfig` gains `arbiter_profile`.
+
+**Next steps:** manual — pick arbiter B ≠ session A, confirm overlay shows B.
+
 ## Release v1.0.4 (2026-08-26)
 
 **Scope:** milestone 1.0.4 — export filename fix (#350), in-TUI path picker on

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -512,8 +512,9 @@ impl Agent {
         )
         .await;
 
-        // Confirm overlay labels the auditor by profile name (not API model id)
-        // so launcher-chosen arbiter B is distinguishable from session A (#360).
+        // `arbiter_model_name` is the arbiter *profile* name (set in runner from
+        // `LlmProfile.name`), despite the historical field name. Confirm overlay
+        // compares it to the session profile name (#360).
         self.emit(AgentEvent::CommandAudited {
             verdict: audit.verdict.label().to_string(),
             reason: audit.reason.clone(),

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -512,15 +512,12 @@ impl Agent {
         )
         .await;
 
-        let model_display = audit
-            .model
-            .clone()
-            .unwrap_or_else(|| self.arbiter_model_name.clone());
-
+        // Confirm overlay labels the auditor by profile name (not API model id)
+        // so launcher-chosen arbiter B is distinguishable from session A (#360).
         self.emit(AgentEvent::CommandAudited {
             verdict: audit.verdict.label().to_string(),
             reason: audit.reason.clone(),
-            arbiter_model: Some(model_display),
+            arbiter_model: Some(self.arbiter_model_name.clone()),
             unavailable: audit.unavailable,
         });
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -353,7 +353,7 @@ async fn run() -> anyhow::Result<()> {
     // ── Determine launch parameters ──────────────────────────────────
     // When no CLI args, check for pending launch from a previous GUI
     // session, or spawn the GUI as a subprocess.
-    let (target_name, session_id, llm_config, api_key, key_env_name, ssh_target, gui_selected_profile, launch_profiles, launch_ssh_targets, launch_save_dir) = if args.is_empty() {
+    let (target_name, session_id, llm_config, api_key, key_env_name, ssh_target, gui_selected_profile, launch_profiles, launch_ssh_targets, launch_save_dir, launch_arbiter_profile) = if args.is_empty() {
         // Check if the GUI subprocess already saved a launch config.
         let launch = filar_gui::load_pending_launch().or_else(|| {
             // Spawn GUI subprocess.
@@ -443,6 +443,9 @@ async fn run() -> anyhow::Result<()> {
                     launch.profiles,
                     launch.ssh_targets,
                     launch.save_dir,
+                    launch
+                        .arbiter_profile
+                        .or_else(|| config.arbiter_profile.clone()),
                 )
             }
             None => {
@@ -477,7 +480,7 @@ async fn run() -> anyhow::Result<()> {
             None
         };
 
-        (target, args.session, llm_config, key, key_env, ssh_target, None, config.llm_profiles.clone(), config.ssh_targets.clone(), config.save_dir.clone())
+        (target, args.session, llm_config, key, key_env, ssh_target, None, config.llm_profiles.clone(), config.ssh_targets.clone(), config.save_dir.clone(), config.arbiter_profile.clone())
     };
 
     // Validate API key unless the profile is explicitly keyless (empty key_env).
@@ -638,7 +641,9 @@ async fn run() -> anyhow::Result<()> {
         save_dir: launch_save_dir,
         command_timeout,
         arbiter_enabled: config.arbiter_enabled,
-        arbiter_profile: config.arbiter_profile.clone(),
+        // GUI: from pending_launch (including explicit None = same as session).
+        // CLI: from config.toml (see tuple construction above).
+        arbiter_profile: launch_arbiter_profile,
     };
 
     info!("launching TUI");

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -443,9 +443,9 @@ async fn run() -> anyhow::Result<()> {
                     launch.profiles,
                     launch.ssh_targets,
                     launch.save_dir,
-                    launch
-                        .arbiter_profile
-                        .or_else(|| config.arbiter_profile.clone()),
+                    // Explicit `None` means "same as session" from the launcher —
+                    // do not fall back to CWD/app-data config.toml (#360).
+                    launch.arbiter_profile,
                 )
             }
             None => {

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -233,6 +233,10 @@ pub struct LaunchConfig {
     /// Full SSH target list (for Ctrl+O cycling in the TUI).
     #[serde(default)]
     pub ssh_targets: Vec<filar_core::SshTarget>,
+    /// Optional arbiter LLM profile name (`None` = same as session profile).
+    /// Carried through pending_launch so the TUI does not depend on CWD config.toml (#360).
+    #[serde(default)]
+    pub arbiter_profile: Option<String>,
 }
 
 fn default_glm_key_env_gui() -> String {
@@ -1072,6 +1076,7 @@ impl LauncherApp {
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
             }).collect(),
             ssh_targets,
+            arbiter_profile: self.arbiter_profile.clone(),
         };
         save_pending_launch(&cfg);
         std::process::exit(0);
@@ -1311,6 +1316,7 @@ mod tests {
             save_dir: None,
             profiles: vec![],
             ssh_targets: vec![],
+            arbiter_profile: None,
         };
         let json = serde_json::to_string_pretty(&cfg).unwrap();
         assert!(!json.contains("supersecret"));
@@ -1396,12 +1402,36 @@ mod tests {
                 auth: filar_core::SshAuth::Password { password: None },
                 host_key_policy: filar_core::HostKeyPolicy::Tofu,
             }],
+            arbiter_profile: None,
         };
         let json = serde_json::to_string_pretty(&cfg).unwrap();
         assert!(!json.contains("\"password\":"), "must not emit password key when None, got: {json}");
         assert!(json.contains("10.0.0.1"), "ssh target must survive");
         // And the secret-detection heuristic in load_pending_launch must not trip.
         assert!(!json.contains("\"api_key\":"), "must not emit api_key");
+    }
+
+    #[test]
+    fn launch_config_round_trips_arbiter_profile() {
+        let cfg = LaunchConfig {
+            target: "local".into(),
+            ssh: None,
+            model: "glm".into(),
+            api_base_url: "https://api.example.com".into(),
+            api_key: String::new(),
+            session_id: None,
+            temperature: String::new(),
+            extra_body: String::new(),
+            selected_profile: Some("session-a".into()),
+            key_env: "GLM_API_KEY".into(),
+            save_dir: None,
+            profiles: vec![],
+            ssh_targets: vec![],
+            arbiter_profile: Some("arbiter-b".into()),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let loaded: LaunchConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.arbiter_profile.as_deref(), Some("arbiter-b"));
     }
 
     #[test]

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -56,6 +56,8 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     let audit_model = confirm.audit_model.clone();
     let audit_unavailable = confirm.audit_unavailable;
 
+    // `audit_model` holds the arbiter *profile* name from `CommandAudited`
+    // (runner passes `LlmProfile.name` as `arbiter_model_name`).
     let session_profile = app.llm_profile.clone();
     let same_as_session = match (audit_model.as_deref(), session_profile.as_deref()) {
         (Some(arb), Some(sess)) => arb == sess,

--- a/crates/tui/src/ui/confirm.rs
+++ b/crates/tui/src/ui/confirm.rs
@@ -56,6 +56,14 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
     let audit_model = confirm.audit_model.clone();
     let audit_unavailable = confirm.audit_unavailable;
 
+    let session_profile = app.llm_profile.clone();
+    let same_as_session = match (audit_model.as_deref(), session_profile.as_deref()) {
+        (Some(arb), Some(sess)) => arb == sess,
+        (Some(_), None) => false,
+        (None, _) => true,
+    };
+    let session_name = session_profile.clone().unwrap_or_default();
+
     // --- Estimate modal dimensions ---
     // Minimum width 32 so buttons fit inside borders (30 chars + 2 borders).
     let modal_width = 70u16.min(area.width.saturating_sub(8)).max(32);
@@ -93,6 +101,8 @@ pub(crate) fn render_confirm_modal(f: &mut Frame, app: &mut App, area: Rect) {
         audit_verdict.as_deref(),
         &audit_reason,
         audit_model.as_deref(),
+        same_as_session,
+        &session_name,
         app.theme.fg_style(),
         app.theme.danger_fg(),
         app.theme.warning_fg(),
@@ -193,6 +203,8 @@ fn build_modal_lines(
     audit_verdict: Option<&str>,
     audit_reason: &str,
     audit_model: Option<&str>,
+    same_as_session: bool,
+    session_name: &str,
     fg: Style,
     danger: Style,
     warning: Style,
@@ -240,6 +252,8 @@ fn build_modal_lines(
             audit_verdict,
             audit_reason,
             audit_model,
+            same_as_session,
+            session_name,
             muted,
             success,
             danger,
@@ -289,6 +303,8 @@ fn append_audit_lines(
     verdict: Option<&str>,
     reason: &str,
     model: Option<&str>,
+    same_as_session: bool,
+    session_name: &str,
     muted: Style,
     success: Style,
     danger: Style,
@@ -312,9 +328,16 @@ fn append_audit_lines(
         return;
     };
     if verdict.eq_ignore_ascii_case("AGREE") {
-        let model_note = model
-            .map(|m| format!(" (checked by {m})"))
-            .unwrap_or_default();
+        let model_note = match model {
+            Some(m) if same_as_session => {
+                format!(" (same as session profile: {m})")
+            }
+            Some(m) if !session_name.is_empty() => {
+                format!(" (arbiter profile: {m}; session: {session_name})")
+            }
+            Some(m) => format!(" (arbiter profile: {m})"),
+            None => String::new(),
+        };
         let _ = push_line(
             lines,
             used,
@@ -339,12 +362,19 @@ fn append_audit_lines(
     }
     if let Some(m) = model {
         if *used < max_rows {
+            let label = if same_as_session {
+                format!("— same as session profile: {m}")
+            } else if !session_name.is_empty() {
+                format!("— arbiter profile: {m} (session: {session_name})")
+            } else {
+                format!("— arbiter profile: {m}")
+            };
             let _ = push_line(
                 lines,
                 used,
                 max_rows,
                 inner_width,
-                format!("— {m}"),
+                label,
                 muted,
             );
         }


### PR DESCRIPTION
Closes #360

## Summary
- `LaunchConfig` / `pending_launch.json` now carries `arbiter_profile` from the GUI launcher into the TUI (was ignored; CWD `config.toml` always fell back to the session profile).
- Confirm overlay labels same-vs-independent arbiter clearly (`same as session profile` vs `arbiter profile: B; session: A`).
- `CommandAudited` labels by arbiter **profile** name so the overlay matches the launcher choice.

## Test plan
- [x] `cargo test -p filar-gui launch_config`
- [x] `cargo test -p filar-agent arbiter`
- [x] `cargo test -p filar-tui confirm`
- [x] `cargo build -p filar-app`
- [ ] Manual: pick arbiter B ≠ session A → confirm overlay shows B