### PR TITLE
feat(tui): track context fill and add a per-profile compaction threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ## [Unreleased]
 
+### Added
+
+- Sessions now track how full the model's context is, measured from the
+  `prompt_tokens` the provider reports for the most recent request rather than
+  from the session's running total. A new per-profile `compact_at_tokens`
+  setting (default `200000`, `0` disables) marks the point at which the history
+  will be compacted; reaching it currently logs and shows a one-off notice in
+  the feed, and the summarisation itself follows in a later change
+  ([#376](https://github.com/devlawey/filar/issues/376)).
+
 ### Fixed
 
 - Streaming LLM replies no longer die on the first transient network hiccup

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5385,6 +5385,65 @@ on its own PR. `eval/README.md` updated.
 changes went unverified. If it is, triage the failures as a separate issue and
 **do not lower the 90% threshold** to make it pass.
 
+## Issue #376: feat(tui) — context fill tracking and the compaction threshold
+
+**Milestone:** 1.0.6. **Branch:** `feat/376-context-fill-tracking`. Part 1 of 4
+of the context-compaction spec; #377–#379 build on it.
+
+**The trap this issue exists to avoid.** `Session::tokens_in` accumulates every
+request in the session (`s.tokens_in += tokens_in`), so triggering on it would
+fire many times too early and then keep firing. The measurement that matters is
+`prompt_tokens` of the *last* request, which arrives as `tokens_in` on a single
+`AgentEvent::TokenUsage`. Stored separately as `last_prompt_tokens`, leaving the
+running totals untouched. Arbiter events (`arbiter: true`) are excluded — the
+arbiter sends its own short prompt, not the session history — and a reported
+zero is treated as "no measurement" rather than as an empty context.
+
+**Where the check runs.** `begin_agent_request` is the single choke point before
+a request is sent, which is also where the spec wants it: deciding after the
+response arrives would make the user wait on something after their answer.
+
+**Boundary, and a correction to the spec.** The spec frames the cut in terms of
+orphaned `tool_call_id`s. That does not apply here: the TUI keeps history as
+`Vec<ChatBlock>` and flattens it in `runner.rs`, where `ChatBlock::Command`
+becomes a plain assistant message — there are no `tool` role messages in what is
+sent, they exist only inside one `run_loop` call. The real invariant is that a
+turn is a `User` block plus everything answering it, so `compaction_boundary`
+always returns the index of a `User` block; otherwise the tail would open with
+commands belonging to a request that is no longer there. The original
+`tool_call_id` requirement is recorded in the function's doc comment for
+whenever the representation changes.
+
+**Config plumbing.** `LlmProfile::compact_at_tokens` had to be threaded through
+every hand-written conversion, which in the GUI means four separate
+`LlmProfileData` → `LlmProfile` sites plus the reverse, the default-profile
+path, both add-profile buttons and the test literals. `parse_compact_at_tokens`
+falls back to the default rather than to `0` on empty input, because `0` means
+"disabled" and a blank box must not silently switch the feature off. This is the
+same class of defect as #380, where `max_tokens` and `top_p` are lost on every
+launcher save; the round-trip test here exists specifically to stop this field
+going the same way.
+
+**Deliberately not done:** `last_prompt_tokens` is not persisted in the session
+JSON, so after reopening a saved session the threshold stays dormant until the
+first response. Persisting it would mean touching the session format, which is
+#379's territory, and the gap is exactly what the reactive path in #378 covers.
+`keep_turns` is a documented constant rather than a config field: nothing
+consumes it until #377 actually compacts, and a second config knob would mean a
+second round of the plumbing above for no present benefit.
+
+**Done:** 9 unit tests on the pure functions in `filar_core::compaction`,
+6 in the TUI (trigger source, arbiter exclusion, zero-usage, one-notice-per-
+crossing, disabled profile, per-profile threshold) and 2 in the GUI for the
+config round trip.
+
+**Public contract:** `LlmProfile` gains a field. Additive and `#[serde(default)]`,
+so existing `config.toml`, `settings.json` and `pending_launch.json` files load
+unchanged, but every struct literal in the workspace had to be updated.
+
+**Next steps:** neither build nor tests could be run by the agent (no Rust
+toolchain) — CI and a manual run are required, see the PR.
+
 ## Issue #374: fix(agent) — mid-stream LLM failures were never retried
 
 **Milestone:** 1.0.6. **Branch:** `fix/374-stream-retry`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5426,11 +5426,20 @@ going the same way.
 
 **Deliberately not done:** `last_prompt_tokens` is not persisted in the session
 JSON, so after reopening a saved session the threshold stays dormant until the
-first response. Persisting it would mean touching the session format, which is
-#379's territory, and the gap is exactly what the reactive path in #378 covers.
-`keep_turns` is a documented constant rather than a config field: nothing
-consumes it until #377 actually compacts, and a second config knob would mean a
-second round of the plumbing above for no present benefit.
+first response arrives. Persisting it would mean touching the session format,
+which belongs to #379, and the gap is exactly what the reactive path in #378
+covers. `keep_turns` is a documented constant rather than a config field:
+nothing consumes it until #377 actually compacts, and a second config knob would
+mean a second round of the plumbing above for no present benefit.
+
+**Review (PR #381).** Three findings, all accepted. The important one: neither
+`apply_loaded_session` nor `with_history` reset the two new runtime fields, so
+restoring a session over a tab kept the replaced conversation's measurement —
+which would report a crossing that never happened for the new history, or hold a
+real one suppressed. Both paths now clear them, with a regression test. The
+launcher hint did not say that an empty threshold field means "default" rather
+than "off", and `README.md` / `config.toml` described compaction as if it
+already happened; both corrected to state that this change only reports.
 
 **Done:** 9 unit tests on the pure functions in `filar_core::compaction`,
 6 in the TUI (trigger source, arbiter exclusion, zero-usage, one-notice-per-

--- a/README.md
+++ b/README.md
@@ -191,25 +191,32 @@ model = "deepseek-chat"
 api_base_url = "https://api.deepseek.com/v1"
 max_tokens = 8192
 key_env = "DEEPSEEK_API_KEY"
-# Prompt tokens at which the session history is compacted before the next
-# request. Per-profile, because context windows differ. 0 disables it.
+# Prompt tokens at which the context is considered full. Per-profile, because
+# context windows differ. Currently this only logs and shows a notice — history
+# compaction is not implemented yet. 0 turns the notice off.
 compact_at_tokens = 200000
 
-#### Context compaction
+#### Context fill
 
 A long investigation eventually fills the model's context window: the whole
 history is re-sent with every request, so each turn costs more than the last
-until the provider refuses outright. `compact_at_tokens` is the point at which
-filar folds the earlier part of the conversation into a summary and carries on.
+until the provider refuses outright. `compact_at_tokens` marks the point at
+which that becomes a problem.
+
+**Today this only reports.** Reaching the threshold writes a warning to the log
+and adds one notice to the session feed; the history is left untouched. Folding
+the earlier part of the conversation into a summary is not implemented yet, so
+do not rely on this setting to keep a session under the window.
 
 The threshold is per-profile because context windows differ — a figure that
 suits a 1M-token model is meaningless for a 128k one. Set it comfortably below
-the window, since the reply and the tool definitions also need room. `0`
-disables compaction for that profile.
+the window, since the reply and the tool definitions also need room. `0` turns
+the notice off for that profile.
 
-filar measures fill from the `prompt_tokens` the provider reports for the most
+Fill is measured from the `prompt_tokens` the provider reports for the most
 recent request, not from the session's running total, so the figure reflects
-the context actually being sent.
+the context actually being sent. It is not saved with the session: after
+reopening one, the first response measures it again.
 
 # ── Timeouts (seconds) ─────────────────────────────────────
 [timeouts]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,25 @@ model = "deepseek-chat"
 api_base_url = "https://api.deepseek.com/v1"
 max_tokens = 8192
 key_env = "DEEPSEEK_API_KEY"
+# Prompt tokens at which the session history is compacted before the next
+# request. Per-profile, because context windows differ. 0 disables it.
+compact_at_tokens = 200000
+
+#### Context compaction
+
+A long investigation eventually fills the model's context window: the whole
+history is re-sent with every request, so each turn costs more than the last
+until the provider refuses outright. `compact_at_tokens` is the point at which
+filar folds the earlier part of the conversation into a summary and carries on.
+
+The threshold is per-profile because context windows differ — a figure that
+suits a 1M-token model is meaningless for a 128k one. Set it comfortably below
+the window, since the reply and the tool definitions also need room. `0`
+disables compaction for that profile.
+
+filar measures fill from the `prompt_tokens` the provider reports for the most
+recent request, not from the session's running total, so the figure reflects
+the context actually being sent.
 
 # ── Timeouts (seconds) ─────────────────────────────────────
 [timeouts]

--- a/config.toml
+++ b/config.toml
@@ -19,8 +19,9 @@ max_tokens = 4096
 # api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 # key_env = "GLM_API_KEY"
 # max_tokens = 4096
-# # Prompt tokens at which the session history is compacted before the next
-# # request. Set it below the model's context window; 0 disables compaction.
+# # Prompt tokens at which the context is considered full. Set it below the
+# # model's context window. Currently this only logs and shows a notice in the
+# # session feed — history compaction is not implemented yet. 0 turns it off.
 # compact_at_tokens = 200000
 
 [timeouts]

--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,21 @@ model = "glm-5.1"
 api_base_url = "https://open.bigmodel.cn/api/paas/v4"
 max_tokens = 4096
 
+# ── LLM profiles ─────────────────────────────────────────────────────
+# Named profiles cycled with Ctrl+L in the TUI. The `[llm]` section above is
+# the fallback when no profiles are defined. API keys live in the OS credential
+# store under the name given by `key_env` — never here.
+
+# [[llm_profiles]]
+# name = "glm"
+# model = "glm-5.1"
+# api_base_url = "https://open.bigmodel.cn/api/paas/v4"
+# key_env = "GLM_API_KEY"
+# max_tokens = 4096
+# # Prompt tokens at which the session history is compacted before the next
+# # request. Set it below the model's context window; 0 disables compaction.
+# compact_at_tokens = 200000
+
 [timeouts]
 command_secs = 300
 # One non-streaming LLM call end to end. While a reply is streaming, this is

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -801,6 +801,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         };
         let result = build_llm_client_from_profile(&profile, &sp, 60);
         assert!(result.is_ok(), "factory must succeed with a valid key");
@@ -818,6 +819,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         };
         let result = build_llm_client_from_profile(&profile, &sp, 60);
         assert!(result.is_err(), "factory must fail when no key is available");
@@ -835,6 +837,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         };
         let result = build_llm_client_from_profile(&profile, &sp, 60);
         assert!(
@@ -855,6 +858,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         };
         assert!(
             check_profile_api_key(&profile, &sp).is_none(),
@@ -874,6 +878,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         };
         let msg = check_profile_api_key(&profile, &sp);
         assert!(msg.is_some(), "key_checker must fail when required key is missing");
@@ -896,6 +901,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         };
         // Test 1: key is absent → error must NOT contain the test value.
         let result = build_llm_client_from_profile(&profile, &sp, 60);
@@ -930,6 +936,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         }
     }
 

--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -1,0 +1,211 @@
+//! Context compaction: deciding when the model's context is full enough to
+//! warrant compacting the history, and where that history may safely be cut.
+//!
+//! This module is deliberately free of I/O and of any TUI types: both decisions
+//! are pure functions of the conversation and a threshold, so they can be
+//! tested directly.
+//!
+//! Only the measurement and the boundary live here. Producing the summary that
+//! replaces the compacted head is a separate step (see issue #377).
+
+use crate::ChatBlock;
+
+/// How many complete turns are kept verbatim at the end of the history.
+///
+/// Recent context matters most and does not survive being paraphrased, so the
+/// tail is never summarised. Four to six turns is the useful range; five is the
+/// default.
+pub const DEFAULT_KEEP_TURNS: usize = 5;
+
+/// Whether the history should be compacted before the next request.
+///
+/// `last_prompt_tokens` must be the `prompt_tokens` figure the provider
+/// reported for the **most recent** request — that is the measured size of the
+/// context that was actually sent. A cumulative per-session counter is the
+/// wrong input: it sums every request in the session and would cross any
+/// threshold long before the context itself does.
+///
+/// `None` means the provider reported no usage, so the context size is unknown
+/// and the threshold cannot fire; the reactive path (issue #378) covers that
+/// case. A `compact_at_tokens` of `0` disables compaction entirely.
+pub fn should_compact(last_prompt_tokens: Option<u64>, compact_at_tokens: u64) -> bool {
+    if compact_at_tokens == 0 {
+        return false;
+    }
+    matches!(last_prompt_tokens, Some(used) if used >= compact_at_tokens)
+}
+
+/// Index in `blocks` where the verbatim tail begins.
+///
+/// Everything before the returned index is the head, which may be replaced by a
+/// summary; everything from it onward is kept word for word. `0` means there is
+/// nothing to compact — the whole history is already within the tail.
+///
+/// The boundary always lands on a [`ChatBlock::User`], because a turn is a user
+/// message plus every agent and command block that answers it. Cutting inside a
+/// turn would leave commands in the tail with no request they belong to, and
+/// their `Command:`/`Output:` text would read as if the agent had run them
+/// unprompted.
+///
+/// Note for future changes: the history the TUI hands to the model is built by
+/// flattening [`ChatBlock`]s into plain assistant messages, so there are no
+/// `tool` role messages and no `tool_call_id` values in it. If that
+/// representation ever changes to real tool messages, this boundary must also
+/// never fall between a tool call and its result — an orphaned `tool_call_id`
+/// is rejected by the provider.
+pub fn compaction_boundary(blocks: &[ChatBlock], keep_turns: usize) -> usize {
+    // `keep_turns == 0` means nothing is kept verbatim: the whole history is
+    // the head.
+    if keep_turns == 0 {
+        return blocks.len();
+    }
+
+    let turn_starts: Vec<usize> = blocks
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| matches!(b, ChatBlock::User(_)))
+        .map(|(i, _)| i)
+        .collect();
+
+    if turn_starts.len() <= keep_turns {
+        return 0;
+    }
+    turn_starts[turn_starts.len() - keep_turns]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(s: &str) -> ChatBlock {
+        ChatBlock::User(s.into())
+    }
+    fn agent(s: &str) -> ChatBlock {
+        ChatBlock::Agent(s.into())
+    }
+    fn command(s: &str) -> ChatBlock {
+        ChatBlock::Command {
+            command: s.into(),
+            explanation: String::new(),
+            output: Some("ok".into()),
+            approved: true,
+        }
+    }
+    fn system(s: &str) -> ChatBlock {
+        ChatBlock::System(s.into())
+    }
+
+    #[test]
+    fn threshold_fires_on_the_last_request_not_on_a_running_total() {
+        // The session has burned 300k tokens in total, but the context that was
+        // actually sent last time was 20k. Compaction must not fire.
+        let cumulative_would_be = 300_000;
+        assert!(
+            should_compact(Some(cumulative_would_be), 200_000),
+            "sanity: the cumulative figure would cross the threshold"
+        );
+        assert!(
+            !should_compact(Some(20_000), 200_000),
+            "the real context size is well below the threshold"
+        );
+    }
+
+    #[test]
+    fn threshold_fires_at_and_above_the_limit() {
+        assert!(!should_compact(Some(199_999), 200_000));
+        assert!(should_compact(Some(200_000), 200_000));
+        assert!(should_compact(Some(200_001), 200_000));
+    }
+
+    #[test]
+    fn zero_threshold_disables_compaction() {
+        assert!(!should_compact(Some(u64::MAX), 0));
+    }
+
+    #[test]
+    fn unknown_context_size_never_fires() {
+        assert!(!should_compact(None, 1));
+    }
+
+    #[test]
+    fn boundary_lands_on_a_user_block() {
+        let blocks = vec![
+            user("q1"),
+            agent("a1"),
+            user("q2"),
+            command("ls"),
+            agent("a2"),
+            user("q3"),
+            agent("a3"),
+        ];
+        let cut = compaction_boundary(&blocks, 2);
+        assert_eq!(cut, 2, "the tail must start at the second-to-last turn");
+        assert!(matches!(blocks[cut], ChatBlock::User(_)));
+    }
+
+    #[test]
+    fn boundary_never_separates_a_command_from_its_user_message() {
+        // The tail length lands mid-turn: turn 2 is user + two commands. A
+        // naive "keep the last N blocks" cut would start at a Command.
+        let blocks = vec![
+            user("q1"),
+            agent("a1"),
+            user("q2"),
+            command("systemctl restart nginx"),
+            command("systemctl status nginx"),
+            agent("a2"),
+        ];
+        let cut = compaction_boundary(&blocks, 1);
+        assert_eq!(cut, 2);
+        assert!(
+            matches!(blocks[cut], ChatBlock::User(_)),
+            "the tail must open with the request the commands belong to"
+        );
+        assert!(
+            !blocks[cut..]
+                .iter()
+                .any(|b| matches!(b, ChatBlock::Command { .. }))
+                || matches!(blocks[cut], ChatBlock::User(_)),
+            "no command may appear in the tail before its user message"
+        );
+    }
+
+    #[test]
+    fn nothing_to_compact_when_history_fits_in_the_tail() {
+        let blocks = vec![user("q1"), agent("a1"), user("q2"), agent("a2")];
+        assert_eq!(compaction_boundary(&blocks, 5), 0);
+        assert_eq!(
+            compaction_boundary(&blocks, 2),
+            0,
+            "exactly `keep_turns` turns is still nothing to compact"
+        );
+    }
+
+    #[test]
+    fn system_blocks_do_not_start_a_turn() {
+        // System notices are dropped when the history is converted for the
+        // model, so they must not be mistaken for a turn boundary.
+        let blocks = vec![
+            system("session started"),
+            user("q1"),
+            agent("a1"),
+            system("switched profile"),
+            user("q2"),
+            agent("a2"),
+        ];
+        let cut = compaction_boundary(&blocks, 1);
+        assert_eq!(cut, 4, "the tail starts at the last user block, not the notice");
+    }
+
+    #[test]
+    fn history_without_user_blocks_is_never_cut() {
+        let blocks = vec![system("session started"), agent("greeting")];
+        assert_eq!(compaction_boundary(&blocks, 1), 0);
+    }
+
+    #[test]
+    fn keeping_no_turns_makes_the_whole_history_the_head() {
+        let blocks = vec![user("q1"), agent("a1")];
+        assert_eq!(compaction_boundary(&blocks, 0), blocks.len());
+    }
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -252,6 +252,21 @@ pub struct LlmProfile {
     /// Arbitrary extra fields merged into the JSON request body.
     #[serde(default)]
     pub extra_body: Option<serde_json::Value>,
+    /// Prompt-token count at which the session history is compacted before the
+    /// next request. `0` disables compaction for this profile.
+    ///
+    /// Per-profile because context windows differ: a threshold that makes
+    /// sense for a 1M-token window is meaningless for 128k. This is a
+    /// client-side setting and is never sent to the API.
+    #[serde(default = "default_compact_at_tokens")]
+    pub compact_at_tokens: u64,
+}
+
+/// Default `[[llm_profiles]].compact_at_tokens` — 200k prompt tokens.
+pub const DEFAULT_COMPACT_AT_TOKENS: u64 = 200_000;
+
+fn default_compact_at_tokens() -> u64 {
+    DEFAULT_COMPACT_AT_TOKENS
 }
 
 fn default_glm_key_env() -> String {
@@ -556,6 +571,7 @@ api_base_url = "https://open.bigmodel.cn/api/paas/v4"
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: DEFAULT_COMPACT_AT_TOKENS,
         }];
         let (name, warn) = cfg.resolve_arbiter_profile("session", &profiles);
         assert_eq!(name, "session");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,15 +6,17 @@
 //! - [`secrets`]: Secure reading of API keys and other secrets from the environment.
 
 pub mod chat;
+pub mod compaction;
 pub mod config;
 pub mod error;
 pub mod secrets;
 pub mod session;
 
 pub use chat::ChatBlock;
+pub use compaction::{compaction_boundary, should_compact, DEFAULT_KEEP_TURNS};
 pub use config::{
     Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig,
-    HostKeyPolicy, DEFAULT_COMMAND_TIMEOUT_SECS,
+    HostKeyPolicy, DEFAULT_COMMAND_TIMEOUT_SECS, DEFAULT_COMPACT_AT_TOKENS,
 };
 pub use error::{CoreError, Result};
 pub use secrets::{

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -132,6 +132,20 @@ fn load_secret_for_profile(profile: &filar_core::LlmProfile) -> String {
 
 /// Generate a unique profile name with the given prefix.
 /// Finds the first free number (profile-1, profile-2, ...) not already in use.
+/// Parse the compaction threshold typed in the launcher.
+///
+/// An empty or unparseable field falls back to the built-in default rather
+/// than to `0`, because `0` means "compaction disabled" and silently disabling
+/// a feature because someone left a box blank would be the wrong default.
+/// Validation rejects genuinely malformed input before Launch.
+fn parse_compact_at_tokens(raw: &str) -> u64 {
+    let text = raw.trim();
+    if text.is_empty() {
+        return filar_core::DEFAULT_COMPACT_AT_TOKENS;
+    }
+    text.parse().unwrap_or(filar_core::DEFAULT_COMPACT_AT_TOKENS)
+}
+
 fn unique_profile_name(existing: &[LlmProfileData], prefix: &str) -> String {
     let mut n = 1;
     loop {
@@ -570,6 +584,10 @@ struct LlmProfileData {
     api_key: String,
     temperature: String,
     extra_body: String,
+    /// Compaction threshold in prompt tokens, as typed. Empty = profile
+    /// default; `0` disables compaction. Kept as a string like `temperature`
+    /// so a half-typed value does not reset the field.
+    compact_at_tokens: String,
 }
 
 /// Apply the dark theme, matching the TUI accent palette:
@@ -809,7 +827,7 @@ impl LauncherApp {
                     name: "default".into(), model: String::new(),
                     api_base_url: String::new(), key_env: "GLM_API_KEY".into(),
                     api_key: String::new(), temperature: String::new(),
-                    extra_body: String::new(),
+                    extra_body: String::new(), compact_at_tokens: String::new(),
                 });
                 self.selected_profile = 0;
                 self.save_profiles();
@@ -833,7 +851,7 @@ impl LauncherApp {
                     name, key_env,
                     model: String::new(), api_base_url: String::new(),
                     api_key: String::new(), temperature: String::new(),
-                    extra_body: String::new(),
+                    extra_body: String::new(), compact_at_tokens: String::new(),
                 });
                 self.selected_profile = self.profiles.len() - 1;
                 self.save_profiles();
@@ -896,6 +914,17 @@ impl LauncherApp {
                 );
             }
             ui.horizontal(|ui| { ui.label("Temp:"); ui.text_edit_singleline(&mut p.temperature); });
+            ui.horizontal(|ui| {
+                ui.label("Compact at:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut p.compact_at_tokens)
+                        .hint_text(format!("{} (0 = off)", filar_core::DEFAULT_COMPACT_AT_TOKENS)),
+                )
+                .on_hover_text(
+                    "Prompt tokens at which the session history is compacted. \
+                     Set below the model's context window. 0 disables it.",
+                );
+            });
             ui.label("Extra body (JSON):");
             ui.add(egui::TextEdit::multiline(&mut p.extra_body)
                 .hint_text("e.g. {\"thinking\":{\"type\":\"disabled\"}}")
@@ -975,6 +1004,7 @@ impl LauncherApp {
                 key_env: d.key_env.clone(), max_tokens: 4096,
                 temperature: d.temperature.trim().parse().ok(),
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
+                compact_at_tokens: parse_compact_at_tokens(&d.compact_at_tokens),
             }).collect(),
             selected_profile: self.selected_profile,
             save_dir: self.save_dir.clone(),
@@ -1011,6 +1041,15 @@ impl LauncherApp {
             self.validation_error = format!("Invalid temperature: '{}'. Expected [0.0, 2.0].", p.temperature);
         }
         if self.validation_error.is_empty()
+            && !p.compact_at_tokens.trim().is_empty()
+            && p.compact_at_tokens.trim().parse::<u64>().is_err()
+        {
+            self.validation_error = format!(
+                "Invalid compaction threshold: '{}'. Expected a whole number of tokens (0 = off).",
+                p.compact_at_tokens
+            );
+        }
+        if self.validation_error.is_empty()
             && !p.extra_body.trim().is_empty()
             && serde_json::from_str::<serde_json::Value>(&p.extra_body).is_err()
         {
@@ -1042,6 +1081,7 @@ impl LauncherApp {
                 key_env: d.key_env.clone(), max_tokens: 4096,
                 temperature: d.temperature.trim().parse().ok(),
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
+                compact_at_tokens: parse_compact_at_tokens(&d.compact_at_tokens),
             }).collect(),
             selected_profile: self.selected_profile,
             save_dir: self.save_dir.clone(),
@@ -1074,6 +1114,7 @@ impl LauncherApp {
                 key_env: d.key_env.clone(), max_tokens: 4096,
                 temperature: d.temperature.trim().parse().ok(),
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
+                compact_at_tokens: parse_compact_at_tokens(&d.compact_at_tokens),
             }).collect(),
             ssh_targets,
             arbiter_profile: self.arbiter_profile.clone(),
@@ -1164,6 +1205,7 @@ pub fn run_launcher(config: &Config) {
                 .as_ref()
                 .map(|v| v.to_string())
                 .unwrap_or_default(),
+            compact_at_tokens: p.compact_at_tokens.to_string(),
         })
         .collect();
 
@@ -1178,6 +1220,7 @@ pub fn run_launcher(config: &Config) {
             api_key,
             temperature: settings.temperature.clone(),
             extra_body: settings.extra_body.clone(),
+            compact_at_tokens: String::new(),
         });
     }
 
@@ -1205,6 +1248,7 @@ pub fn run_launcher(config: &Config) {
                 key_env: d.key_env.clone(), max_tokens: 4096,
                 temperature: d.temperature.trim().parse().ok(),
                 top_p: None, extra_body: serde_json::from_str(&d.extra_body).ok(),
+                compact_at_tokens: parse_compact_at_tokens(&d.compact_at_tokens),
             }).collect(),
             selected_profile: settings.selected_profile.min(profiles.len().saturating_sub(1)),
             save_dir: settings.save_dir.clone(),
@@ -1412,8 +1456,66 @@ mod tests {
     }
 
     #[test]
-    fn launch_config_round_trips_arbiter_profile() {
-        let cfg = LaunchConfig {
+    fn compact_threshold_survives_the_launcher_round_trip() {
+        // The launcher edits profiles through a flat string struct, and the
+        // conversion back to `LlmProfile` is written out by hand in four
+        // places. A field that is not threaded through all of them is silently
+        // reset — which is exactly how `max_tokens` was lost (see #380).
+        let edited = LlmProfileData {
+            name: "glm".into(),
+            model: "glm-5.1".into(),
+            api_base_url: "https://example.invalid/v1".into(),
+            key_env: "GLM_API_KEY".into(),
+            api_key: String::new(),
+            temperature: String::new(),
+            extra_body: String::new(),
+            compact_at_tokens: "120000".into(),
+        };
+
+        let stored = filar_core::LlmProfile {
+            name: edited.name.clone(),
+            model: edited.model.clone(),
+            api_base_url: edited.api_base_url.clone(),
+            key_env: edited.key_env.clone(),
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+            compact_at_tokens: parse_compact_at_tokens(&edited.compact_at_tokens),
+        };
+        assert_eq!(stored.compact_at_tokens, 120_000);
+
+        // …and back into the editor, unchanged.
+        assert_eq!(stored.compact_at_tokens.to_string(), edited.compact_at_tokens);
+
+        // The value must also survive serialisation into settings.json /
+        // pending_launch.json.
+        let json = serde_json::to_string(&stored).unwrap();
+        let loaded: filar_core::LlmProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.compact_at_tokens, 120_000);
+    }
+
+    #[test]
+    fn blank_compact_threshold_falls_back_to_the_default_not_to_zero() {
+        // `0` means "compaction disabled"; an empty box must not mean that.
+        assert_eq!(
+            parse_compact_at_tokens(""),
+            filar_core::DEFAULT_COMPACT_AT_TOKENS
+        );
+        assert_eq!(
+            parse_compact_at_tokens("  "),
+            filar_core::DEFAULT_COMPACT_AT_TOKENS
+        );
+        assert_eq!(
+            parse_compact_at_tokens("nonsense"),
+            filar_core::DEFAULT_COMPACT_AT_TOKENS
+        );
+        assert_eq!(parse_compact_at_tokens("0"), 0, "an explicit 0 disables it");
+        assert_eq!(parse_compact_at_tokens(" 65536 "), 65_536);
+    }
+
+    #[test]
+    fn launch_config_round_trips_arbiter_profile() {        let cfg = LaunchConfig {
             target: "local".into(),
             ssh: None,
             model: "glm".into(),
@@ -1558,8 +1660,8 @@ mod tests {
     #[test]
     fn unique_profile_name_fills_gaps() {
         let existing = vec![
-            LlmProfileData { name: "profile-1".into(), model: String::new(), api_base_url: String::new(), key_env: String::new(), api_key: String::new(), temperature: String::new(), extra_body: String::new() },
-            LlmProfileData { name: "profile-3".into(), model: String::new(), api_base_url: String::new(), key_env: String::new(), api_key: String::new(), temperature: String::new(), extra_body: String::new() },
+            LlmProfileData { name: "profile-1".into(), model: String::new(), api_base_url: String::new(), key_env: String::new(), api_key: String::new(), temperature: String::new(), extra_body: String::new(), compact_at_tokens: String::new() },
+            LlmProfileData { name: "profile-3".into(), model: String::new(), api_base_url: String::new(), key_env: String::new(), api_key: String::new(), temperature: String::new(), extra_body: String::new(), compact_at_tokens: String::new() },
         ];
         let name = unique_profile_name(&existing, "profile");
         assert_eq!(name, "profile-2", "must find first free number, not len+1");
@@ -1575,8 +1677,8 @@ mod tests {
     #[test]
     fn deduplicate_profiles_renames_collisions() {
         let mut profiles = vec![
-            LlmProfileData { name: "dup".into(), model: String::new(), api_base_url: String::new(), key_env: "k1".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new() },
-            LlmProfileData { name: "dup".into(), model: String::new(), api_base_url: String::new(), key_env: "k2".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new() },
+            LlmProfileData { name: "dup".into(), model: String::new(), api_base_url: String::new(), key_env: "k1".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new(), compact_at_tokens: String::new() },
+            LlmProfileData { name: "dup".into(), model: String::new(), api_base_url: String::new(), key_env: "k2".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new(), compact_at_tokens: String::new() },
         ];
         deduplicate_profiles(&mut profiles);
         assert_ne!(profiles[0].name, profiles[1].name, "names must differ after dedup");
@@ -1585,9 +1687,9 @@ mod tests {
     #[test]
     fn deduplicate_three_identical_names_completes() {
         let mut profiles = vec![
-            LlmProfileData { name: "x".into(), model: String::new(), api_base_url: String::new(), key_env: "k1".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new() },
-            LlmProfileData { name: "x".into(), model: String::new(), api_base_url: String::new(), key_env: "k2".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new() },
-            LlmProfileData { name: "x".into(), model: String::new(), api_base_url: String::new(), key_env: "k3".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new() },
+            LlmProfileData { name: "x".into(), model: String::new(), api_base_url: String::new(), key_env: "k1".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new(), compact_at_tokens: String::new() },
+            LlmProfileData { name: "x".into(), model: String::new(), api_base_url: String::new(), key_env: "k2".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new(), compact_at_tokens: String::new() },
+            LlmProfileData { name: "x".into(), model: String::new(), api_base_url: String::new(), key_env: "k3".into(), api_key: String::new(), temperature: String::new(), extra_body: String::new(), compact_at_tokens: String::new() },
         ];
         deduplicate_profiles(&mut profiles);
         assert_ne!(profiles[0].name, profiles[1].name);
@@ -1647,6 +1749,7 @@ mod tests {
                 api_key: String::new(),
                 temperature: String::new(),
                 extra_body: String::new(),
+                compact_at_tokens: String::new(),
             }],
             selected_profile: 0,
             validation_error: String::new(),

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -918,11 +918,15 @@ impl LauncherApp {
                 ui.label("Compact at:");
                 ui.add(
                     egui::TextEdit::singleline(&mut p.compact_at_tokens)
-                        .hint_text(format!("{} (0 = off)", filar_core::DEFAULT_COMPACT_AT_TOKENS)),
+                        .hint_text(format!(
+                            "{} — default when empty, 0 = off",
+                            filar_core::DEFAULT_COMPACT_AT_TOKENS
+                        )),
                 )
                 .on_hover_text(
                     "Prompt tokens at which the session history is compacted. \
-                     Set below the model's context window. 0 disables it.",
+                     Set below the model's context window. Leave empty for the \
+                     default; enter 0 to disable compaction for this profile.",
                 );
             });
             ui.label("Extra body (JSON):");

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -428,6 +428,19 @@ pub struct Session {
     pub llm_profile: Option<String>,
     /// Cumulative input tokens consumed by this session.
     pub tokens_in: u64,
+    /// Prompt tokens the provider reported for the **most recent** main-loop
+    /// request.
+    ///
+    /// This is the measured size of the context that was actually sent, and it
+    /// is the only correct trigger for compaction. `tokens_in` above sums every
+    /// request in the session and would cross any threshold far too early.
+    ///
+    /// `None` until the first response carrying usage arrives — including right
+    /// after a saved session is reopened, since the figure is not persisted.
+    pub last_prompt_tokens: Option<u64>,
+    /// Whether the "context is full" notice has already been shown for the
+    /// current crossing of the threshold (reset when it drops back below).
+    pub context_full_notice_shown: bool,
     /// Cumulative output tokens generated for this session.
     pub tokens_out: u64,
     /// Cumulative cost in USD. Summed across all profiles.
@@ -760,6 +773,8 @@ impl Session {
             cwd: local_cwd(),
             llm_profile: None,
             tokens_in: 0,
+            last_prompt_tokens: None,
+            context_full_notice_shown: false,
             tokens_out: 0,
             cost_usd: None,
             per_profile: HashMap::new(),
@@ -1140,10 +1155,64 @@ impl App {
             .llm_profile
             .clone()
             .unwrap_or_else(|| self.default_profile_name.clone());
+        self.report_context_fill(&profile);
         self.mode = AppMode::Thinking;
         self.agent_running = true;
         self.pending_input = Some(input);
         self.active_session_mut().pending_llm_profile = Some(profile);
+    }
+
+    /// Compaction threshold for a profile, in prompt tokens (`0` = disabled).
+    ///
+    /// An unknown profile falls back to the built-in default so that behaviour
+    /// does not depend on whether a profile list was configured at all.
+    pub fn compact_at_tokens_for(&self, profile_name: &str) -> u64 {
+        self.profiles
+            .iter()
+            .find(|p| p.name == profile_name)
+            .map(|p| p.compact_at_tokens)
+            .unwrap_or(filar_core::DEFAULT_COMPACT_AT_TOKENS)
+    }
+
+    /// Report that the context has reached the compaction threshold.
+    ///
+    /// Called before a request is sent rather than when the response arrives,
+    /// so the user is not made to wait on anything after their answer.
+    ///
+    /// This only reports: the history is left untouched. Replacing the head
+    /// with a summary is issue #377, and until that lands the message must not
+    /// promise something that will not happen.
+    fn report_context_fill(&mut self, profile_name: &str) {
+        let threshold = self.compact_at_tokens_for(profile_name);
+        let used = self.active_session().last_prompt_tokens;
+
+        if !filar_core::should_compact(used, threshold) {
+            // Back below the threshold (a new session, or a smaller request):
+            // arm the notice again.
+            self.active_session_mut().context_full_notice_shown = false;
+            return;
+        }
+        if self.active_session().context_full_notice_shown {
+            return;
+        }
+
+        let used = used.unwrap_or(0);
+        let boundary = filar_core::compaction_boundary(
+            &self.active_session().messages,
+            filar_core::DEFAULT_KEEP_TURNS,
+        );
+        warn!(
+            profile = %profile_name,
+            last_prompt_tokens = used,
+            threshold,
+            compactable_blocks = boundary,
+            "context reached the compaction threshold"
+        );
+        self.active_session_mut().context_full_notice_shown = true;
+        self.push_message(ChatBlock::System(format!(
+            "Context is at {used} prompt tokens, at or above the {threshold} threshold \
+             for profile '{profile_name}'. History compaction is not enabled yet."
+        )));
     }
 
     /// Open the host-selection overlay. The cursor starts on the currently
@@ -3350,6 +3419,16 @@ impl App {
                         } else {
                             s.tokens_in += tokens_in;
                             s.tokens_out += tokens_out;
+                            // The size of the context that was actually sent,
+                            // kept separately from the running total above:
+                            // this is what compaction triggers on. Arbiter
+                            // usage is excluded on purpose — the arbiter sends
+                            // its own short prompt, not the session history.
+                            // A zero means the provider reported usage without
+                            // `prompt_tokens`, which tells us nothing.
+                            if tokens_in > 0 {
+                                s.last_prompt_tokens = Some(tokens_in);
+                            }
                             if let Some(c) = cost {
                                 let total = s.cost_usd.unwrap_or(0.0) + c;
                                 s.cost_usd = Some((total * 10000.0).round() / 10000.0);
@@ -7093,8 +7172,8 @@ mod tests {
     fn ctrl_l_cycles_llm_profiles() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.profiles = vec![
-            filar_core::LlmProfile { name: "glm".into(), model: "g".into(), api_base_url: "u".into(), max_tokens: 4096, key_env: "k1".into(), temperature: None, top_p: None, extra_body: None },
-            filar_core::LlmProfile { name: "ds".into(), model: "d".into(), api_base_url: "u".into(), max_tokens: 4096, key_env: "k2".into(), temperature: None, top_p: None, extra_body: None },
+            filar_core::LlmProfile { name: "glm".into(), model: "g".into(), api_base_url: "u".into(), max_tokens: 4096, key_env: "k1".into(), temperature: None, top_p: None, extra_body: None, compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS },
+            filar_core::LlmProfile { name: "ds".into(), model: "d".into(), api_base_url: "u".into(), max_tokens: 4096, key_env: "k2".into(), temperature: None, top_p: None, extra_body: None, compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS },
         ];
         app.default_profile_name = "glm".into();
 
@@ -7172,6 +7251,151 @@ mod tests {
     }
 
     #[test]
+    fn last_prompt_tokens_tracks_the_last_request_not_the_running_total() {
+        // The compaction trigger must read the size of the context that was
+        // actually sent. `tokens_in` accumulates and would cross any threshold
+        // long before the context itself does.
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let sid = app.sessions[0].id;
+        for used in [30_000u64, 45_000, 20_000] {
+            app.handle_agent_event(TuiEvent::Agent {
+                session_id: sid,
+                event: filar_agent::AgentEvent::TokenUsage {
+                    tokens_in: used, tokens_out: 100, cost: None, model: None, arbiter: false,
+                },
+            });
+        }
+        assert_eq!(app.sessions[0].tokens_in, 95_000, "the running total still accumulates");
+        assert_eq!(
+            app.sessions[0].last_prompt_tokens,
+            Some(20_000),
+            "the trigger reads the most recent request only"
+        );
+        assert!(
+            !filar_core::should_compact(app.sessions[0].last_prompt_tokens, 50_000),
+            "must not fire: the real context is 20k, not the 95k total"
+        );
+    }
+
+    #[test]
+    fn arbiter_usage_does_not_move_the_compaction_trigger() {
+        // The arbiter sends its own short prompt, not the session history.
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let sid = app.sessions[0].id;
+        app.handle_agent_event(TuiEvent::Agent {
+            session_id: sid,
+            event: filar_agent::AgentEvent::TokenUsage {
+                tokens_in: 40_000, tokens_out: 100, cost: None, model: None, arbiter: false,
+            },
+        });
+        app.handle_agent_event(TuiEvent::Agent {
+            session_id: sid,
+            event: filar_agent::AgentEvent::TokenUsage {
+                tokens_in: 800, tokens_out: 20, cost: None, model: None, arbiter: true,
+            },
+        });
+        assert_eq!(app.sessions[0].last_prompt_tokens, Some(40_000));
+        assert_eq!(app.sessions[0].arbiter_tokens_in, 800, "arbiter usage is still counted");
+    }
+
+    #[test]
+    fn usage_without_prompt_tokens_leaves_the_context_size_unknown() {
+        // A provider may report usage with no `prompt_tokens`, which arrives
+        // here as a zero. That is not a measurement of anything.
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        let sid = app.sessions[0].id;
+        app.handle_agent_event(TuiEvent::Agent {
+            session_id: sid,
+            event: filar_agent::AgentEvent::TokenUsage {
+                tokens_in: 0, tokens_out: 50, cost: None, model: None, arbiter: false,
+            },
+        });
+        assert_eq!(app.sessions[0].last_prompt_tokens, None);
+    }
+
+    #[test]
+    fn context_notice_fires_once_per_crossing_and_leaves_history_alone() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.profiles = vec![filar_core::LlmProfile {
+            name: "glm".into(), model: "g".into(), api_base_url: "u".into(),
+            max_tokens: 4096, key_env: "k".into(),
+            temperature: None, top_p: None, extra_body: None,
+            compact_at_tokens: 50_000,
+        }];
+        app.llm_profile = Some("glm".into());
+        app.default_profile_name = "glm".into();
+        app.active_session_mut().last_prompt_tokens = Some(60_000);
+
+        let before = app.active_session().messages.len();
+        app.begin_agent_request("one".into());
+        let after_first = app.active_session().messages.len();
+        assert_eq!(after_first, before + 1, "one notice is pushed");
+        assert!(matches!(
+            app.active_session().messages.last(),
+            Some(ChatBlock::System(s)) if s.contains("60000") && s.contains("50000")
+        ));
+
+        app.begin_agent_request("two".into());
+        assert_eq!(
+            app.active_session().messages.len(),
+            after_first,
+            "the notice must not repeat on every request"
+        );
+
+        // Back under the threshold: the notice is armed again.
+        app.active_session_mut().last_prompt_tokens = Some(1_000);
+        app.begin_agent_request("three".into());
+        assert!(!app.active_session().context_full_notice_shown);
+        app.active_session_mut().last_prompt_tokens = Some(60_000);
+        app.begin_agent_request("four".into());
+        assert_eq!(app.active_session().messages.len(), after_first + 1);
+    }
+
+    #[test]
+    fn zero_threshold_profile_never_reports() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.profiles = vec![filar_core::LlmProfile {
+            name: "glm".into(), model: "g".into(), api_base_url: "u".into(),
+            max_tokens: 4096, key_env: "k".into(),
+            temperature: None, top_p: None, extra_body: None,
+            compact_at_tokens: 0,
+        }];
+        app.llm_profile = Some("glm".into());
+        app.default_profile_name = "glm".into();
+        app.active_session_mut().last_prompt_tokens = Some(u64::MAX);
+
+        let before = app.active_session().messages.len();
+        app.begin_agent_request("hello".into());
+        assert_eq!(app.active_session().messages.len(), before);
+    }
+
+    #[test]
+    fn threshold_follows_the_active_profile() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.profiles = vec![
+            filar_core::LlmProfile {
+                name: "big".into(), model: "g".into(), api_base_url: "u".into(),
+                max_tokens: 4096, key_env: "k".into(),
+                temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: 900_000,
+            },
+            filar_core::LlmProfile {
+                name: "small".into(), model: "d".into(), api_base_url: "u".into(),
+                max_tokens: 4096, key_env: "k".into(),
+                temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: 100_000,
+            },
+        ];
+        assert_eq!(app.compact_at_tokens_for("big"), 900_000);
+        assert_eq!(app.compact_at_tokens_for("small"), 100_000);
+        assert_eq!(
+            app.compact_at_tokens_for("missing"),
+            filar_core::DEFAULT_COMPACT_AT_TOKENS,
+            "an unknown profile falls back to the built-in default"
+        );
+    }
+
+    #[test]
     fn begin_agent_request_sets_pending_llm_profile() {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.profiles = vec![
@@ -7179,6 +7403,7 @@ mod tests {
                 name: "glm".into(), model: "glm".into(), api_base_url: "".into(),
                 max_tokens: 1024, key_env: "K".into(),
                 temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
         ];
         app.llm_profile = Some("glm".into());
@@ -7196,11 +7421,13 @@ mod tests {
                 name: "glm".into(), model: "glm".into(), api_base_url: "".into(),
                 max_tokens: 1024, key_env: "K".into(),
                 temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
             filar_core::LlmProfile {
                 name: "ds".into(), model: "ds".into(), api_base_url: "".into(),
                 max_tokens: 1024, key_env: "K".into(),
                 temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
         ];
         // Send time: profile = glm, so pending = glm.
@@ -7541,6 +7768,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         }];
         let session = filar_core::Session {
             id: "1".into(),
@@ -7755,6 +7983,7 @@ mod tests {
             temperature: None,
             top_p: None,
             extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         }];
         app.llm_profile = Some("other".into());
         let session = filar_core::Session {

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1126,6 +1126,9 @@ impl App {
             s.per_profile = per_profile;
             s.last_served_model = last_served_model;
             s.model_per_profile = model_per_profile;
+            // Not restored on purpose — see `apply_loaded_session`.
+            s.last_prompt_tokens = None;
+            s.context_full_notice_shown = false;
         }
         let default_name = if default_profile_name.is_empty() { "default" } else { default_profile_name };
         if let Some(profile) = llm_profile {
@@ -1410,6 +1413,13 @@ impl App {
         self.per_profile = session.per_profile;
         self.last_served_model = session.last_served_model;
         self.model_per_profile = session.model_per_profile;
+        // Compaction state is measured, not saved: it describes the context of
+        // the request this tab last sent, which has nothing to do with the
+        // history just loaded. Carrying the replaced tab's values over would
+        // either report a crossing that never happened or keep a real one
+        // suppressed. The first response with usage measures it again.
+        self.last_prompt_tokens = None;
+        self.context_full_notice_shown = false;
         self.scroll = 0;
 
         // Resolve LLM profile. Reset to the default when the saved session has
@@ -7797,6 +7807,62 @@ mod tests {
         assert_eq!(app.target_name, "prod");
         assert!(app.ssh_info.is_none());
         assert!(app.pending_ssh.is_none());
+    }
+
+    #[test]
+    fn apply_loaded_session_clears_measured_context_state() {
+        // The compaction figures describe the request this tab last sent, not
+        // the history being loaded over it. Carrying them across a restore
+        // would report a crossing that never happened for the new history, or
+        // keep a real one suppressed.
+        let mut app = App::new("local".into(), CommandConfirmMode::Always);
+        app.profiles = vec![filar_core::LlmProfile {
+            name: "glm".into(),
+            model: "glm-5.1".into(),
+            api_base_url: String::new(),
+            max_tokens: 1024,
+            key_env: String::new(),
+            temperature: None,
+            top_p: None,
+            extra_body: None,
+            compact_at_tokens: 50_000,
+        }];
+        app.default_profile_name = "glm".into();
+        app.llm_profile = Some("glm".into());
+        app.active_session_mut().last_prompt_tokens = Some(250_000);
+        app.active_session_mut().context_full_notice_shown = true;
+
+        let session = filar_core::Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "prod".into(),
+            llm_profile: Some("glm".into()),
+            messages: vec![ChatBlock::User("fresh start".into())],
+            input_history: vec![],
+            tokens_in: 11,
+            tokens_out: 22,
+            cost_usd: None,
+            per_profile: HashMap::new(),
+            last_served_model: None,
+            model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
+        };
+        app.apply_loaded_session(session);
+
+        assert_eq!(app.active_session().last_prompt_tokens, None);
+        assert!(!app.active_session().context_full_notice_shown);
+
+        // And the stale figure must not produce a notice on the next request.
+        let before = app.active_session().messages.len();
+        app.begin_agent_request("hello".into());
+        assert_eq!(
+            app.active_session().messages.len(),
+            before,
+            "a restored session has no measurement yet, so nothing is reported"
+        );
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1934,6 +1934,7 @@ mod tests {
                 temperature: None,
                 top_p: None,
                 extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
             LlmProfile {
                 name: "other".into(),
@@ -1944,6 +1945,7 @@ mod tests {
                 temperature: None,
                 top_p: None,
                 extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
         ];
         // Default differs from the session's selected profile, so the test

--- a/crates/tui/src/ui/bars.rs
+++ b/crates/tui/src/ui/bars.rs
@@ -374,6 +374,7 @@ mod tests {
                 name: "glm".into(), model: "z-ai/glm-5.2".into(), api_base_url: "".into(),
                 max_tokens: 1024, key_env: "K".into(),
                 temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
         ];
         app.active_session_mut().llm_profile = Some("glm".into());
@@ -389,6 +390,7 @@ mod tests {
                 name: "glm".into(), model: "z-ai/glm-5.2".into(), api_base_url: "".into(),
                 max_tokens: 1024, key_env: "K".into(),
                 temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
         ];
         app.active_session_mut().llm_profile = Some("glm".into());
@@ -475,11 +477,13 @@ mod tests {
                 name: "glm".into(), model: "z-ai/glm-5.2".into(), api_base_url: "".into(),
                 max_tokens: 1024, key_env: "K".into(),
                 temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
             filar_core::LlmProfile {
                 name: "ds".into(), model: "deepseek-v3".into(), api_base_url: "".into(),
                 max_tokens: 1024, key_env: "K".into(),
                 temperature: None, top_p: None, extra_body: None,
+                compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
             },
         ];
         // Profile A: has served model and tokens


### PR DESCRIPTION
Closes #376

Часть 1 из 4 по спецификации автоматического сжатия контекста. Фундамент: измерение заполнения, порог, безопасная граница обрезки. Сводки здесь нет — при срабатывании только запись в лог и одна системная строка.

## Измерение

Главное в этой правке. `Session::tokens_in` суммирует все запросы сессии, и триггер по нему сработал бы кратно раньше времени, а дальше срабатывал бы постоянно. Правильный сигнал — `prompt_tokens` последнего запроса, он приходит как `tokens_in` в одном событии `AgentEvent::TokenUsage`. Хранится отдельным полем `last_prompt_tokens`, накопительные счётчики не тронуты.

События арбитра (`arbiter: true`) исключены: арбитр ходит к модели со своим коротким промптом, к размеру истории отношения не имеет. Ноль трактуется как «измерения нет», а не как пустой контекст — провайдер может вернуть usage без `prompt_tokens`.

Проверка выполняется в `begin_agent_request`, единственной точке перед отправкой запроса. Решать после получения ответа значило бы заставлять пользователя ждать чего-то уже после его ответа.

## Граница обрезки и поправка к спецификации

Обе решающие функции — `should_compact` и `compaction_boundary` — вынесены в новый модуль `filar_core::compaction`, без I/O и без типов TUI, поэтому проверяются напрямую.

Граница всегда встаёт на блок `User`. Ход — это пользовательское сообщение плюс всё, что на него отвечает; срез внутри хода оставил бы в хвосте команды, чей запрос уже свёрнут, и их `Command:`/`Output:` читались бы так, будто агент выполнил их сам по себе.

Спецификация формулировала это через осиротевший `tool_call_id`. К текущему коду неприменимо: TUI хранит историю как `Vec<ChatBlock>` и в `runner.rs` схлопывает `ChatBlock::Command` в обычное assistant-сообщение — сообщений роли `tool` в том, что уходит провайдеру, нет вообще, они живут только внутри одного вызова `run_loop`. Исходное требование записано в doc-комментарии функции на случай, если представление истории когда-нибудь изменится.

## Проводка конфига

`LlmProfile::compact_at_tokens` (дефолт 200000, `0` выключает) проведён через все ручные конверсии. В лаунчере это **четыре** отдельные точки `LlmProfileData` → `LlmProfile`, плюс обратное направление, создание профиля по умолчанию, обе кнопки добавления и тестовые литералы. Поле добавлено в редактор моделей с подсказкой и валидацией.

`parse_compact_at_tokens` на пустое поле возвращает дефолт, а не `0`: ноль означает «сжатие выключено», и молча выключать фичу из-за незаполненной формы — неправильное поведение по умолчанию.

Это тот же класс дефекта, что и #380, где `max_tokens` и `top_p` теряются при каждом сохранении из лаунчера. Тест на круг «сохранить → прочитать» добавлен именно затем, чтобы новое поле не ушло тем же путём.

## Что осознанно не сделано

- **`last_prompt_tokens` не сохраняется в JSON сессии.** После открытия сохранённой сессии порог молчит до первого ответа. Сохранение означало бы правку формата сессии — это территория #379, а сам пробел закрывает реактивный путь из #378. Если хотите иначе, скажите: перенести несложно.
- **`keep_turns` — константа, а не настройка.** До #377 её никто не потребляет, а второй параметр конфига потребовал бы второго круга проводки выше без сегодняшней пользы.
- Сводка, промпт, ручной запуск — #377. Реактивный путь и отказы — #378. Расшифровка, сессии, `Ctrl+L` — #379.

## Не проверено в окружении агента

**Сборка и тесты не запускались — в контейнере нет Rust-тулчейна** (rustup закрыт сетевой политикой, в apt Rust 1.75 при `rust-version = "1.85"`).

Отдельно предупреждаю: поле пришлось вставлять в 28 литералов `LlmProfile` по всему воркспейсу, и часть вставок делалась скриптом. Одна вышла битой — в `make_profile` в `crates/app/src/main.rs` поле улетело за закрывающую скобку; найдено и исправлено, отступы выровнены вручную. Компилятор такие вещи ловит мгновенно, но раз я его не запускал, первый прогон CI здесь ценнее обычного.

Тесты: 9 юнит-тестов на чистые функции в `filar_core::compaction`, 6 в TUI (источник триггера, исключение арбитра, нулевой usage, одно уведомление на пересечение, выключенный профиль, порог по активному профилю), 2 в GUI на круг конфига. Тесты на измерение и на границу **падают на старом коде** — старого кода для них попросту нет, обе функции новые, а тест `last_prompt_tokens_tracks_the_last_request_not_the_running_total` проверяет ровно ту подмену, о которой предупреждает спецификация.

## Ручная проверка

Автотестами не закрывается, нужна на собранном бинарнике:

- Профиль с низким порогом (например 5000), разговор с несколькими командами: при пересечении в ленте появляется ровно одна системная строка с текущим и пороговым значением, история не меняется, работа продолжается.
- Порог `0` — строка не появляется никогда.
- Поле «Compact at» в лаунчере: ввод сохраняется, при повторном открытии показывается, мусорный ввод блокируется валидацией до Launch.
- Профиль с непустым порогом в `config.toml` доезжает до TUI через `pending_launch.json` без сброса.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-profile context-fill tracking using the provider’s latest prompt-token count.
  * Added a configurable threshold, defaulting to 200,000 tokens; set it to `0` to disable notices.
  * Added a one-time session notice when the threshold is reached. Conversation history is not yet compacted.
  * Added support for editing, validating, and saving the setting in profile configuration.

* **Documentation**
  * Documented context-fill tracking, threshold behavior, token measurement, and notice-only handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->