### PR TITLE
chore(ci): build and test workspace on PR and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+# Builds and unit-tests the whole workspace on every pull request and on every
+# push to main. Platforms match the 1.0.x release targets (Windows x86_64 and
+# macOS aarch64) — see release.yml and docs/PLATFORM_NOTES.md.
+#
+# This is the gate AGENTS.md assumes when it requires `cargo build --workspace`
+# and `cargo test --workspace` to stay green: before this workflow, a PR that
+# broke the tui/gui/app crates passed CI untouched (engine-targets.yml only
+# `cargo check`s the engine crates without the `local` feature).
+#
+# Linux is deliberately absent: it is not a release target for 1.0.x, the
+# engine crates are already covered by engine-targets.yml, and a full workspace
+# build would additionally need GUI system dependencies (GTK for rfd, GL for
+# eframe).
+#
+# `#[ignore]`d tests need a running docker-sshd (docker/sshd) and are skipped by
+# `cargo test` on purpose — they stay manual (#367).
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'pics/**'
+      - 'LICENSE'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'pics/**'
+      - 'LICENSE'
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+# A new push supersedes the previous run on the same ref.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & test (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      # Report both platforms even when one fails — a Windows-only break should
+      # not hide the macOS result.
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows-x86_64
+          - os: macos-14
+            name: macos-aarch64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.name }}
+
+      # `--locked` fails if Cargo.lock would have to change, which catches
+      # dependency drift that was never committed.
+      - name: Build workspace
+        run: cargo build --workspace --locked
+
+      - name: Test workspace
+        run: cargo test --workspace --locked

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5232,6 +5232,37 @@ copy (same vs independent + session name), `CommandAudited` labels by arbiter
 
 **Next steps:** manual — pick arbiter B ≠ session A, confirm overlay shows B.
 
+## Issue #367: chore(ci) — build and test workspace on every PR
+
+**Milestone:** 1.0.6. **Branch:** `chore/367-ci-build-test-pr`.
+
+**Problem:** no workflow built or tested the full workspace before merge.
+`engine-targets.yml` only `cargo check`s the engine crates without the `local`
+feature; `eval-smoke.yml` is path-scoped and secret-gated; `release.yml` runs
+only after publish. A PR breaking `tui`/`gui`/`app` — or a failing unit test —
+passed CI green. The AGENTS.md requirement of green
+`cargo build --workspace` / `cargo test --workspace` rested entirely on the
+author running them locally.
+
+**Design:** new `.github/workflows/ci.yml` — `cargo build --workspace --locked`
++ `cargo test --workspace --locked` on a `fail-fast: false` matrix of
+`windows-latest` and `macos-14`, matching the 1.0.x release targets. Triggers on
+`pull_request` and on `push: main`; the latter makes the release preflight
+checkable through the check-runs API instead of on trust. `paths-ignore` for
+`**.md` / `pics/**` / `LICENSE`; `concurrency` with `cancel-in-progress`;
+toolchain and cache actions match `engine-targets.yml`.
+
+**Done:** workflow added. Linux excluded on purpose (not a 1.0.x release
+target; engine crates already covered by `engine-targets.yml`; a full workspace
+build would need GTK/GL system deps).
+
+**Public contract:** none.
+
+**Next steps:** confirm both check-runs appear on the first PR; if CI becomes a
+required check in branch protection, revisit `paths-ignore` (a skipped check on
+a docs-only PR can block merge). Clippy / `cargo fmt --check` deliberately left
+out of scope — separate issue after the existing warnings are triaged.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug


### PR DESCRIPTION
Closes #367

## Summary

Adds `.github/workflows/ci.yml`: `cargo build --workspace --locked` and
`cargo test --workspace --locked` on every PR into `main` and every push to
`main`, across a `windows-latest` + `macos-14` matrix (the 1.0.x release
targets).

Before this, no workflow built or tested the full workspace prior to merge —
`engine-targets.yml` only `cargo check`s the engine crates without the `local`
feature, `eval-smoke.yml` is path-scoped and secret-gated, and `release.yml`
runs only after publish. A PR that broke `tui`/`gui`/`app`, or a failing unit
test, went through green.

## Changes

- `.github/workflows/ci.yml` — new workflow:
  - triggers: `pull_request` → `main`, `push` → `main`, both with `paths-ignore`
    for `**.md`, `pics/**`, `LICENSE`
  - matrix `windows-latest` / `macos-14`, `fail-fast: false` so a break on one
    platform does not hide the other's result
  - `dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache@v2` (keyed per
    platform), matching `engine-targets.yml`
  - `--locked` on both commands, so uncommitted `Cargo.lock` drift fails loudly
  - `concurrency` with `cancel-in-progress`; `permissions: contents: read`;
    `persist-credentials: false`; 30-minute timeout
- `PROGRESS.md` — entry for #367

`CHANGELOG.md` is intentionally untouched: per AGENTS.md, pure CI configuration
with no user-visible effect does not get a changelog line.

## Не проверено в окружении агента

Правка сделана AI-агентом в песочнице **без Rust-тулчейна** (`rustup`
недоступен, в apt только 1.75 при `rust-version = "1.85"`). Поэтому:

- `cargo build --workspace` и `cargo test --workspace` **не запускались** — их
  впервые прогонит сам этот workflow на данном PR;
- YAML провалидирован парсером (структура, триггеры, матрица, шаги), но не
  actionlint;
- DoD-прогон бинарника не требуется: изменение затрагивает только конфигурацию
  CI, что по AGENTS.md освобождено от этого требования.

Проверить при ревью:

1. На этом PR появились **два** check-run: `Build & test (windows-x86_64)` и
   `Build & test (macos-aarch64)`, оба зелёные. Это же и есть проверка того,
   что `main` собирается и тесты проходят.
2. Повторный прогон заметно быстрее холодного (кэш `rust-cache` работает).
3. `#[ignore]`-тесты (docker-sshd) не выполнялись и не уронили прогон.

## Вне скоупа

- `cargo clippy -- -D warnings` и `cargo fmt --check`: на существующей кодовой
  базе могут дать вал замечаний и заблокировать PR-ы. Заводить отдельной
  задачей после разбора текущих предупреждений.
- Linux в матрицу не включён: не релизная цель 1.0.x, движковые крейты уже
  покрыты `engine-targets.yml`, а полная сборка workspace потребовала бы
  системных зависимостей GUI (GTK для `rfd`, GL для `eframe`).
- Если CI станет required-проверкой в branch protection, `paths-ignore` может
  заблокировать мерж документационного PR (пропущенный check). Тогда — либо
  убрать `paths-ignore`, либо добавить job-заглушку. Отмечено в PROGRESS.
