### PR TITLE
fix(tui/tests): clear cwd on remote session in path picker tests

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5232,6 +5232,40 @@ copy (same vs independent + session name), `CommandAudited` labels by arbiter
 
 **Next steps:** manual — pick arbiter B ≠ session A, confirm overlay shows B.
 
+## Issue #370: fix(tui/tests) — path picker tests assumed a Windows-shaped cwd
+
+**Milestone:** 1.0.6. **Branch:** `fix/370-path-picker-tests-cwd`.
+
+**Problem:** `open_path_picker_sets_remote_root` and
+`path_picker_enter_home_from_root_uses_posix` failed on macOS
+(`left: "/Users/runner/work/filar/filar/crates/tui", right: "/"`) while passing
+on Windows. Both set `ssh_info` on a session built by `App::new()` but left
+`cwd` at the process working directory — a remote-session-with-local-cwd state
+that production never produces. `initial_picker_dir` keeps a remote `cwd` only
+when it `starts_with('/')`, so a Windows `D:\…` path fell through to the `"/"`
+fallback and the assertion held by accident; a POSIX path does not.
+
+Surfaced by the new CI (#367) — the first `cargo test` run on macOS in the
+project. `release.yml` only builds `filar-app`, `engine-targets.yml` only
+`cargo check`s the engine crates on Linux, so the failure had been invisible.
+
+**Design:** tests only. Clear `cwd` alongside `ssh_info`, mirroring what
+`runner.rs` does at both sites where a session goes remote (startup with
+`--target`, and `TuiEvent::TransportChanged`), where the comment already
+records that a remote cwd is unknown until OSC 7 / the #313 sync reports one.
+
+**Done:** `cwd = None` added to both tests with a comment pointing at the
+invariant. Audited the other `ssh_info = Some(...)` tests in `app.rs` — tab
+labels, `new_tab` inheritance and `status_target` do not read `cwd` through
+`initial_picker_dir` and are unaffected.
+
+**Public contract:** none. `initial_picker_dir` / `open_path_picker` unchanged.
+
+**Next steps:** the "remote ⇒ cwd is None or POSIX" invariant is maintained by
+hand at two places in `runner.rs`; a third site that forgets it would open the
+picker at a *local* path on a macOS/Linux client (masked on Windows by the
+`starts_with('/')` filter). Worth a separate issue if it ever recurs.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -6996,6 +6996,12 @@ mod tests {
     fn open_path_picker_sets_remote_root() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.sessions[0].ssh_info = Some("root@host:22".into());
+        // A remote session has no known cwd until OSC 7 / the #313 sync
+        // reports one — `runner.rs` clears it whenever a session goes remote.
+        // Without this the test inherits the process cwd, which passes on
+        // Windows only because `D:\...` fails the `starts_with('/')` filter in
+        // `initial_picker_dir` (#370).
+        app.sessions[0].cwd = None;
         app.open_path_picker(crate::path_picker::PathPickerKind::File);
         assert!(app.path_picker_visible);
         assert_eq!(app.path_picker_dir, "/");
@@ -7007,6 +7013,8 @@ mod tests {
     fn path_picker_enter_home_from_root_uses_posix() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.sessions[0].ssh_info = Some("root@host:22".into());
+        // Remote session: cwd unknown until synced (see #370).
+        app.sessions[0].cwd = None;
         app.open_path_picker(crate::path_picker::PathPickerKind::File);
         assert_eq!(app.path_picker_dir, "/");
         assert!(app.path_picker_remote);


### PR DESCRIPTION
Closes #370

## Summary

`open_path_picker_sets_remote_root` and `path_picker_enter_home_from_root_uses_posix`
failed on macOS while passing on Windows:

```
left: "/Users/runner/work/filar/filar/crates/tui"
right: "/"
```

Both build a session via `App::new()` (which fills `cwd` with the process
working directory), then set `ssh_info` without clearing `cwd` — a
remote-session-with-local-cwd state that production never produces.
`initial_picker_dir` keeps a remote `cwd` only when it `starts_with('/')`, so a
Windows `D:\…` path fell through to the `"/"` fallback and the assertion held
**by accident**. A POSIX path passes the filter and is returned as-is.

Surfaced by the new CI in #367 — the first `cargo test` run on macOS in this
project. `release.yml` only builds `filar-app`, `engine-targets.yml` only
`cargo check`s the engine crates on Linux, so the failure had been invisible
since the tests were written. This is a pre-existing bug, not a regression
from #368.

## Changes

- `crates/tui/src/app.rs` — both tests now clear `cwd` alongside setting
  `ssh_info`, mirroring `runner.rs`, which does exactly this at both sites
  where a session goes remote (startup with `--target`, and
  `TuiEvent::TransportChanged`), with the comment "Unknown until OSC 7 /
  command marker / #313 sync". A comment in the test records why.
- `PROGRESS.md` — entry for #370.

Product code is untouched: `initial_picker_dir` and `open_path_picker` behave
correctly; only the tests violated the invariant.

`CHANGELOG.md` is intentionally untouched — tests-only change with no
user-visible effect (AGENTS.md).

## Audit

Checked every other `ssh_info = Some(...)` test in `app.rs`
(`new_tab_does_not_inherit_ssh_state`, the three `tab_label_ssh_*` cases, and
the two `status_target_ssh_*` cases). None of them reach `cwd` through
`initial_picker_dir` — the status-bar tests pass an explicit POSIX `cwd` — so
no further changes were needed.

## Не проверено в окружении агента

Правка сделана AI-агентом в песочнице **без Rust-тулчейна** (`rustup`
недоступен, в apt только 1.75 при `rust-version = "1.85"`), поэтому
`cargo build --workspace` и `cargo test --workspace` локально **не
запускались**. Проверку выполняет CI из #367 на обеих платформах.

Прогон бинарника по DoD не требуется: изменение затрагивает только тесты, что
по AGENTS.md освобождено от этого требования.

**CI на этом PR не запускается.** `ci.yml` пока существует только в ветке
#368 и на `main` отсутствует, а эта ветка отпочкована от `main` — запускать
нечего. Проверка станет возможна только после того, как CI попадёт в `main`.

Ожидаемый результат после этого: `401 passed; 0 failed` на macOS и Windows
(было `400 passed; 2 failed` на macOS).

## Вне скоупа

Инвариант «remote ⇒ `cwd` либо `None`, либо POSIX-путь с удалённой стороны»
поддерживается вручную в двух местах `runner.rs`. Третье место, где его
забудут, откроет пикер для SSH-таргета в **локальном** пути на macOS/Linux
(на Windows это маскирует фильтр `starts_with('/')`). Ужесточение — отдельной
задачей, если ситуация повторится; отмечено в `PROGRESS.md`.

## Порядок мержа

Между этим PR и #368 замкнутый круг: #368 красный из-за этих двух тестов, а
здесь проверить починку нечем, потому что `ci.yml` ещё не в `main`.

Развязка — мержить **этот PR первым**, без прогона CI (ровно так, как в
проекте мержились все PR до появления #368: правка на две строки, только в
тестах, продуктовый код не тронут). Затем обновить ветку #368 из `main` —
CI перезапустится уже на исправленном коде и должен дать зелёное на обеих
платформах, после чего #368 можно мержить.

Обратный порядок потребовал бы смержить заведомо красный PR.
