### PR TITLE
fix(tui): sanitize control bytes in command output; settle repaint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- Redraw artifacts (leftover glyphs, one line painted over another) that
+  persisted until the terminal window was resized. Raw command output reached
+  the terminal with its control bytes intact — a `\r` from a progress bar moved
+  the physical cursor out from under ratatui's buffer, so the diff skipped
+  cells that were actually stale. Command output is now sanitised (CR/backspace
+  resolved as cursor movement, ANSI escapes and remaining control characters
+  removed) before it becomes chat lines, and a single full repaint settles the
+  screen shortly after output stops
+  ([#366](https://github.com/devlawey/filar/issues/366)).
+
 - `sudo -S` combined with a `<<EOF` heredoc in one command silently fed the
   heredoc body to sudo as password attempts (the heredoc replaces the secret
   pipe's stdin), making Ctrl+P secrets appear "not substituted". The agent now

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5385,6 +5385,57 @@ on its own PR. `eval/README.md` updated.
 changes went unverified. If it is, triage the failures as a separate issue and
 **do not lower the 90% threshold** to make it pass.
 
+## Issue #366: fix(tui) — control/ANSI bytes desynced the physical screen
+
+**Milestone:** 1.0.6. **Branch:** `fix/366-sanitize-command-output`.
+
+**Problem:** leftover glyphs and lines painted over one another, healed only by
+resizing the window. Four earlier attempts (#231, #245, #328, #333) fixed the
+ratatui *buffer* — `reset_area_cells`, `pad_line_to_width`, `Clear` — and the
+buffer was already correct. The desync was between the buffer and the
+*physical* screen: raw command output reached the terminal through `Span::raw`
+with its control bytes intact, a `\r` moved the real cursor to column 0, and
+the diff then legitimately skipped cells it believed unchanged. No per-frame
+buffer reset can fix that by construction.
+
+**Design:** sanitise at the source. `text.rs::sanitize_output` runs per line:
+strip ANSI escapes first (CSI to its final byte, OSC to BEL/ST, two-character
+escapes) so parameter bytes are never mistaken for text; then resolve `\r` and
+`\x08` as cursor movement; then drop remaining C0/C1/DEL, keeping `\t` for
+`expand_tabs`. Applied in `layout_cache.rs` where `ChatBlock::Command` output
+becomes lines, with a fast path for output containing no control bytes.
+
+`\r` is **emulated, not dropped**: progress bars (`hf download`, `pip`, `curl`)
+send frame after frame separated by `\r` with no `\n`, so the whole animation
+arrives as one line. Emulation reproduces what a terminal would show — the last
+frame, plus the tail of a longer previous frame when the last one is shorter —
+instead of concatenating every frame or truncating to the last segment.
+
+`strip_emoji` also fixed: its `cp <= 0x024F` whitelist admitted the entire C0
+block, so `ESC`/`CR`/`BS` passed through in every block type. `\n` and `\t` stay
+whitelisted — wrapping depends on them.
+
+Safety net in `runner.rs`: a debounced settle repaint — one `terminal.clear()`
++ draw, 250 ms after the last frame — armed only while output is streaming
+(Thinking mode, or the starved-tick fallback path). Arming it after every frame
+would flash the whole screen after each typing pause; an unconditional 1 Hz
+timer, as first proposed in the issue, would also repaint forever and keep the
+process awake, breaking the deliberate zero-CPU-at-idle property of the render
+tick.
+
+**Done:** sanitiser + 8 unit tests (progress-bar frames, overwrite tail, CSI,
+OSC with both terminators, truncated CSI, backspace, stray C0/C1/DEL, line
+structure), `strip_emoji` control-character test, settle repaint.
+
+**Public contract:** none. `CommandExecutor` / `LlmClient` untouched;
+confirm gate and transport not involved.
+
+**Next steps:** manual repro on both platforms is required and could not be run
+by the agent (no Rust toolchain) — see the PR. A manual force-repaint binding
+was left out: `Ctrl+R` is reverse-i-search in a shell and would collide in
+interactive mode, so the key choice needs a decision of its own. Translating
+SGR into ratatui styles instead of discarding colour is a possible follow-up.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5398,12 +5398,16 @@ with its control bytes intact, a `\r` moved the real cursor to column 0, and
 the diff then legitimately skipped cells it believed unchanged. No per-frame
 buffer reset can fix that by construction.
 
-**Design:** sanitise at the source. `text.rs::sanitize_output` runs per line:
-strip ANSI escapes first (CSI to its final byte, OSC to BEL/ST, two-character
-escapes) so parameter bytes are never mistaken for text; then resolve `\r` and
-`\x08` as cursor movement; then drop remaining C0/C1/DEL, keeping `\t` for
-`expand_tabs`. Applied in `layout_cache.rs` where `ChatBlock::Command` output
-becomes lines, with a fast path for output containing no control bytes.
+**Design:** sanitise at the source. `text.rs::sanitize_line` replays one line
+as a terminal would, in a **single pass** over escapes and cursor motion: erase
+sequences act relative to the cursor, so stripping escapes in a separate pass
+would lose the position they apply to. Cells are addressed in display columns
+(`LineCells`), a double-width character occupies two, and `None` marks its right
+half so clobbering the left one leaves a blank column. Recognised: 7-bit and
+8-bit CSI/OSC, erase (`K` with 0/1/2), cursor motion (`G`, `C`, `D`), `\r`,
+`\x08`, `\t`; presentation-only sequences (SGR) and stray C0/C1/DEL are
+dropped. Applied in `layout_cache.rs` where `ChatBlock::Command` output becomes
+lines, with a fast path for output containing no control bytes.
 
 `\r` is **emulated, not dropped**: progress bars (`hf download`, `pip`, `curl`)
 send frame after frame separated by `\r` with no `\n`, so the whole animation
@@ -5423,9 +5427,19 @@ timer, as first proposed in the issue, would also repaint forever and keep the
 process awake, breaking the deliberate zero-CPU-at-idle property of the render
 tick.
 
-**Done:** sanitiser + 8 unit tests (progress-bar frames, overwrite tail, CSI,
-OSC with both terminators, truncated CSI, backspace, stray C0/C1/DEL, line
-structure), `strip_emoji` control-character test, settle repaint.
+**Done:** sanitiser + 11 unit tests (progress-bar frames, overwrite tail,
+erase-to-end/start/all, 8-bit C1 introducers, display-column arithmetic with
+tabs and wide characters, cursor motion, backspace, SGR, OSC with both
+terminators, truncated CSI, stray C0/DEL, line structure), `strip_emoji`
+control-character test, settle repaint.
+
+Review (#373) caught three real gaps in the first, two-pass version, all
+confirmed against a prototype before fixing: 8-bit C1 introducers left their
+parameter bytes as visible text; `CSI K` was discarded, so `\r` + erase — the
+standard way a progress bar clears its previous frame — still left the stale
+tail that #366 is about; and column arithmetic counted `char`s, so CR/BS after
+a tab or a wide character landed on the wrong position. The single-pass,
+column-addressed rewrite is the answer to all three.
 
 **Public contract:** none. `CommandExecutor` / `LlmClient` untouched;
 confirm gate and transport not involved.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5433,13 +5433,24 @@ tabs and wide characters, cursor motion, backspace, SGR, OSC with both
 terminators, truncated CSI, stray C0/DEL, line structure), `strip_emoji`
 control-character test, settle repaint.
 
-Review (#373) caught three real gaps in the first, two-pass version, all
-confirmed against a prototype before fixing: 8-bit C1 introducers left their
+Review (#373) caught real gaps in two rounds, each confirmed against a
+prototype before fixing. First round, on the two-pass version: 8-bit C1 introducers left their
 parameter bytes as visible text; `CSI K` was discarded, so `\r` + erase — the
 standard way a progress bar clears its previous frame — still left the stale
 tail that #366 is about; and column arithmetic counted `char`s, so CR/BS after
 a tab or a wide character landed on the wrong position. The single-pass,
 column-addressed rewrite is the answer to all three.
+
+Second round, on the rewrite: writing into the right half of a wide character
+left its left half on screen; a combining mark after a wide character was
+dropped (its base cell is two columns back); 8-bit ST (`U+009C`) was not
+accepted as an OSC terminator; and — the serious one — `CSI G`/`C` took an
+unbounded column from untrusted output, so `ESC[1000000000G` would have made
+the next printable character pad a billion cells and hang the TUI. Cursor jumps
+are now clamped to `MAX_CURSOR_COL`; ordinary left-to-right writing is
+deliberately *not* clamped, so long lines are never truncated. The settle
+repaint was also armed by the fallback draw path, which fires for plain
+keystroke redraws too — now gated on Thinking mode in both places.
 
 **Public contract:** none. `CommandExecutor` / `LlmClient` untouched;
 confirm gate and transport not involved.

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -570,6 +570,18 @@ async fn run_app(
     // PTY); we draw at the end of the iteration body if a frame is pending
     // and a frame deadline has passed, avoiding competition with read_output.
     let mut last_draw = Instant::now();
+    // Settle repaint (#366): one full repaint shortly after output stops.
+    //
+    // Sanitising command output removes the known source of buffer/screen
+    // desync, but ratatui's diff cannot detect a screen that drifted for any
+    // other reason — that is precisely why nudging the window used to "fix"
+    // the display. This is the safety net: after the last draw settles, issue
+    // a single `terminal.clear()` + draw. It costs one extra frame after a
+    // burst of output and nothing at all while idle, unlike an unconditional
+    // timer, which would repaint forever and keep the process awake (the
+    // render tick is deliberately gated so CPU idle stays at zero).
+    const SETTLE_DELAY: Duration = Duration::from_millis(250);
+    let mut settle_pending = false;
 
     // Periodic auto-save (#272): one stable id for the whole run so each
     // 30s save overwrites the same file, plus the revision/session of the
@@ -1479,11 +1491,34 @@ async fn run_app(
                 terminal.draw(|f| ui::render(f, &mut app)).ok();
                 needs_redraw = false;
                 last_draw = Instant::now();
+                // Arm the settle repaint only while output is actually
+                // streaming (agent running commands). Arming it after every
+                // frame would repaint the whole screen after each typing
+                // pause — a visible flash over SSH, for no benefit: plain
+                // keystroke rendering does not desync the screen.
+                if app.mode == AppMode::Thinking {
+                    settle_pending = true;
+                }
                 // Clear an expired toast so the next tick's guard goes false and
                 // ticking stops after this erasing frame.
                 if app.toast_text().is_none() {
                     app.toast = None;
                 }
+            }
+
+            // Settle repaint (#366). Fires once, SETTLE_DELAY after the last
+            // frame, and only when no newer frame arrived in between — while
+            // output streams, draws keep resetting `last_draw` and this branch
+            // never becomes ready. `settle_pending` is cleared here, so a quiet
+            // session performs exactly one repaint and then stops: the guard is
+            // false afterwards and the process goes back to sleep.
+            _ = tokio::time::sleep(SETTLE_DELAY.saturating_sub(last_draw.elapsed())),
+                if settle_pending && !app.should_quit => {
+                terminal.clear().ok();
+                terminal.draw(|f| ui::render(f, &mut app)).ok();
+                settle_pending = false;
+                last_draw = Instant::now();
+                render_interval.reset();
             }
         }
 
@@ -1512,6 +1547,9 @@ async fn run_app(
             terminal.draw(|f| ui::render(f, &mut app)).ok();
             needs_redraw = false;
             last_draw = Instant::now();
+            // This path exists because continuous output starves the render
+            // tick, so reaching it always means a burst of output (#366).
+            settle_pending = true;
             // Prevent the normal render tick from firing immediately on
             // the next iteration — the frame we just drew is current.
             render_interval.reset();

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1547,9 +1547,14 @@ async fn run_app(
             terminal.draw(|f| ui::render(f, &mut app)).ok();
             needs_redraw = false;
             last_draw = Instant::now();
-            // This path exists because continuous output starves the render
-            // tick, so reaching it always means a burst of output (#366).
-            settle_pending = true;
+            // Same condition as the render tick: only a run producing output
+            // needs the settle repaint. This fallback also fires for ordinary
+            // keystroke redraws when the 16 ms deadline has passed, and arming
+            // it there would clear and repaint the screen after every typing
+            // pause (#373 review).
+            if app.mode == AppMode::Thinking {
+                settle_pending = true;
+            }
             // Prevent the normal render tick from firing immediately on
             // the next iteration — the frame we just drew is current.
             render_interval.reset();

--- a/crates/tui/src/ui/layout_cache.rs
+++ b/crates/tui/src/ui/layout_cache.rs
@@ -16,7 +16,7 @@ use ratatui::text::{Line, Span};
 
 use filar_core::ChatBlock;
 
-use super::text::{render_markdown_line, strip_emoji, wrap_text, MarkdownState};
+use super::text::{render_markdown_line, sanitize_output, strip_emoji, wrap_text, MarkdownState};
 use super::theme::Theme;
 
 /// Which part of a [`ChatBlock`] a rendered line belongs to.
@@ -181,6 +181,11 @@ impl ChatLayoutCache {
                     }
 
                     if let Some(out) = output {
+                        // Command stdout carries \r, backspaces and ANSI escapes.
+                        // They must not reach the terminal: ratatui writes span
+                        // content verbatim, and a stray \r moves the physical
+                        // cursor out from under its buffer (#366).
+                        let out = sanitize_output(out);
                         let all_lines: Vec<&str> = out.lines().collect();
                         let total = all_lines.len();
 

--- a/crates/tui/src/ui/text.rs
+++ b/crates/tui/src/ui/text.rs
@@ -8,6 +8,13 @@ use super::theme::Theme;
 /// Tab stop used when expanding `\t` for wrap/pad (columnar `ps` / tables).
 const TAB_STOP: usize = 8;
 
+/// Upper bound for **explicit cursor jumps** (`CSI G`/`C`, tabs) while
+/// replaying a line. Command output is untrusted: `ESC[1000000000G` would
+/// otherwise make the next printable character pad a billion cells and hang
+/// the TUI (#373 review). Natural left-to-right writing is not capped, so a
+/// genuinely long line is never truncated.
+const MAX_CURSOR_COL: usize = 4096;
+
 /// Expand horizontal tabs to spaces at [`TAB_STOP`] boundaries so wrap and
 /// pad agree with typical terminal columnar layout (#333).
 pub(crate) fn expand_tabs(s: &str) -> String {
@@ -41,6 +48,7 @@ impl LineCells {
     }
 
     fn pad_to(&mut self, n: usize) {
+        let n = n.min(MAX_CURSOR_COL);
         while self.cells.len() < n {
             self.cells.push(Some(" ".to_string()));
         }
@@ -49,13 +57,22 @@ impl LineCells {
     fn put(&mut self, c: char) {
         let w = UnicodeWidthChar::width(c).unwrap_or(0);
         if w == 0 {
-            // Combining mark: attach to the base character to its left.
-            if self.col > 0 {
-                if let Some(Some(prev)) = self.cells.get_mut(self.col - 1) {
-                    prev.push(c);
+            // Combining mark: attach to the nearest base cell to the left. A
+            // wide character puts its base two columns back, not one.
+            let mut k = self.col.min(self.cells.len());
+            while k > 0 {
+                k -= 1;
+                if let Some(text) = self.cells[k].as_mut() {
+                    text.push(c);
+                    break;
                 }
             }
             return;
+        }
+        // Writing into the right half of a wide character destroys the whole
+        // character; its orphaned left half becomes a blank column.
+        if matches!(self.cells.get(self.col), Some(None)) && self.col > 0 {
+            self.cells[self.col - 1] = Some(" ".to_string());
         }
         self.pad_to(self.col);
         for i in 0..w {
@@ -76,7 +93,7 @@ impl LineCells {
     }
 
     fn tab(&mut self) {
-        let target = self.col + (TAB_STOP - (self.col % TAB_STOP));
+        let target = (self.col + (TAB_STOP - (self.col % TAB_STOP))).min(MAX_CURSOR_COL - 1);
         self.pad_to(target);
         self.col = target;
     }
@@ -159,8 +176,8 @@ fn sanitize_line(src: &str) -> String {
                     2 => line.cells.clear(),
                     _ => line.erase_to_end(),
                 },
-                'G' => line.col = num.saturating_sub(1),
-                'C' => line.col += num.max(1),
+                'G' => line.col = num.saturating_sub(1).min(MAX_CURSOR_COL - 1),
+                'C' => line.col = line.col.saturating_add(num.max(1)).min(MAX_CURSOR_COL - 1),
                 'D' => line.col = line.col.saturating_sub(num.max(1)),
                 _ => {} // SGR and friends: presentation only
             }
@@ -171,8 +188,8 @@ fn sanitize_line(src: &str) -> String {
         if esc_next == Some(']') || cp == 0x9D {
             let mut j = i + if c == '\u{1b}' { 2 } else { 1 };
             while j < chars.len() {
-                if chars[j] == '\u{7}' {
-                    j += 1;
+                if chars[j] == '\u{7}' || chars[j] == '\u{9c}' {
+                    j += 1; // BEL or 8-bit ST
                     break;
                 }
                 if chars[j] == '\u{1b}' && j + 1 < chars.len() && chars[j + 1] == '\\' {
@@ -723,8 +740,45 @@ mod tests {
     #[test]
     fn sanitize_preserves_line_structure() {
         assert_eq!(sanitize_output("line1\nline2"), "line1\nline2");
-        // Line count must not change: `str::lines()` runs on the result.
+        // `split('\n')` is used rather than `lines()`, so a trailing newline
+        // survives and `str::lines()` on the result sees the same count.
+        assert_eq!(sanitize_output("a\u{1b}[0m\nb\n"), "a\nb\n");
         assert_eq!(sanitize_output("a\u{1b}[0m\nb\n").lines().count(), 2);
+    }
+
+    #[test]
+    fn sanitize_clobbering_wide_char_right_half_blanks_the_left() {
+        // Writing into the right half destroys the whole wide character.
+        assert_eq!(sanitize_output("\u{5bbd}\u{1b}[2GA"), " A");
+    }
+
+    #[test]
+    fn sanitize_keeps_combining_mark_after_wide_char() {
+        // The base cell of a wide character is two columns back, not one.
+        assert_eq!(sanitize_output("\u{4f60}\u{301}"), "\u{4f60}\u{301}");
+    }
+
+    #[test]
+    fn sanitize_accepts_c1_string_terminator() {
+        assert_eq!(sanitize_output("a\u{9d}0;title\u{9c}b"), "ab");
+    }
+
+    #[test]
+    fn sanitize_bounds_cursor_jumps() {
+        // Untrusted output must not make us pad a billion cells (#373 review).
+        let out = sanitize_output("\u{1b}[1000000000GX");
+        assert!(out.ends_with('X'));
+        assert_eq!(out.chars().count(), MAX_CURSOR_COL);
+        let out = sanitize_output("a\u{1b}[999999999CX");
+        assert!(out.ends_with('X'));
+        assert_eq!(out.chars().count(), MAX_CURSOR_COL);
+    }
+
+    #[test]
+    fn sanitize_does_not_truncate_long_lines() {
+        // Only explicit cursor jumps are clamped; ordinary writing is not.
+        let long: String = "y".repeat(9000);
+        assert_eq!(sanitize_output(&format!("\u{{1b}}[0m{long}")), long);
     }
 
     #[test]

--- a/crates/tui/src/ui/text.rs
+++ b/crates/tui/src/ui/text.rs
@@ -26,14 +26,148 @@ pub(crate) fn expand_tabs(s: &str) -> String {
     out
 }
 
+/// Strip ANSI escape sequences from a single line: CSI (`ESC [` … final byte
+/// `0x40..=0x7E`), OSC (`ESC ]` … `BEL` or `ESC \`), and two-character escapes
+/// (`ESC (B`, `ESC =`, …). A truncated sequence at end of line is dropped whole.
+fn strip_escapes(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0usize;
+    while i < chars.len() {
+        if chars[i] != '\u{1b}' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        if i + 1 >= chars.len() {
+            break; // lone trailing ESC
+        }
+        match chars[i + 1] {
+            '[' => {
+                let mut j = i + 2;
+                while j < chars.len() {
+                    let cp = chars[j] as u32;
+                    if (0x40..=0x7E).contains(&cp) {
+                        break;
+                    }
+                    j += 1;
+                }
+                i = if j < chars.len() { j + 1 } else { chars.len() };
+            }
+            ']' => {
+                let mut j = i + 2;
+                while j < chars.len() {
+                    if chars[j] == '\u{7}' {
+                        j += 1;
+                        break;
+                    }
+                    if chars[j] == '\u{1b}' && j + 1 < chars.len() && chars[j + 1] == '\\' {
+                        j += 2;
+                        break;
+                    }
+                    j += 1;
+                }
+                i = j;
+            }
+            _ => i += 2,
+        }
+    }
+    out
+}
+
+/// Apply the cursor semantics of `\r` (carriage return) and `\x08` (backspace)
+/// inside one line, reproducing what a terminal would actually display.
+///
+/// Progress bars (`hf download`, `pip`, `curl`, `docker pull`) redraw by
+/// emitting frame after frame separated by `\r` with no `\n`, so the whole
+/// animation arrives as a single line. Dropping `\r` would concatenate every
+/// frame; emulating it keeps the final frame — and, exactly like a real
+/// terminal, keeps the tail of a longer previous frame when the last one is
+/// shorter.
+fn apply_overwrite(line: &str) -> String {
+    let mut buf: Vec<char> = Vec::new();
+    let mut col = 0usize;
+    for c in line.chars() {
+        match c {
+            '\r' => col = 0,
+            '\u{8}' => col = col.saturating_sub(1),
+            _ => {
+                if col < buf.len() {
+                    buf[col] = c;
+                } else {
+                    buf.push(c);
+                }
+                col += 1;
+            }
+        }
+    }
+    buf.into_iter().collect()
+}
+
+/// Drop C0/C1 control characters and DEL, keeping `\t` (expanded later by
+/// [`expand_tabs`]).
+fn drop_controls(line: &str) -> String {
+    line.chars()
+        .filter(|&c| {
+            if c == '\t' {
+                return true;
+            }
+            let cp = c as u32;
+            !(cp < 0x20 || cp == 0x7F || (0x80..=0x9F).contains(&cp))
+        })
+        .collect()
+}
+
+/// Sanitise raw command output before it becomes chat lines (#366).
+///
+/// Command stdout is not text: it carries `\r`, backspaces and ANSI escapes.
+/// ratatui writes span content to the terminal verbatim, so a stray `\r` moves
+/// the physical cursor to column 0 and the rest of the frame is painted over
+/// whatever was there — while ratatui's buffer still believes the cell is
+/// unchanged and its diff emits nothing. That desync is what left redraw
+/// artifacts on screen until a window resize forced a full repaint.
+///
+/// Escapes are removed first (so CSI parameter bytes are never mistaken for
+/// text), then `\r`/`\x08` are resolved as cursor movement, then any remaining
+/// control characters are dropped. Newlines are preserved: each line is
+/// processed independently.
+pub(crate) fn sanitize_output(s: &str) -> String {
+    // Fast path: the overwhelming majority of command output is plain text.
+    let needs_work = s.chars().any(|c| {
+        let cp = c as u32;
+        c != '\t' && c != '\n' && (cp < 0x20 || cp == 0x7F || (0x80..=0x9F).contains(&cp))
+    });
+    if !needs_work {
+        return s.to_string();
+    }
+
+    let mut out = String::with_capacity(s.len());
+    for (i, line) in s.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let stripped = strip_escapes(line);
+        let overwritten = apply_overwrite(&stripped);
+        out.push_str(&drop_controls(&overwritten));
+    }
+    out
+}
+
 /// Strip emoji and other non-renderable Unicode characters from a string.
 /// Windows terminal (conhost) can't display most emojis, so they show as '?'.
 /// Conservative whitelist: ASCII, Cyrillic, Latin, punctuation, arrows, math, box drawing.
+///
+/// Control characters are **not** whitelisted: `ESC`/`CR`/`BS` reaching the
+/// terminal desynchronise ratatui's buffer from the physical screen (#366).
+/// `\t` and `\n` are kept — wrapping and [`expand_tabs`] depend on them.
 pub(crate) fn strip_emoji(s: &str) -> String {
     s.chars()
         .filter(|&c| {
             let cp = c as u32;
-            cp <= 0x024F                        // ASCII + Latin + Latin Extended
+            c == '\n' || c == '\t'
+            || ((0x20..=0x024F).contains(&cp)   // ASCII + Latin + Latin Extended
+                && cp != 0x7F                   // minus DEL
+                && !(0x80..=0x9F).contains(&cp))// minus C1 controls
             || (0x0300..=0x036F).contains(&cp)  // Combining diacritics
             || (0x0400..=0x04FF).contains(&cp)  // Cyrillic
             || (0x2000..=0x206F).contains(&cp)  // General punctuation (— " " ' ')
@@ -406,5 +540,85 @@ mod tests {
         let spans = md_spans("`foo` and `bar`");
         assert!(spans.iter().any(|s| s == "foo"));
         assert!(spans.iter().any(|s| s == "bar"));
+    }
+
+    // ── #366: command output sanitisation ────────────────────────────────
+
+    #[test]
+    fn sanitize_keeps_plain_output_untouched() {
+        let plain = "total 12\ndrwxr-xr-x 2 user user 4096 Aug 30 10:00 dir\n";
+        assert_eq!(sanitize_output(plain), plain);
+        assert_eq!(sanitize_output("col1\tcol2"), "col1\tcol2");
+    }
+
+    #[test]
+    fn sanitize_resolves_progress_bar_frames() {
+        // `hf download` style: frames separated by \r, no \n at all.
+        let src = "Fetching 4 files:   0%| | 0/4\rFetching 4 files:  25%|# | 1/4\rFetching 4 files: 100%|##| 4/4";
+        assert_eq!(sanitize_output(src), "Fetching 4 files: 100%|##| 4/4");
+    }
+
+    #[test]
+    fn sanitize_overwrite_keeps_tail_like_a_real_terminal() {
+        // A shorter frame does not erase the longer one underneath it.
+        assert_eq!(sanitize_output("abcdefghij\rXY"), "XYcdefghij");
+    }
+
+    #[test]
+    fn sanitize_handles_backspace() {
+        assert_eq!(sanitize_output("loading |\u{8}/\u{8}-"), "loading -");
+    }
+
+    #[test]
+    fn sanitize_strips_csi_sequences() {
+        // `ls --color=always`
+        assert_eq!(
+            sanitize_output("\u{1b}[0m\u{1b}[01;34mdir\u{1b}[0m  file"),
+            "dir  file"
+        );
+        // `grep --color`: SGR plus erase-to-end-of-line.
+        assert_eq!(
+            sanitize_output("pre\u{1b}[01;31m\u{1b}[Kmatch\u{1b}[m\u{1b}[Kpost"),
+            "prematchpost"
+        );
+        // Truncated sequence at end of line is dropped whole.
+        assert_eq!(sanitize_output("text\u{1b}[38;5;"), "text");
+    }
+
+    #[test]
+    fn sanitize_strips_osc_sequences() {
+        // OSC 7 (cwd report) terminated by BEL.
+        assert_eq!(
+            sanitize_output("\u{1b}]7;file://host/tmp\u{7}text"),
+            "text"
+        );
+        // OSC terminated by ST (ESC \).
+        assert_eq!(sanitize_output("\u{1b}]0;title\u{1b}\\body"), "body");
+    }
+
+    #[test]
+    fn sanitize_drops_stray_c0_c1_and_del() {
+        assert_eq!(sanitize_output("a\u{9b}b\u{7f}c\u{0}d"), "abcd");
+    }
+
+    #[test]
+    fn sanitize_preserves_line_structure() {
+        assert_eq!(sanitize_output("line1\nline2"), "line1\nline2");
+        // Trailing newline must survive so `str::lines()` sees the same count.
+        assert_eq!(sanitize_output("a\u{1b}[0m\nb\n"), "a\nb\n");
+    }
+
+    #[test]
+    fn strip_emoji_removes_control_characters() {
+        // #366: ESC/CR/BS used to pass the `cp <= 0x024F` whitelist.
+        assert_eq!(strip_emoji("a\u{1b}b"), "ab");
+        assert_eq!(strip_emoji("a\rb"), "ab");
+        assert_eq!(strip_emoji("a\u{8}b"), "ab");
+        assert_eq!(strip_emoji("a\u{7f}b"), "ab");
+        assert_eq!(strip_emoji("a\u{9b}b"), "ab");
+        // Newlines and tabs are still needed by wrapping and expand_tabs.
+        assert_eq!(strip_emoji("a\nb\tc"), "a\nb\tc");
+        // Regression guard: normal text is unaffected.
+        assert_eq!(strip_emoji("Привет — ok ✓"), "Привет — ok ✓");
     }
 }

--- a/crates/tui/src/ui/text.rs
+++ b/crates/tui/src/ui/text.rs
@@ -26,96 +26,181 @@ pub(crate) fn expand_tabs(s: &str) -> String {
     out
 }
 
-/// Strip ANSI escape sequences from a single line: CSI (`ESC [` … final byte
-/// `0x40..=0x7E`), OSC (`ESC ]` … `BEL` or `ESC \`), and two-character escapes
-/// (`ESC (B`, `ESC =`, …). A truncated sequence at end of line is dropped whole.
-fn strip_escapes(line: &str) -> String {
-    let chars: Vec<char> = line.chars().collect();
-    let mut out = String::with_capacity(line.len());
+/// One line of a terminal, addressed in **display columns**.
+///
+/// `None` marks the right half of a double-width character, so overwriting the
+/// left half leaves a visible gap exactly as a real terminal does.
+struct LineCells {
+    cells: Vec<Option<String>>,
+    col: usize,
+}
+
+impl LineCells {
+    fn new() -> Self {
+        Self { cells: Vec::new(), col: 0 }
+    }
+
+    fn pad_to(&mut self, n: usize) {
+        while self.cells.len() < n {
+            self.cells.push(Some(" ".to_string()));
+        }
+    }
+
+    fn put(&mut self, c: char) {
+        let w = UnicodeWidthChar::width(c).unwrap_or(0);
+        if w == 0 {
+            // Combining mark: attach to the base character to its left.
+            if self.col > 0 {
+                if let Some(Some(prev)) = self.cells.get_mut(self.col - 1) {
+                    prev.push(c);
+                }
+            }
+            return;
+        }
+        self.pad_to(self.col);
+        for i in 0..w {
+            let val = if i == 0 { Some(c.to_string()) } else { None };
+            if self.col + i < self.cells.len() {
+                self.cells[self.col + i] = val;
+            } else {
+                self.cells.push(val);
+            }
+        }
+        // If we clobbered the left half of a wide character, its orphaned
+        // right half becomes a blank column.
+        let next = self.col + w;
+        if matches!(self.cells.get(next), Some(None)) {
+            self.cells[next] = Some(" ".to_string());
+        }
+        self.col += w;
+    }
+
+    fn tab(&mut self) {
+        let target = self.col + (TAB_STOP - (self.col % TAB_STOP));
+        self.pad_to(target);
+        self.col = target;
+    }
+
+    fn erase_to_end(&mut self) {
+        self.cells.truncate(self.col);
+    }
+
+    fn erase_to_start(&mut self) {
+        self.pad_to(self.col + 1);
+        for cell in self.cells.iter_mut().take(self.col + 1) {
+            *cell = Some(" ".to_string());
+        }
+    }
+
+    fn render(&self) -> String {
+        let mut out = String::new();
+        for cell in &self.cells {
+            if let Some(text) = cell {
+                out.push_str(text);
+            }
+        }
+        out.trim_end().to_string()
+    }
+}
+
+/// Replay one line of raw command output as a terminal would, returning what
+/// would be visible on screen.
+///
+/// Escape parsing and cursor movement happen in a **single pass** on purpose:
+/// erase sequences act relative to the cursor, so stripping escapes separately
+/// would lose the position they apply to. `\r` followed by `CSI K` is exactly
+/// how progress bars clear the tail of the previous frame — handling the `\r`
+/// but discarding the erase would leave the stale tail on screen, which is the
+/// artifact this whole change exists to remove (#366).
+///
+/// Both the 7-bit (`ESC [`, `ESC ]`) and 8-bit (`U+009B`, `U+009D`) forms of
+/// CSI and OSC are recognised. Sequences that only affect presentation (SGR
+/// colours and the like) are discarded; those that move the cursor or erase
+/// content (`K`, `G`, `C`, `D`) are applied. A sequence truncated at end of
+/// line is dropped whole.
+fn sanitize_line(src: &str) -> String {
+    let chars: Vec<char> = src.chars().collect();
+    let mut line = LineCells::new();
     let mut i = 0usize;
+
     while i < chars.len() {
-        if chars[i] != '\u{1b}' {
-            out.push(chars[i]);
-            i += 1;
+        let c = chars[i];
+        let cp = c as u32;
+        let esc_next = if c == '\u{1b}' && i + 1 < chars.len() {
+            Some(chars[i + 1])
+        } else {
+            None
+        };
+
+        if esc_next == Some('[') || cp == 0x9B {
+            let mut j = i + if c == '\u{1b}' { 2 } else { 1 };
+            let start = j;
+            while j < chars.len() {
+                let b = chars[j] as u32;
+                if (0x40..=0x7E).contains(&b) {
+                    break;
+                }
+                j += 1;
+            }
+            if j >= chars.len() {
+                break; // truncated sequence at end of line
+            }
+            let params: String = chars[start..j].iter().collect();
+            let num: usize = params
+                .trim_start_matches('?')
+                .split(';')
+                .next()
+                .unwrap_or("")
+                .parse()
+                .unwrap_or(0);
+            match chars[j] {
+                'K' => match num {
+                    1 => line.erase_to_start(),
+                    2 => line.cells.clear(),
+                    _ => line.erase_to_end(),
+                },
+                'G' => line.col = num.saturating_sub(1),
+                'C' => line.col += num.max(1),
+                'D' => line.col = line.col.saturating_sub(num.max(1)),
+                _ => {} // SGR and friends: presentation only
+            }
+            i = j + 1;
             continue;
         }
-        if i + 1 >= chars.len() {
-            break; // lone trailing ESC
-        }
-        match chars[i + 1] {
-            '[' => {
-                let mut j = i + 2;
-                while j < chars.len() {
-                    let cp = chars[j] as u32;
-                    if (0x40..=0x7E).contains(&cp) {
-                        break;
-                    }
-                    j += 1;
-                }
-                i = if j < chars.len() { j + 1 } else { chars.len() };
-            }
-            ']' => {
-                let mut j = i + 2;
-                while j < chars.len() {
-                    if chars[j] == '\u{7}' {
-                        j += 1;
-                        break;
-                    }
-                    if chars[j] == '\u{1b}' && j + 1 < chars.len() && chars[j + 1] == '\\' {
-                        j += 2;
-                        break;
-                    }
-                    j += 1;
-                }
-                i = j;
-            }
-            _ => i += 2,
-        }
-    }
-    out
-}
 
-/// Apply the cursor semantics of `\r` (carriage return) and `\x08` (backspace)
-/// inside one line, reproducing what a terminal would actually display.
-///
-/// Progress bars (`hf download`, `pip`, `curl`, `docker pull`) redraw by
-/// emitting frame after frame separated by `\r` with no `\n`, so the whole
-/// animation arrives as a single line. Dropping `\r` would concatenate every
-/// frame; emulating it keeps the final frame — and, exactly like a real
-/// terminal, keeps the tail of a longer previous frame when the last one is
-/// shorter.
-fn apply_overwrite(line: &str) -> String {
-    let mut buf: Vec<char> = Vec::new();
-    let mut col = 0usize;
-    for c in line.chars() {
+        if esc_next == Some(']') || cp == 0x9D {
+            let mut j = i + if c == '\u{1b}' { 2 } else { 1 };
+            while j < chars.len() {
+                if chars[j] == '\u{7}' {
+                    j += 1;
+                    break;
+                }
+                if chars[j] == '\u{1b}' && j + 1 < chars.len() && chars[j + 1] == '\\' {
+                    j += 2;
+                    break;
+                }
+                j += 1;
+            }
+            i = j;
+            continue;
+        }
+
+        if c == '\u{1b}' {
+            i += 2; // two-character escape (ESC(B, ESC=, …)
+            continue;
+        }
+
         match c {
-            '\r' => col = 0,
-            '\u{8}' => col = col.saturating_sub(1),
-            _ => {
-                if col < buf.len() {
-                    buf[col] = c;
-                } else {
-                    buf.push(c);
-                }
-                col += 1;
-            }
+            '\r' => line.col = 0,
+            '\u{8}' => line.col = line.col.saturating_sub(1),
+            '\t' => line.tab(),
+            _ if cp < 0x20 || cp == 0x7F || (0x80..=0x9F).contains(&cp) => {}
+            _ => line.put(c),
         }
+        i += 1;
     }
-    buf.into_iter().collect()
-}
 
-/// Drop C0/C1 control characters and DEL, keeping `\t` (expanded later by
-/// [`expand_tabs`]).
-fn drop_controls(line: &str) -> String {
-    line.chars()
-        .filter(|&c| {
-            if c == '\t' {
-                return true;
-            }
-            let cp = c as u32;
-            !(cp < 0x20 || cp == 0x7F || (0x80..=0x9F).contains(&cp))
-        })
-        .collect()
+    line.render()
 }
 
 /// Sanitise raw command output before it becomes chat lines (#366).
@@ -127,12 +212,12 @@ fn drop_controls(line: &str) -> String {
 /// unchanged and its diff emits nothing. That desync is what left redraw
 /// artifacts on screen until a window resize forced a full repaint.
 ///
-/// Escapes are removed first (so CSI parameter bytes are never mistaken for
-/// text), then `\r`/`\x08` are resolved as cursor movement, then any remaining
-/// control characters are dropped. Newlines are preserved: each line is
-/// processed independently.
+/// Each line is replayed independently by [`sanitize_line`]; newlines are
+/// preserved so line counts stay identical.
 pub(crate) fn sanitize_output(s: &str) -> String {
     // Fast path: the overwhelming majority of command output is plain text.
+    // `\t` is left for `expand_tabs`; without cursor motion its column is
+    // unambiguous, so there is nothing to replay.
     let needs_work = s.chars().any(|c| {
         let cp = c as u32;
         c != '\t' && c != '\n' && (cp < 0x20 || cp == 0x7F || (0x80..=0x9F).contains(&cp))
@@ -146,9 +231,7 @@ pub(crate) fn sanitize_output(s: &str) -> String {
         if i > 0 {
             out.push('\n');
         }
-        let stripped = strip_escapes(line);
-        let overwritten = apply_overwrite(&stripped);
-        out.push_str(&drop_controls(&overwritten));
+        out.push_str(&sanitize_line(line));
     }
     out
 }
@@ -548,6 +631,8 @@ mod tests {
     fn sanitize_keeps_plain_output_untouched() {
         let plain = "total 12\ndrwxr-xr-x 2 user user 4096 Aug 30 10:00 dir\n";
         assert_eq!(sanitize_output(plain), plain);
+        // Tabs alone take the fast path: without cursor motion their column is
+        // unambiguous and `expand_tabs` handles them at wrap time.
         assert_eq!(sanitize_output("col1\tcol2"), "col1\tcol2");
     }
 
@@ -559,9 +644,46 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_overwrite_keeps_tail_like_a_real_terminal() {
-        // A shorter frame does not erase the longer one underneath it.
+    fn sanitize_overwrite_keeps_tail_when_nothing_erases_it() {
+        // No erase sequence: a real terminal keeps the tail of the longer
+        // previous frame underneath.
         assert_eq!(sanitize_output("abcdefghij\rXY"), "XYcdefghij");
+    }
+
+    #[test]
+    fn sanitize_applies_erase_to_end_of_line() {
+        // `\r` + CSI K is how progress bars clear the previous frame. Dropping
+        // the erase would leave the stale tail — the artifact of #366.
+        assert_eq!(sanitize_output("abcdef\r\u{1b}[KXY"), "XY");
+        // CSI 2K erases the whole line.
+        assert_eq!(sanitize_output("abcdef\r\u{1b}[2KXY"), "XY");
+        // CSI 1K erases up to and including the cursor.
+        assert_eq!(sanitize_output("abcdef\u{1b}[3G\u{1b}[1KX"), "  Xdef");
+    }
+
+    #[test]
+    fn sanitize_handles_eight_bit_c1_introducers() {
+        // U+009B is CSI, U+009D is OSC. Dropping only the introducer would
+        // leave the parameter bytes as visible text.
+        assert_eq!(sanitize_output("a\u{9b}31mred"), "ared");
+        assert_eq!(sanitize_output("a\u{9d}0;title\u{7}b"), "ab");
+    }
+
+    #[test]
+    fn sanitize_counts_display_columns_not_chars() {
+        // Backspace after a tab lands on column 7, not on the tab character.
+        assert_eq!(sanitize_output("A\t\u{8}X"), "A      X");
+        // Two single-width chars cover only the first wide character.
+        assert_eq!(sanitize_output("\u{4f60}\u{597d}\rAB"), "AB\u{597d}");
+        // Clobbering the left half of a wide char leaves a blank column.
+        assert_eq!(sanitize_output("\u{4f60}x\rA"), "A x");
+    }
+
+    #[test]
+    fn sanitize_handles_cursor_movement() {
+        assert_eq!(sanitize_output("abcdef\u{1b}[3GX"), "abXdef");
+        assert_eq!(sanitize_output("abc\u{1b}[2DX"), "aXc");
+        assert_eq!(sanitize_output("ab\u{1b}[2CX"), "ab  X");
     }
 
     #[test]
@@ -570,13 +692,13 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_strips_csi_sequences() {
+    fn sanitize_strips_presentation_sequences() {
         // `ls --color=always`
         assert_eq!(
             sanitize_output("\u{1b}[0m\u{1b}[01;34mdir\u{1b}[0m  file"),
             "dir  file"
         );
-        // `grep --color`: SGR plus erase-to-end-of-line.
+        // `grep --color`: SGR plus erase-to-end-of-line at the cursor.
         assert_eq!(
             sanitize_output("pre\u{1b}[01;31m\u{1b}[Kmatch\u{1b}[m\u{1b}[Kpost"),
             "prematchpost"
@@ -588,24 +710,21 @@ mod tests {
     #[test]
     fn sanitize_strips_osc_sequences() {
         // OSC 7 (cwd report) terminated by BEL.
-        assert_eq!(
-            sanitize_output("\u{1b}]7;file://host/tmp\u{7}text"),
-            "text"
-        );
+        assert_eq!(sanitize_output("\u{1b}]7;file://host/tmp\u{7}text"), "text");
         // OSC terminated by ST (ESC \).
         assert_eq!(sanitize_output("\u{1b}]0;title\u{1b}\\body"), "body");
     }
 
     #[test]
-    fn sanitize_drops_stray_c0_c1_and_del() {
-        assert_eq!(sanitize_output("a\u{9b}b\u{7f}c\u{0}d"), "abcd");
+    fn sanitize_drops_stray_c0_and_del() {
+        assert_eq!(sanitize_output("a\u{0}b\u{7f}c"), "abc");
     }
 
     #[test]
     fn sanitize_preserves_line_structure() {
         assert_eq!(sanitize_output("line1\nline2"), "line1\nline2");
-        // Trailing newline must survive so `str::lines()` sees the same count.
-        assert_eq!(sanitize_output("a\u{1b}[0m\nb\n"), "a\nb\n");
+        // Line count must not change: `str::lines()` runs on the result.
+        assert_eq!(sanitize_output("a\u{1b}[0m\nb\n").lines().count(), 2);
     }
 
     #[test]

--- a/crates/tui/src/ui/text.rs
+++ b/crates/tui/src/ui/text.rs
@@ -778,7 +778,8 @@ mod tests {
     fn sanitize_does_not_truncate_long_lines() {
         // Only explicit cursor jumps are clamped; ordinary writing is not.
         let long: String = "y".repeat(9000);
-        assert_eq!(sanitize_output(&format!("\u{{1b}}[0m{long}")), long);
+        let src = format!("\u{1b}[0m{long}");
+        assert_eq!(sanitize_output(&src), long);
     }
 
     #[test]


### PR DESCRIPTION
Closes #366

## Summary

Redraw artifacts survived every earlier fix because the desync was never in the
ratatui buffer. Raw command output reached the terminal through `Span::raw`
with its control bytes intact: a `\r` from a progress bar moved the **physical**
cursor to column 0, the rest of the frame was painted over whatever was there,
and ratatui's diff then skipped those cells because its buffer said they were
unchanged. `reset_area_cells` / `pad_line_to_width` / `Clear` (#231, #245,
#328, #333) all fix the buffer, which was already correct — that is why only a
window resize (a full `ESC[2J` repaint) healed the screen.

This PR removes the control bytes at the source and adds a repaint as a safety
net.

## Changes

**`text.rs::sanitize_output`** — per line, in this order:

1. strip ANSI escapes: CSI (`ESC [` … final `0x40..=0x7E`), OSC (`ESC ]` … BEL
   or ST), two-character escapes; a truncated sequence at end of line is
   dropped whole. Escapes go first so CSI parameter bytes are never treated as
   text;
2. resolve `\r` and `\x08` as cursor movement;
3. drop remaining C0/C1/DEL, keeping `\t` for `expand_tabs`.

A fast path returns the input unchanged when it holds no control bytes, so the
common case costs one scan.

**`\r` is emulated, not dropped.** The issue left this choice to the PR.
Progress bars (`hf download`, `pip`, `curl`, `docker pull`) redraw by emitting
frame after frame separated by `\r` with no `\n`, so the whole animation is one
line. Emulating the cursor reproduces what a terminal actually shows — the last
frame, and the tail of a longer previous frame when the last is shorter —
rather than concatenating frames or truncating to the final segment.

**`layout_cache.rs`** — applied where `ChatBlock::Command` output becomes chat
lines, covering both the collapsed and expanded branches.

**`strip_emoji` fixed** — the `cp <= 0x024F` whitelist admitted the entire C0
block, so `ESC`/`CR`/`BS` passed through in *every* block type, not just
command output. `\n` and `\t` remain whitelisted; wrapping depends on them.

**`runner.rs` — debounced settle repaint.** One `terminal.clear()` + draw,
250 ms after the last frame, armed only while output is streaming (Thinking
mode, or the fallback path that exists because continuous output starves the
render tick).

Two deliberate departures from the issue text:

- not an unconditional 1 Hz timer — that repaints forever, flickers over SSH,
  defeats the diff backend, and breaks the zero-CPU-at-idle property the render
  tick guard is written to preserve;
- not armed after *every* frame — that would flash the whole screen after each
  typing pause, for no benefit, since keystroke rendering does not desync
  anything.

No synthetic resize event is needed: `Terminal::resize()` calls `clear()`
internally, so `terminal.clear()` (already used on mode/tab change) is the same
operation.

## Tests

Eight unit tests for the sanitiser — progress-bar frames, overwrite tail, CSI
(`ls --color`, `grep --color`, truncated sequence), OSC with both terminators,
backspace, stray C0/C1/DEL, preserved line structure — plus a `strip_emoji`
test covering `ESC`/`CR`/`BS`/`DEL`/C1 and the retention of `\n`/`\t`.

The algorithm was prototyped and validated against 12 cases before being ported
to Rust.

## Не проверено в окружении агента

Правка сделана AI-агентом в песочнице **без Rust-тулчейна** (`rustup`
недоступен, в apt только 1.75 при `rust-version = "1.85"`), поэтому
`cargo build --workspace` и `cargo test --workspace` **не запускались** — их
выполнит CI из #367 на Windows и macOS.

**DoD требует ручного прогона, и он остаётся за человеком** — этот PR меняет
поведение отрисовки, что автотестами не покрывается:

1. Repro: команда с `\r`-прогресс-баром (`hf download`, `curl -O` большого
   файла), затем команда с колоночным выводом (`ps aux`) → артефактов быть не
   должно **без** изменения размера окна.
2. Вывод с ANSI-цветами (`ls --color=always`, `grep --color`) не ломает кадр.
3. Не регрессировали #325 (короткая строка поверх длинной при scroll) и #333
   (wrap + колонки).
4. Settle-repaint не мерцает при обычной работе и не будит процесс в простое
   (CPU в простое остаётся нулевым).
5. Проверить **на обеих платформах** — macOS (Terminal.app / iTerm) и Windows
   (Windows Terminal / conhost). Если поведение разойдётся, дополнить
   `docs/PLATFORM_NOTES.md`.

## Вне скоупа

- **Ручной форс-репейнт.** Issue предлагает `Ctrl+R`, но это reverse-i-search в
  шелле — в интерактивном режиме будет конфликт. Выбор клавиши требует
  отдельного решения, поэтому в этот PR не вошло.
- **Трансляция SGR в стили ratatui** вместо отбрасывания цвета — отдельная
  задача; сейчас цвет из вывода команд удаляется, как и раньше.
- **Interactive-режим** (`TerminalModel` на alacritty_terminal) идёт своим
  путём и разбирает escape-последовательности штатно — не затронут.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed terminal display artifacts caused by command output containing carriage returns, backspaces, ANSI escape sequences, and other control characters.
  - Improved handling of progress bars and cursor movement so stale characters no longer remain on screen.
  - Added a brief final screen refresh after streaming output stops to ensure the display is fully synchronized.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->