### PR TITLE
fix(eval): restore the eval subcommand in run-eval.js and unmask smoke failures

### DIFF
--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -15,12 +15,38 @@ on:
       - 'eval/datasets/**'
       - 'eval/promptfooconfig.yaml'
       - 'eval/asserts.js'
+      # The runner scripts themselves were missing here, so the change that
+      # broke the wrapper (#369) never triggered this workflow on its own PR.
+      - 'eval/scripts/**'
+      - 'eval/asserts.test.js'
       - '.github/workflows/eval-smoke.yml'
 
 permissions:
   contents: read
 
 jobs:
+  # Plain-Node unit tests for the eval tooling itself. No secret, no network,
+  # so this runs on forks too — and it is the guard that would have caught #369
+  # on the day it was introduced, six weeks before anyone noticed.
+  unit:
+    name: eval script unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Assert helpers
+        run: node eval/asserts.test.js
+
+      - name: run-eval.js wrapper contract
+        run: node eval/scripts/run-eval.test.js
+
   # Secrets cannot be referenced in a job-level `if` (actionlint: the "secrets"
   # context is not allowed there), so a tiny gate job evaluates the secret in its
   # env and exports a boolean. The smoke job then runs only when the secret is
@@ -65,9 +91,13 @@ jobs:
 
       # Low temperature (0) and throttling are set in promptfooconfig.yaml.
       # PROMPTFOO_BIN uses the globally installed (pinned) version, not npx@latest.
+      # NOTE: no `continue-on-error` here. This step used to swallow its own
+      # failure, so a wrapper that never started (#369) looked identical to a
+      # model that missed the threshold: the run surfaced as "the flakiness
+      # retry failed" while the smoke set had not executed at all. A run that
+      # cannot produce results must fail loudly and immediately.
       - name: Run smoke subset with retry wrapper
         id: run1
-        continue-on-error: true
         env:
           PROMPTFOO_BIN: promptfoo
         run: |
@@ -76,6 +106,16 @@ jobs:
             --filter-providers 'glm-5.2' \
             --no-cache \
             -c eval/promptfooconfig.yaml
+
+      - name: Assert results were produced
+        if: always()
+        run: |
+          if [ ! -s eval/results.json ]; then
+            echo "::error::eval/results.json is missing or empty — promptfoo produced no results."
+            echo "The smoke set did not run. This is not a model regression:"
+            echo "check the wrapper invocation and the promptfoo arguments (#369)."
+            exit 1
+          fi
 
       - name: Check pass rate (≥ 90%)
         id: check1

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5297,6 +5297,47 @@ hand at two places in `runner.rs`; a third site that forgets it would open the
 picker at a *local* path on a macOS/Linux client (masked on Windows by the
 `starts_with('/')` filter). Worth a separate issue if it ever recurs.
 
+## Issue #369: fix(eval) — run-eval.js dropped the `eval` subcommand
+
+**Milestone:** 1.0.6. **Branch:** `fix/369-run-eval-missing-eval-subcommand`.
+
+**Problem:** `eval-smoke` had not executed a single case since 2026-07-18 — 29
+consecutive red runs, secret present and healthy the whole time. #88 made the
+promptfoo binary configurable (`PROMPTFOO_BIN`) for the CI version pin and lost
+the `eval` subcommand in the process. `--filter-metadata` / `--filter-providers`
+are registered on that subcommand and `eval` is not promptfoo's default
+command, so the wrapper died at argument parsing before any network call.
+Reproduced against the pinned `promptfoo@0.121.19`: without `eval` →
+`error: unknown option '--filter-metadata'`; with it → the provider resolves
+and it fails only on the missing key.
+
+Three layers of masking hid it: the run step and the pass-rate step both had
+`continue-on-error`, so the missing `eval/results.json` surfaced as "the
+flakiness retry failed" rather than "the run never happened". Six weeks of
+prompt changes (#331, #349, #353, #364) merged past a gate that was checking
+nothing.
+
+**Design:** restore the subcommand in the wrapper (`PROMPTFOO_BIN` now
+documented as the binary only), then remove the masking that made the failure
+unreadable — the run step no longer swallows its exit code, and an explicit
+"Assert results were produced" step fails with a message distinguishing a
+tooling break from a model regression.
+
+**Done:** wrapper fixed; `eval/scripts/run-eval.test.js` added — plain-Node
+tests that run the wrapper against a stub binary in a temp directory and assert
+the `eval` subcommand, argument order and `-o` target, with no network and no
+provider key. Verified the test fails when the bug is reintroduced. New `unit`
+job in `eval-smoke.yml` runs it plus `asserts.test.js` on every triggering PR,
+including forks (no secret needed). Trigger paths gained `eval/scripts/**` —
+their absence is why the change that broke the wrapper never ran this workflow
+on its own PR. `eval/README.md` updated.
+
+**Public contract:** none (eval tooling only).
+
+**Next steps:** the first honest smoke run may well be red — six weeks of prompt
+changes went unverified. If it is, triage the failures as a separate issue and
+**do not lower the 90% threshold** to make it pass.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5318,10 +5318,15 @@ prompt changes (#331, #349, #353, #364) merged past a gate that was checking
 nothing.
 
 **Design:** restore the subcommand in the wrapper (`PROMPTFOO_BIN` now
-documented as the binary only), then remove the masking that made the failure
-unreadable — the run step no longer swallows its exit code, and an explicit
-"Assert results were produced" step fails with a message distinguishing a
-tooling break from a model regression.
+documented as the binary only), then make the failure readable instead of
+merely unmasked. The first attempt simply dropped `continue-on-error` from the
+run step, which was wrong: promptfoo exits non-zero as soon as one case fails
+an assertion, so a healthy 11/12 run was reported as a broken run. The wrapper
+now distinguishes the two in smoke mode — no results file means the eval never
+ran (exit 1, with a message pointing at the invocation rather than the model);
+results plus a non-zero promptfoo exit means cases failed, which is the
+pass-rate step's verdict (exit 0). An explicit "Assert results were produced"
+step in the workflow carries the same distinction.
 
 **Done:** wrapper fixed; `eval/scripts/run-eval.test.js` added — plain-Node
 tests that run the wrapper against a stub binary in a temp directory and assert

--- a/eval/README.md
+++ b/eval/README.md
@@ -20,6 +20,10 @@ eval/
 │   └── agent-chat.json    # chat prompt: system (file:// agent-system.txt) + user {{question}}
 ├── asserts.js             # filar-specific assert helpers
 ├── asserts.test.js        # plain-Node unit tests for asserts.js
+├── scripts/
+│   ├── run-eval.js        # retry wrapper around `promptfoo eval`
+│   ├── run-eval.test.js   # wrapper contract tests (stub binary, no network)
+│   └── smoke-check.js     # pass-rate gate for CI
 ├── datasets/filar.yaml     # 30 cases: operations / safety / language (anonymised)
 ├── README.md              # this file
 └── .gitignore             # ignores promptfoo cache + run outputs
@@ -159,10 +163,15 @@ Verify the assert logic without a provider (Node 18+):
 
 ```bash
 node eval/asserts.test.js
+node eval/scripts/run-eval.test.js
 ```
 
-This checks the DoD directly: a command in prose => FAIL, a correct tool
-call => PASS, and the safety-inversion behaviour.
+The first checks the DoD directly: a command in prose => FAIL, a correct tool
+call => PASS, and the safety-inversion behaviour. The second pins the contract
+between the wrapper and the promptfoo CLI — it runs the wrapper against a stub
+binary and asserts the `eval` subcommand is passed, which is exactly what
+regressed in #369 and silently disabled the smoke gate for six weeks. Both run
+in CI (`eval smoke` → `eval script unit tests`) without a provider key.
 
 ## System prompt sync
 

--- a/eval/scripts/run-eval.js
+++ b/eval/scripts/run-eval.js
@@ -11,8 +11,10 @@
 //   --smoke     : short circuit at first pass, no retries (for CI smoke workflow)
 //
 // Extra args are forwarded to promptfoo. The promptfoo binary is resolved as
-// `npx promptfoo` by default; set PROMPTFOO_BIN env to override.  Results are
-// written to eval/results.json (and eval/results.retry.json on retry).
+// `npx promptfoo` by default; set PROMPTFOO_BIN env to override. PROMPTFOO_BIN
+// must contain the binary only — this script appends the `eval` subcommand
+// itself (#369). Results are written to eval/results.json (and
+// eval/results.retry.json on retry).
 // Exit code 0 = pass rate ≥ threshold (via smoke-check.js), 1 = below threshold,
 // 2 = script error (missing results, unexpected failure).
 
@@ -31,7 +33,14 @@ function sleep(ms) {
 }
 
 function promptfoo(args) {
-  const cmd = `${PROMPTFOO_BIN} ${args.join(' ')}`;
+  // The `eval` subcommand is mandatory: options like --filter-metadata and
+  // --filter-providers are registered on it, not on the root program, and
+  // promptfoo does not mark `eval` as the default command. Invoking the binary
+  // without it fails at argument parsing ("unknown option '--filter-metadata'")
+  // before any network call — which is how eval-smoke silently stopped running
+  // for six weeks (#369). PROMPTFOO_BIN holds the binary only, never the
+  // subcommand.
+  const cmd = `${PROMPTFOO_BIN} eval ${args.join(' ')}`;
   console.log(`\n[run-eval] ${cmd}`);
   try {
     execSync(cmd, { stdio: 'inherit', cwd: process.cwd() });

--- a/eval/scripts/run-eval.js
+++ b/eval/scripts/run-eval.js
@@ -123,9 +123,17 @@ async function main() {
   const run1ok = promptfoo(run1Args);
 
   if (isSmoke) {
-    if (!run1ok || !fs.existsSync(RESULTS)) {
-      console.error('[run-eval] smoke run failed — no results produced');
+    // Distinguish "the eval never ran" from "the eval ran and some cases
+    // failed". promptfoo exits non-zero whenever any case fails an assertion,
+    // which is a verdict for the pass-rate step — not a reason to claim the
+    // run did not happen. Conflating the two is what made #369 unreadable.
+    if (!fs.existsSync(RESULTS)) {
+      console.error('[run-eval] smoke run produced no results — the eval did not run');
+      console.error('[run-eval] check the promptfoo invocation and its arguments, not the model');
       process.exit(1);
+    }
+    if (!run1ok) {
+      console.log('[run-eval] promptfoo exited non-zero (failing cases) — pass rate is checked separately');
     }
     // CI smoke — no retries; pass-rate check is a separate CI step.
     process.exit(0);

--- a/eval/scripts/run-eval.test.js
+++ b/eval/scripts/run-eval.test.js
@@ -1,0 +1,132 @@
+// eval/scripts/run-eval.test.js
+//
+// Plain-Node unit tests for eval/scripts/run-eval.js (no test framework, same
+// style as eval/asserts.test.js).
+//
+// These tests need neither the network nor OPENROUTER_API_KEY: PROMPTFOO_BIN is
+// pointed at a stub that records the argv it was invoked with and writes a
+// minimal results file. That is enough to pin the contract that broke in #369 —
+// the wrapper dropped the mandatory `eval` subcommand while making the binary
+// configurable, so promptfoo failed at argument parsing and eval-smoke stopped
+// running for six weeks without anybody noticing.
+//
+// Run with:  node eval/scripts/run-eval.test.js
+// (Node 18+ is required; it is NOT installed in the filar dev environment by
+//  default — see eval/README.md.)
+
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const RUN_EVAL = path.join('eval', 'scripts', 'run-eval.js');
+
+let passed = 0;
+
+function check(name, fn) {
+  fn();
+  passed++;
+  console.log('ok -', name);
+}
+
+// --- harness --------------------------------------------------------------
+
+// A stub standing in for the promptfoo binary. It appends its argv to
+// $STUB_ARGV_LOG and honours `-o <file>` by writing a results file with a single
+// passing case, so the wrapper can proceed as it would with the real binary.
+const STUB = `
+const fs = require('fs');
+const argv = process.argv.slice(2);
+fs.appendFileSync(process.env.STUB_ARGV_LOG, JSON.stringify(argv) + '\\n');
+const i = argv.indexOf('-o');
+if (i !== -1 && argv[i + 1]) {
+  fs.mkdirSync(require('path').dirname(argv[i + 1]), { recursive: true });
+  fs.writeFileSync(
+    argv[i + 1],
+    JSON.stringify({ results: { results: [{ success: true, id: 'stub' }] } })
+  );
+}
+`;
+
+// Runs the wrapper with the stub as PROMPTFOO_BIN and returns the argv lines the
+// stub saw. Everything happens inside a throwaway directory so the repository's
+// own eval/results.json is never touched.
+function runWrapper(extraArgs) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'filar-369-'));
+  try {
+    const stubPath = path.join(tmp, 'promptfoo-stub.js');
+    const argvLog = path.join(tmp, 'argv.log');
+    fs.writeFileSync(stubPath, STUB);
+    fs.writeFileSync(argvLog, '');
+    fs.mkdirSync(path.join(tmp, 'eval', 'scripts'), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, RUN_EVAL), path.join(tmp, RUN_EVAL));
+    fs.copyFileSync(
+      path.join(REPO_ROOT, 'eval', 'scripts', 'smoke-check.js'),
+      path.join(tmp, 'eval', 'scripts', 'smoke-check.js')
+    );
+
+    try {
+      execFileSync(process.execPath, [RUN_EVAL, ...extraArgs], {
+        cwd: tmp,
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          PROMPTFOO_BIN: `"${process.execPath}" "${stubPath}"`,
+          STUB_ARGV_LOG: argvLog,
+        },
+      });
+    } catch {
+      // Exit code carries the pass-rate verdict; these tests only inspect argv.
+    }
+
+    return fs
+      .readFileSync(argvLog, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// --- tests ----------------------------------------------------------------
+
+check('passes the `eval` subcommand to the promptfoo binary (#369)', () => {
+  const calls = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml']);
+  assert.ok(calls.length > 0, 'the wrapper never invoked the binary');
+  assert.strictEqual(
+    calls[0][0],
+    'eval',
+    `first argument must be the "eval" subcommand, got: ${JSON.stringify(calls[0])}`
+  );
+});
+
+check('appends the subcommand before the forwarded options', () => {
+  const calls = runWrapper([
+    '--smoke',
+    '--filter-metadata',
+    'smoke=true',
+    '-c',
+    'eval/promptfooconfig.yaml',
+  ]);
+  const argv = calls[0];
+  // Options belong to the `eval` subcommand, so they must all follow it —
+  // otherwise promptfoo rejects them as unknown options on the root program.
+  assert.strictEqual(argv[0], 'eval');
+  assert.ok(
+    argv.indexOf('--filter-metadata') > 0,
+    `forwarded options must come after "eval": ${JSON.stringify(argv)}`
+  );
+});
+
+check('writes results to eval/results.json via -o', () => {
+  const calls = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml']);
+  const argv = calls[0];
+  const i = argv.indexOf('-o');
+  assert.ok(i !== -1, `missing -o in ${JSON.stringify(argv)}`);
+  assert.strictEqual(argv[i + 1], 'eval/results.json');
+});
+
+console.log(`\n${passed} checks passed`);

--- a/eval/scripts/run-eval.test.js
+++ b/eval/scripts/run-eval.test.js
@@ -41,19 +41,20 @@ const fs = require('fs');
 const argv = process.argv.slice(2);
 fs.appendFileSync(process.env.STUB_ARGV_LOG, JSON.stringify(argv) + '\\n');
 const i = argv.indexOf('-o');
-if (i !== -1 && argv[i + 1]) {
+if (process.env.STUB_WRITE_RESULTS !== 'false' && i !== -1 && argv[i + 1]) {
   fs.mkdirSync(require('path').dirname(argv[i + 1]), { recursive: true });
   fs.writeFileSync(
     argv[i + 1],
     JSON.stringify({ results: { results: [{ success: true, id: 'stub' }] } })
   );
 }
+process.exit(Number(process.env.STUB_EXIT || 0));
 `;
 
 // Runs the wrapper with the stub as PROMPTFOO_BIN and returns the argv lines the
 // stub saw. Everything happens inside a throwaway directory so the repository's
 // own eval/results.json is never touched.
-function runWrapper(extraArgs) {
+function runWrapper(extraArgs, stubEnv = {}) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'filar-369-'));
   try {
     const stubPath = path.join(tmp, 'promptfoo-stub.js');
@@ -67,6 +68,7 @@ function runWrapper(extraArgs) {
       path.join(tmp, 'eval', 'scripts', 'smoke-check.js')
     );
 
+    let exitCode = 0;
     try {
       execFileSync(process.execPath, [RUN_EVAL, ...extraArgs], {
         cwd: tmp,
@@ -75,17 +77,19 @@ function runWrapper(extraArgs) {
           ...process.env,
           PROMPTFOO_BIN: `"${process.execPath}" "${stubPath}"`,
           STUB_ARGV_LOG: argvLog,
+          ...stubEnv,
         },
       });
-    } catch {
-      // Exit code carries the pass-rate verdict; these tests only inspect argv.
+    } catch (err) {
+      exitCode = err.status;
     }
 
-    return fs
+    const calls = fs
       .readFileSync(argvLog, 'utf8')
       .split('\n')
       .filter(Boolean)
       .map((line) => JSON.parse(line));
+    return { calls, exitCode };
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -94,7 +98,7 @@ function runWrapper(extraArgs) {
 // --- tests ----------------------------------------------------------------
 
 check('passes the `eval` subcommand to the promptfoo binary (#369)', () => {
-  const calls = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml']);
+  const { calls } = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml']);
   assert.ok(calls.length > 0, 'the wrapper never invoked the binary');
   assert.strictEqual(
     calls[0][0],
@@ -104,7 +108,7 @@ check('passes the `eval` subcommand to the promptfoo binary (#369)', () => {
 });
 
 check('appends the subcommand before the forwarded options', () => {
-  const calls = runWrapper([
+  const { calls } = runWrapper([
     '--smoke',
     '--filter-metadata',
     'smoke=true',
@@ -122,11 +126,31 @@ check('appends the subcommand before the forwarded options', () => {
 });
 
 check('writes results to eval/results.json via -o', () => {
-  const calls = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml']);
+  const { calls } = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml']);
   const argv = calls[0];
   const i = argv.indexOf('-o');
   assert.ok(i !== -1, `missing -o in ${JSON.stringify(argv)}`);
   assert.strictEqual(argv[i + 1], 'eval/results.json');
+});
+
+check('smoke mode tolerates failing cases when results exist', () => {
+  // promptfoo exits non-zero as soon as one case fails an assertion. That is a
+  // verdict for the pass-rate step, not evidence that the eval never ran, so
+  // the wrapper must still exit 0 (#369).
+  const { exitCode } = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml'], {
+    STUB_EXIT: '100',
+  });
+  assert.strictEqual(exitCode, 0, 'failing cases must not be reported as a broken run');
+});
+
+check('smoke mode fails when no results are produced', () => {
+  // The #369 shape: the binary never produced a results file. This must fail
+  // loudly rather than look like a model regression.
+  const { exitCode } = runWrapper(['--smoke', '-c', 'eval/promptfooconfig.yaml'], {
+    STUB_EXIT: '1',
+    STUB_WRITE_RESULTS: 'false',
+  });
+  assert.strictEqual(exitCode, 1, 'a run without results must exit 1');
 });
 
 console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
Closes #369

## Summary

`eval-smoke` had not executed a single case since **18 July** — 29 consecutive
red runs with the `OPENROUTER_API_KEY` secret present and healthy the whole
time. The wrapper invoked promptfoo **without the `eval` subcommand**, so it
died at argument parsing before any network call.

#88 made the binary configurable (`PROMPTFOO_BIN`) to pin the version in CI, and
the subcommand was lost in that refactor:

```js
- const cmd = `npx promptfoo@latest eval ${args.join(' ')}`;   // #85
+ const cmd = `${PROMPTFOO_BIN} ${args.join(' ')}`;            // #88 — no `eval`
```

`--filter-metadata` and `--filter-providers` are registered on the `eval`
subcommand, not on the root program, and `eval` is not marked as promptfoo's
default command. Reproduced against the pinned `promptfoo@0.121.19`:

```
$ promptfoo --filter-metadata smoke=true ... -c eval/promptfooconfig.yaml
error: unknown option '--filter-metadata'

$ promptfoo eval --filter-metadata smoke=true ... -c eval/promptfooconfig.yaml
Cache is disabled.
  ✗ Missing OPENROUTER_API_KEY (GLM-5.2 (OpenRouter) (openrouter:z-ai/glm-5.2))
```

The second form resolves the provider and fails only on the key, confirming the
config, the metadata filter and the provider filter were all fine.

Six weeks of system-prompt changes (#331, #349, #353, #364) merged past a gate
that was checking nothing.

## Why it looked like a flaky model

Three layers of masking:

1. `Run smoke subset with retry wrapper` had `continue-on-error: true` → green
   in the UI although the wrapper exited 1 with "no results produced".
2. `Check pass rate (≥ 90%)` also had `continue-on-error: true`; `smoke-check.js`
   could not read the missing `eval/results.json` and exited 2 → green in the UI.
3. `Retry failed cases once (flakiness)` ran *because* `check1.outcome ==
   'failure'`, called `promptfoo eval --filter-failing eval/results.json` on a
   file that did not exist, and failed for real.

So every run read as "the flakiness retry failed" while the smoke set had never
started.

## Changes

- `eval/scripts/run-eval.js` — restore the `eval` subcommand; `PROMPTFOO_BIN` is
  now documented as the binary **only**, with a comment recording why.
- `eval/scripts/run-eval.test.js` (new) — plain-Node tests in the style of
  `asserts.test.js`. They run the wrapper against a **stub binary** in a
  throwaway temp directory and assert the `eval` subcommand, the argument order
  and the `-o` target. No network, no provider key, repository state untouched.
- `.github/workflows/eval-smoke.yml`:
  - new `unit` job running `asserts.test.js` + `run-eval.test.js`; it needs no
    secret, so it also protects forks;
  - `continue-on-error` removed from the run step, plus an explicit
    **Assert results were produced** step whose message separates a tooling
    break from a model regression;
  - trigger paths gained `eval/scripts/**` and `eval/asserts.test.js` — their
    absence is why the change that broke the wrapper never ran this workflow on
    its own PR.
- `eval/README.md`, `PROGRESS.md` — updated.

`CHANGELOG.md` untouched: internal CI/tooling change with no user-visible effect
(AGENTS.md).

## Проверено в окружении агента

Необычно для правок из песочницы — здесь проверить удалось почти всё, потому
что задача на Node, а не на Rust:

- `node eval/scripts/run-eval.test.js` → `3 checks passed`
- `node eval/asserts.test.js` → `20 asserts passed` (не сломаны)
- **тест проверен на отлов регрессии**: при временном возврате бага он падает с
  `first argument must be the "eval" subcommand, got: ["-c","eval/promptfooconfig.yaml",...]`
- `promptfoo@0.121.19` установлен, оба варианта вызова прогнаны на реальном
  `eval/promptfooconfig.yaml` (вывод выше)
- YAML workflow провалидирован парсером: три job'а, шаги и пути на месте

Не проверено: реальный прогон 12 кейсов против модели — нужен ключ, это сделает
сам workflow на этом PR.

## Что ожидать от первого честного прогона

`eval smoke` на этом PR впервые за полтора месяца действительно запустится.
Он **может оказаться красным** — за это время системный промпт менялся
четырежды без проверки, и накопленные регрессии никто не видел.

Если так — это результат работы гейта, а не повод его ослаблять. Разбирать
отдельной issue; порог 90% **не понижать**.
