### PR TITLE
feat(tui): fold the head of a long history into a summary (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   the feed, and the summarisation itself follows in a later change
   ([#376](https://github.com/devlawey/filar/issues/376)).
 
+- The TUI now compacts a long history instead of only warning about it: the head
+  is folded into a single summary and the last turns are kept verbatim. The feed
+  shows a line before and after, and the summary stays there as a collapsed block
+  you can expand. `Ctrl+K` compacts on request, regardless of the threshold
+  ([#377](https://github.com/devlawey/filar/issues/377)).
+
 ### Fixed
 
 - The GUI launcher no longer resets a profile's `max_tokens` to 4096 and drops

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5446,9 +5446,25 @@ This change is far larger than #380 and touches an enum matched on in several
 places plus the signature of `spawn_agent`; CI is the first real check. The
 manual DoD run and the eval run belong to the PR.
 
+**Review (PR #384).** Two findings fixed. The notice flag doubled as the
+compaction trigger, so a compaction that did not bring the context back under
+the threshold — a large tail, a long summary — would have been the last one of
+the session; `apply_compaction` now re-arms it. And a summary that arrived after
+a cancel or a session restore could be cut into a history it was not made from,
+silently dropping turns; the result is now applied only when it matches what the
+session is still waiting for, and cancel and restore both clear that.
+
+Declined: threading the summarising call's own token usage into the session and
+`per_profile` accounting. Real — the reported cost is currently short by the
+summary — but it is a change to the accounting path #376 built, and it belongs
+with the cheap-profile option, where correct attribution stops being optional.
+Separate issue. Also declined: a request to run the build, tests, eval and
+SMOKE checklist before merging, which restates the DoD rather than finding
+anything; CI covers the first three, the rest is the human's.
+
 **Next steps:** #378 (reactive path when the provider refuses outright, and
 handling a refused summary), #379 (persistence and profile switching). The
-cheap-profile summariser is an open optimisation.
+cheap-profile summariser and the usage accounting above are open.
 
 ## Issue #380: fix(gui) — the launcher reset `max_tokens` and `top_p` on every save
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5385,6 +5385,71 @@ on its own PR. `eval/README.md` updated.
 changes went unverified. If it is, triage the failures as a separate issue and
 **do not lower the 90% threshold** to make it pass.
 
+## Issue #377: feat(tui) — folding the head of the history into a summary
+
+**Milestone:** 1.0.6. **Branch:** `feat/377-history-summary`. Part 2 of 4 of the
+context-compaction spec, on top of #376; #378 and #379 build on it.
+
+**Where the summary lives, and why.** The issue left this open. It is a new
+`ChatBlock::Summary { text, replaced_blocks }` in `filar-core`, not an injection
+at the point the history is flattened into `ChatMessage`s. The summary has to be
+visible and auditable in the feed — compaction that the user cannot inspect is
+compaction they cannot trust — and injection leaves no block to render. It also
+gives #379 something concrete to persist. Backward compatibility runs the way
+that matters: old session files simply do not contain the variant, and a test
+pins that they still load.
+
+**The trap from the issue.** `ChatBlock::System` is dropped when the history is
+built for the model, so a summary stored as a system block would never reach it
+and compaction would be a silent loss of the whole head. The flattening was
+extracted out of `spawn_agent` into `history_to_messages` for exactly this
+reason: whether a block reaches the model is a correctness property and now has
+a test, rather than being a detail buried in a spawned task.
+
+**Where the summarising call runs.** Inside the agent task, before the agent is
+built, rather than in a separate orchestration path. `app.rs` is synchronous and
+the LLM client lives in the runner; a second async path would have meant a second
+state machine for the same wait, and the spinner is already up. The result comes
+back as `TuiEvent::HistoryCompacted` and is applied to the session it belongs to,
+which may no longer be the active tab.
+
+**Model.** The session's own profile. The optional cheap-profile optimisation
+from the issue is deliberately skipped: it requires attributing the usage to the
+profile that actually computed rather than the current one, and that is a real
+risk to `per_profile` accounting in a change that already adds a system prompt
+and an enum variant. Worth doing separately.
+
+**Failure is not the user's problem.** If the summary call fails, the history is
+left untouched and the turn still goes out on the full history, with a line in
+the feed. Recovering from an outright context overflow is #378.
+
+**Manual trigger.** `Ctrl+K` (ЙЦУКЕН: `Ctrl+Л`), independent of
+`compact_at_tokens` — including `0`. It refuses while the agent is working, and
+says so rather than queueing.
+
+**Done:** 5 tests in `filar-core` (head replaced by one summary, tail byte-for-
+byte identical, no-op when there is nothing to compact, summaries fold rather
+than stack, transcript keeps command outcomes but not feed chrome), 2 in
+`filar-agent` on the prompt, 2 in the runner (the summary reaches the model,
+system lines do not), and 6 in `app.rs` (manual trigger with the threshold
+disabled, short history, refusal while running, applying a summary, failure
+path, stale boundary).
+
+**Public contract:** `filar-core` gains the `ChatBlock::Summary` variant plus
+`compact_history` and `transcript_for_summary`; `filar-agent` gains
+`summarise_history` and `COMPACTION_SYSTEM_PROMPT`. Additive, but a new enum
+variant means embedders matching exhaustively on `ChatBlock` must add an arm —
+worth a line in `docs/ENGINE_API.md` when the next engine tag is cut.
+
+**Not verified by the agent:** no Rust toolchain, so nothing was compiled or run.
+This change is far larger than #380 and touches an enum matched on in several
+places plus the signature of `spawn_agent`; CI is the first real check. The
+manual DoD run and the eval run belong to the PR.
+
+**Next steps:** #378 (reactive path when the provider refuses outright, and
+handling a refused summary), #379 (persistence and profile switching). The
+cheap-profile summariser is an open optimisation.
+
 ## Issue #380: fix(gui) — the launcher reset `max_tokens` and `top_p` on every save
 
 **Milestone:** 1.0.6. **Branch:** `fix/380-launcher-profile-fields`. Found while

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ api_base_url = "https://api.deepseek.com/v1"
 max_tokens = 8192
 key_env = "DEEPSEEK_API_KEY"
 # Prompt tokens at which the context is considered full. Per-profile, because
-# context windows differ. Currently this only logs and shows a notice — history
-# compaction is not implemented yet. 0 turns the notice off.
+# context windows differ. Reaching it folds the earlier part of the history into
+# a summary. 0 disables automatic compaction (Ctrl+K still works).
 compact_at_tokens = 200000
 
 #### Context fill
@@ -203,10 +203,25 @@ history is re-sent with every request, so each turn costs more than the last
 until the provider refuses outright. `compact_at_tokens` marks the point at
 which that becomes a problem.
 
-**Today this only reports.** Reaching the threshold writes a warning to the log
-and adds one notice to the session feed; the history is left untouched. Folding
-the earlier part of the conversation into a summary is not implemented yet, so
-do not rely on this setting to keep a session under the window.
+Reaching the threshold folds the head of the history into a single summary and
+keeps the last few turns verbatim. Nothing about this is silent: the feed gets a
+line before ("compacting the first N blocks") and one after ("N blocks to M"),
+and the summary itself stays in the feed as a collapsed block you can expand and
+audit. The summary is produced by the session's own profile, so its cost lands
+where you would expect.
+
+What the summary is asked to keep, in order: commands already executed and what
+they did, established facts about the system, the current hypothesis, and any
+constraints you stated. Executed commands come first for a reason — the failure
+that matters is an agent re-running a destructive action it no longer remembers
+performing.
+
+`Ctrl+K` compacts on your own initiative, without waiting for the threshold —
+useful before moving to a new phase of work. It ignores `compact_at_tokens`
+entirely, so it still works when automatic compaction is off.
+
+If the summary request fails, the history is left alone and your turn still goes
+out on the full history; the feed says so.
 
 The threshold is per-profile because context windows differ — a figure that
 suits a 1M-token model is meaningless for a 128k one. Set it comfortably below
@@ -409,6 +424,7 @@ Type `!` followed by a command to run it directly (bypassing the agent):
 | `Ctrl+N` | New local session tab (always local, never inherits another tab's SSH) |
 | `Ctrl+W` | Close active session tab |
 | `Ctrl+L` | Cycle LLM profile for this tab (different model per tab) |
+| `Ctrl+K` | Compact history now — fold earlier turns into a summary |
 | `Ctrl+O` | Open host-selection overlay (local + configured `[[ssh_targets]]`) |
 | `Ctrl+V` | Paste from system clipboard (also via bracketed paste) |
 | `Ctrl+P` | Enter password input mode (masked) |

--- a/config.toml
+++ b/config.toml
@@ -20,8 +20,9 @@ max_tokens = 4096
 # key_env = "GLM_API_KEY"
 # max_tokens = 4096
 # # Prompt tokens at which the context is considered full. Set it below the
-# # model's context window. Currently this only logs and shows a notice in the
-# # session feed — history compaction is not implemented yet. 0 turns it off.
+# # model's context window. Reaching it folds the earlier part of the history
+# # into a summary and keeps the last turns verbatim. 0 disables automatic
+# # compaction; Ctrl+K still compacts on request.
 # compact_at_tokens = 200000
 
 [timeouts]

--- a/crates/agent/src/compaction.rs
+++ b/crates/agent/src/compaction.rs
@@ -1,0 +1,85 @@
+//! Summarising the head of a session so the conversation can continue in a
+//! smaller context window (issue #377).
+//!
+//! The decision of *when* to compact and *where* to cut lives in
+//! `filar_core::compaction`; this module only turns a transcript into a brief.
+//! It is a single, self-contained LLM call with no tools: the summariser must
+//! not be able to run anything on the host.
+
+use crate::{ChatMessage, ChatRequest, LlmClient, MessageRole};
+use filar_core::{CoreError, Result};
+
+/// System prompt for the summarising call.
+///
+/// The ordering is not cosmetic. Executed commands come first because the
+/// failure that matters most is an agent re-running a destructive action it no
+/// longer remembers performing; everything else degrades more gracefully.
+///
+/// Any change here is a change to a system prompt and requires an eval run —
+/// see `AGENTS.md` and `docs/EVAL_METHODOLOGY.md`.
+pub const COMPACTION_SYSTEM_PROMPT: &str = "\
+You are compacting a system-administration session so it can continue within a smaller
+context window. Produce a compact brief, not a narrative.
+
+Preserve, in this order:
+1. Commands already executed and their outcome — especially anything that changed state.
+   The reader must never repeat a destructive action because it was omitted here.
+2. Established facts about the system: versions, paths, service names, what was checked
+   and ruled out.
+3. The current hypothesis and what remains to be verified.
+4. Constraints and preferences the user stated.
+
+Drop: full command output, reasoning, repetition, pleasantries.
+Do not speculate or add anything that is not in the transcript.
+Write in the language the session is conducted in.";
+
+/// Ask the model to summarise `transcript`.
+///
+/// Returns the brief that will replace the compacted head. The call carries no
+/// tool definitions, so the summariser cannot propose commands, and it is a
+/// plain [`LlmClient::chat`] rather than a streaming call: nothing renders the
+/// partial text, and the caller only needs the finished brief.
+///
+/// An empty reply is reported as an error rather than silently accepted —
+/// replacing the head with an empty summary would lose it outright.
+pub async fn summarise_history(llm: &dyn LlmClient, transcript: &str) -> Result<String> {
+    let request = ChatRequest {
+        messages: vec![
+            ChatMessage::new(MessageRole::System, COMPACTION_SYSTEM_PROMPT),
+            ChatMessage::new(MessageRole::User, transcript),
+        ],
+        tools: Vec::new(),
+    };
+
+    let response = llm.chat(&request).await?;
+    let text = response.text.trim().to_string();
+    if text.is_empty() {
+        return Err(CoreError::Other(
+            "the model returned an empty summary".into(),
+        ));
+    }
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_prompt_states_the_four_things_to_preserve_in_order() {
+        // The order is load-bearing: executed commands first. A reordering here
+        // is a behavioural change and should fail this test rather than pass
+        // review unnoticed.
+        let p = COMPACTION_SYSTEM_PROMPT;
+        let commands = p.find("Commands already executed").expect("commands");
+        let facts = p.find("Established facts").expect("facts");
+        let hypothesis = p.find("current hypothesis").expect("hypothesis");
+        let constraints = p.find("Constraints and preferences").expect("constraints");
+        assert!(commands < facts && facts < hypothesis && hypothesis < constraints);
+    }
+
+    #[test]
+    fn the_prompt_forbids_inventing_content() {
+        assert!(COMPACTION_SYSTEM_PROMPT.contains("Do not speculate"));
+    }
+}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod agent;
 pub mod arbiter;
 pub mod background;
+pub mod compaction;
 pub mod events;
 pub mod long_wait;
 pub mod openai_compat;
@@ -19,6 +20,7 @@ pub mod tools;
 // Re-export key types for convenience.
 pub use agent::{Agent, AgentBuilder};
 pub use arbiter::{ArbiterContext, ArbiterVerdict, ARBITER_TIMEOUT_SECS};
+pub use compaction::{summarise_history, COMPACTION_SYSTEM_PROMPT};
 pub use events::{AgentEvent, EventSink};
 pub use openai_compat::OpenAiCompatClient;
 pub use security::{CliConfirmer, CommandConfirmer, ConfirmDecision};

--- a/crates/core/src/chat.rs
+++ b/crates/core/src/chat.rs
@@ -25,6 +25,18 @@ pub enum ChatBlock {
     Error(String),
     /// A system message (e.g. "agent started").
     System(String),
+    /// A summary that replaced the compacted head of the history (#377).
+    ///
+    /// Unlike [`ChatBlock::System`], this block **is** sent to the model: it
+    /// stands in for the turns it replaced, and dropping it would make
+    /// compaction a silent loss of the whole beginning of the conversation.
+    ///
+    /// `replaced_blocks` is how many blocks were folded into it, used for the
+    /// feed line and for diagnostics.
+    Summary {
+        text: String,
+        replaced_blocks: usize,
+    },
 }
 
 impl ChatBlock {
@@ -36,6 +48,9 @@ impl ChatBlock {
             ChatBlock::Command { command, .. } => format!("$ {}", truncate(command, 60)),
             ChatBlock::Error(s) => format!("Error: {}", truncate(s, 60)),
             ChatBlock::System(s) => truncate(s, 60),
+            ChatBlock::Summary { replaced_blocks, .. } => {
+                format!("Summary of {replaced_blocks} earlier blocks")
+            }
         }
     }
 }
@@ -74,6 +89,28 @@ mod tests {
         assert_eq!(blocks.len(), decoded.len());
         assert!(matches!(&decoded[0], ChatBlock::User(s) if s == "hello"));
         assert!(matches!(&decoded[2], ChatBlock::Command { command, .. } if command == "ls -la"));
+    }
+
+    #[test]
+    fn summary_block_roundtrip_and_preview() {
+        let block = ChatBlock::Summary {
+            text: "Restarted nginx, still 502.".into(),
+            replaced_blocks: 12,
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        let decoded: ChatBlock = serde_json::from_str(&json).unwrap();
+        assert!(matches!(decoded, ChatBlock::Summary { replaced_blocks, .. } if replaced_blocks == 12));
+        assert_eq!(block.preview(), "Summary of 12 earlier blocks");
+    }
+
+    #[test]
+    fn session_files_written_before_the_summary_variant_still_load() {
+        // Adding an enum variant must not break history written by an earlier
+        // build: those files simply never contain it.
+        let old = r#"[{"User":"hello"},{"Agent":"hi"},{"System":"connected"}]"#;
+        let decoded: Vec<ChatBlock> = serde_json::from_str(old).unwrap();
+        assert_eq!(decoded.len(), 3);
+        assert!(matches!(&decoded[0], ChatBlock::User(s) if s == "hello"));
     }
 
     #[test]

--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -73,6 +73,66 @@ pub fn compaction_boundary(blocks: &[ChatBlock], keep_turns: usize) -> usize {
     turn_starts[turn_starts.len() - keep_turns]
 }
 
+/// Replace the head of `blocks` with a single summary block.
+///
+/// Everything from `boundary` onward is kept byte for byte: the tail is what
+/// the model still needs verbatim, and paraphrasing it is exactly the loss
+/// compaction is meant to avoid. `boundary` is expected to come from
+/// [`compaction_boundary`].
+///
+/// A `boundary` of `0` (nothing to compact) returns the history unchanged, so
+/// the caller does not have to special-case a short conversation. Any earlier
+/// summary in the head is folded into the new one along with everything else —
+/// summaries compound rather than accumulate.
+pub fn compact_history(blocks: &[ChatBlock], boundary: usize, summary: &str) -> Vec<ChatBlock> {
+    if boundary == 0 || boundary > blocks.len() {
+        return blocks.to_vec();
+    }
+
+    let mut out = Vec::with_capacity(blocks.len() - boundary + 1);
+    out.push(ChatBlock::Summary {
+        text: summary.to_string(),
+        replaced_blocks: boundary,
+    });
+    out.extend_from_slice(&blocks[boundary..]);
+    out
+}
+
+/// The transcript handed to the summarising model, as plain text.
+///
+/// Command output is included: what a command actually printed is the evidence
+/// the summary has to preserve. The caller decides how much of the history to
+/// pass — normally the head being replaced.
+pub fn transcript_for_summary(blocks: &[ChatBlock]) -> String {
+    let mut out = String::new();
+    for block in blocks {
+        match block {
+            ChatBlock::User(text) => out.push_str(&format!("User: {text}\n")),
+            ChatBlock::Agent(text) => out.push_str(&format!("Agent: {text}\n")),
+            ChatBlock::Command {
+                command,
+                output,
+                approved,
+                ..
+            } => {
+                let outcome = match (approved, output) {
+                    (false, _) => "(denied by user)".to_string(),
+                    (true, None) => "(no output)".to_string(),
+                    (true, Some(o)) => o.clone(),
+                };
+                out.push_str(&format!("Command: {command}\nOutput: {outcome}\n"));
+            }
+            ChatBlock::Error(text) => out.push_str(&format!("Error: {text}\n")),
+            // Feed-only chrome: never part of what the model was told.
+            ChatBlock::System(_) => {}
+            ChatBlock::Summary { text, .. } => {
+                out.push_str(&format!("Summary of earlier turns: {text}\n"))
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,6 +153,101 @@ mod tests {
     }
     fn system(s: &str) -> ChatBlock {
         ChatBlock::System(s.into())
+    }
+
+    #[test]
+    fn compaction_replaces_the_head_and_keeps_the_tail_byte_for_byte() {
+        let blocks = vec![
+            user("first"),
+            agent("a1"),
+            command("systemctl restart nginx"),
+            user("second"),
+            agent("a2"),
+            user("third"),
+            agent("a3"),
+        ];
+        let boundary = compaction_boundary(&blocks, 2);
+        assert_eq!(boundary, 3, "tail starts at the third user turn");
+
+        let compacted = compact_history(&blocks, boundary, "restarted nginx, still 502");
+
+        // One summary in place of the whole head…
+        assert_eq!(compacted.len(), 1 + (blocks.len() - boundary));
+        match &compacted[0] {
+            ChatBlock::Summary {
+                text,
+                replaced_blocks,
+            } => {
+                assert_eq!(text, "restarted nginx, still 502");
+                assert_eq!(*replaced_blocks, 3);
+            }
+            other => panic!("expected a summary, got {other:?}"),
+        }
+
+        // …and the tail unchanged, block for block.
+        let original_tail = serde_json::to_string(&blocks[boundary..]).unwrap();
+        let kept_tail = serde_json::to_string(&compacted[1..]).unwrap();
+        assert_eq!(kept_tail, original_tail, "the tail must not be rewritten");
+    }
+
+    #[test]
+    fn compaction_with_nothing_to_compact_is_a_no_op() {
+        let blocks = vec![user("only"), agent("turn")];
+        let before = serde_json::to_string(&blocks).unwrap();
+        let after = serde_json::to_string(&compact_history(&blocks, 0, "unused")).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn compacting_twice_folds_the_earlier_summary_in_rather_than_stacking() {
+        let blocks = vec![
+            ChatBlock::Summary {
+                text: "first summary".into(),
+                replaced_blocks: 4,
+            },
+            user("second"),
+            agent("a2"),
+            user("third"),
+            agent("a3"),
+        ];
+        let compacted = compact_history(&blocks, 3, "second summary");
+        assert_eq!(
+            compacted
+                .iter()
+                .filter(|b| matches!(b, ChatBlock::Summary { .. }))
+                .count(),
+            1,
+            "summaries must not accumulate"
+        );
+    }
+
+    #[test]
+    fn the_transcript_carries_commands_and_their_output_but_not_feed_chrome() {
+        let blocks = vec![
+            user("why is it 502"),
+            command("systemctl restart nginx"),
+            system("context is filling up"),
+        ];
+        let text = transcript_for_summary(&blocks);
+        assert!(text.contains("why is it 502"));
+        assert!(text.contains("Command: systemctl restart nginx"));
+        assert!(text.contains("Output: ok"), "outcome is the evidence");
+        assert!(
+            !text.contains("context is filling up"),
+            "feed-only system lines were never sent to the model"
+        );
+    }
+
+    #[test]
+    fn a_denied_command_reads_as_denied_not_as_executed() {
+        let blocks = vec![ChatBlock::Command {
+            command: "rm -rf /var/log".into(),
+            explanation: String::new(),
+            output: None,
+            approved: false,
+        }];
+        let text = transcript_for_summary(&blocks);
+        assert!(text.contains("(denied by user)"));
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,7 +13,10 @@ pub mod secrets;
 pub mod session;
 
 pub use chat::ChatBlock;
-pub use compaction::{compaction_boundary, should_compact, DEFAULT_KEEP_TURNS};
+pub use compaction::{
+    compact_history, compaction_boundary, should_compact, transcript_for_summary,
+    DEFAULT_KEEP_TURNS,
+};
 pub use config::{
     Config, SshTarget, SshAuth, LlmConfig, LlmProfile, CommandConfirmMode, TimeoutConfig,
     HostKeyPolicy, DEFAULT_COMMAND_TIMEOUT_SECS, DEFAULT_COMPACT_AT_TOKENS,

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -3418,6 +3418,7 @@ impl App {
             TuiEvent::TransportChanged { session_id, .. } => *session_id,
             TuiEvent::CwdChanged { session_id, .. } => *session_id,
             TuiEvent::PasswordNeeded { session_id, .. } => *session_id,
+            TuiEvent::HistoryCompacted { session_id, .. } => *session_id,
         };
 
         // Dispatch to the originating session. Save the active index so we can
@@ -3632,6 +3633,13 @@ impl App {
                 self.mode = AppMode::PasswordInput;
                 self.agent_running = false;
             }
+            // Dispatch above already switched to the originating session, so
+            // a summary that arrives while the user is on another tab still
+            // lands on the history it was made from (#377).
+            TuiEvent::HistoryCompacted { boundary, summary, .. } => match summary {
+                Ok(text) => self.apply_compaction(boundary, text),
+                Err(e) => self.report_compaction_failure(e),
+            },
         }
         // Auto-scroll to bottom on new content (unless user scrolled up during streaming).
         if auto_scroll {

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1286,6 +1286,16 @@ impl App {
     /// `boundary` is echoed back from the request so a history that changed
     /// while the summary was being produced cannot be cut at a stale index.
     pub fn apply_compaction(&mut self, boundary: usize, summary: String) {
+        // The history may have moved while the summary was being produced: the
+        // user can cancel the run or restore a saved session, and cutting the
+        // result into a history it was not made from would silently lose turns.
+        // `pending_compaction` is the session's own record of what it is
+        // waiting for, and every path that replaces a history clears it.
+        if self.active_session().pending_compaction != Some(boundary) {
+            tracing::debug!(boundary, "discarding a stale compaction result");
+            return;
+        }
+
         let before = self.active_session().messages.len();
         if boundary == 0 || boundary > before {
             self.active_session_mut().pending_compaction = None;
@@ -1300,6 +1310,11 @@ impl App {
         let after = compacted.len();
         self.active_session_mut().messages = compacted;
         self.active_session_mut().pending_compaction = None;
+        // Re-arm the threshold. The flag records that the notice was shown for
+        // one crossing; leaving it set after a compaction that did not bring
+        // the context back under the threshold — a large tail, a long summary —
+        // would mean compaction never fires again for the rest of the session.
+        self.active_session_mut().context_full_notice_shown = false;
         // Block indices moved, so any user collapse overrides now point at the
         // wrong blocks.
         self.collapsed_overrides.clear();
@@ -1503,6 +1518,10 @@ impl App {
 
         self.messages = session.messages;
         self.message_rev = self.message_rev.wrapping_add(1);
+        // A summary still in flight was made from the history this just
+        // replaced, so it must not be applied to the restored one (#377).
+        self.active_session_mut().pending_compaction = None;
+        self.active_session_mut().context_full_notice_shown = false;
         self.push_message(ChatBlock::System(
             "Session restored — history loaded from disk".into(),
         ));
@@ -1695,6 +1714,10 @@ impl App {
                 self.cancellation = None;
                 self.agent_running = false;
                 self.pending_input = None;
+                // A summary may still be in flight for this run; the user has
+                // just asked for the run to stop, so its result is discarded
+                // rather than applied to a history they may now edit (#377).
+                self.active_session_mut().pending_compaction = None;
                 self.pending_ssh = None;
                 self.pending_ssh_password = None;
                 self.mode = AppMode::Normal;
@@ -7553,6 +7576,7 @@ mod tests {
         let before = app.active_session().messages.clone();
         let boundary = filar_core::compaction_boundary(&before, filar_core::DEFAULT_KEEP_TURNS);
         assert!(boundary > 0, "fixture must have something to compact");
+        app.active_session_mut().pending_compaction = Some(boundary);
 
         app.apply_compaction(boundary, "earlier turns, briefly".into());
 
@@ -7601,11 +7625,70 @@ mod tests {
         let mut app = App::new("test".into(), CommandConfirmMode::Always);
         app.push_message(ChatBlock::User("one".into()));
         let before = app.active_session().messages.len();
+        app.active_session_mut().pending_compaction = Some(99);
 
         app.apply_compaction(99, "summary of a history that no longer exists".into());
 
         assert_eq!(app.active_session().messages.len(), before);
         assert_eq!(app.active_session().pending_compaction, None);
+    }
+
+    #[test]
+    fn a_summary_that_arrives_after_a_cancel_is_discarded() {
+        // The user pressed Ctrl+C while the summary was being produced, or
+        // restored a session: the result was made from a history that is no
+        // longer there, and applying it would silently drop turns.
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        for i in 0..8 {
+            app.push_message(ChatBlock::User(format!("q{i}")));
+            app.push_message(ChatBlock::Agent(format!("a{i}")));
+        }
+        let boundary = filar_core::compaction_boundary(
+            &app.active_session().messages,
+            filar_core::DEFAULT_KEEP_TURNS,
+        );
+        app.active_session_mut().pending_compaction = Some(boundary);
+        // Cancellation clears what the session is waiting for.
+        app.active_session_mut().pending_compaction = None;
+        let before = app.active_session().messages.len();
+
+        app.apply_compaction(boundary, "summary of a cancelled run".into());
+
+        assert_eq!(
+            app.active_session().messages.len(),
+            before,
+            "a result nobody is waiting for must not touch the history"
+        );
+        assert!(!app
+            .active_session()
+            .messages
+            .iter()
+            .any(|m| matches!(m, ChatBlock::Summary { .. })));
+    }
+
+    #[test]
+    fn compaction_rearms_the_threshold_for_the_next_crossing() {
+        // The notice flag records one crossing. If a compaction that failed to
+        // bring the context back under the threshold left it set, compaction
+        // would never fire again for the rest of the session.
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        for i in 0..8 {
+            app.push_message(ChatBlock::User(format!("q{i}")));
+            app.push_message(ChatBlock::Agent(format!("a{i}")));
+        }
+        let boundary = filar_core::compaction_boundary(
+            &app.active_session().messages,
+            filar_core::DEFAULT_KEEP_TURNS,
+        );
+        app.active_session_mut().pending_compaction = Some(boundary);
+        app.active_session_mut().context_full_notice_shown = true;
+
+        app.apply_compaction(boundary, "brief".into());
+
+        assert!(
+            !app.active_session().context_full_notice_shown,
+            "the next crossing must be able to arm compaction again"
+        );
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -7566,8 +7566,9 @@ mod tests {
         let kept = &after[1..after.len() - 1];
         let original_tail = &before[boundary..];
         assert_eq!(
-            serde_json::to_string(kept).unwrap(),
-            serde_json::to_string(original_tail).unwrap()
+            format!("{kept:?}"),
+            format!("{original_tail:?}"),
+            "the tail must not be rewritten"
         );
         assert_eq!(app.active_session().pending_compaction, None);
     }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -441,6 +441,10 @@ pub struct Session {
     /// Whether the "context is full" notice has already been shown for the
     /// current crossing of the threshold (reset when it drops back below).
     pub context_full_notice_shown: bool,
+    /// Set when the history should be compacted before the next request, to
+    /// the boundary index the head ends at. The runner performs the summary
+    /// and hands it back; `None` means no compaction is due (#377).
+    pub pending_compaction: Option<usize>,
     /// Cumulative output tokens generated for this session.
     pub tokens_out: u64,
     /// Cumulative cost in USD. Summed across all profiles.
@@ -775,6 +779,7 @@ impl Session {
             tokens_in: 0,
             last_prompt_tokens: None,
             context_full_notice_shown: false,
+            pending_compaction: None,
             tokens_out: 0,
             cost_usd: None,
             per_profile: HashMap::new(),
@@ -1086,6 +1091,14 @@ fn messages_to_markdown(messages: &[ChatBlock], session_name: &str, ssh_info: &O
             ChatBlock::System(s) => {
                 md.push_str(&format!("*{s}*\n\n"));
             }
+            ChatBlock::Summary {
+                text,
+                replaced_blocks,
+            } => {
+                md.push_str(&format!(
+                    "**Summary of {replaced_blocks} earlier blocks:**\n\n{text}\n\n"
+                ));
+            }
         }
     }
     md
@@ -1129,6 +1142,7 @@ impl App {
             // Not restored on purpose — see `apply_loaded_session`.
             s.last_prompt_tokens = None;
             s.context_full_notice_shown = false;
+            s.pending_compaction = None;
         }
         let default_name = if default_profile_name.is_empty() { "default" } else { default_profile_name };
         if let Some(profile) = llm_profile {
@@ -1177,14 +1191,16 @@ impl App {
             .unwrap_or(filar_core::DEFAULT_COMPACT_AT_TOKENS)
     }
 
-    /// Report that the context has reached the compaction threshold.
+    /// Decide whether the history should be compacted before this request, and
+    /// announce it in the feed.
     ///
-    /// Called before a request is sent rather than when the response arrives,
-    /// so the user is not made to wait on anything after their answer.
+    /// Called before the request is sent rather than when the response
+    /// arrives, so the user is not made to wait on anything after their
+    /// answer. The decision is recorded in `pending_compaction`; the summary
+    /// itself is produced by the runner, which is where the LLM client lives.
     ///
-    /// This only reports: the history is left untouched. Replacing the head
-    /// with a summary is issue #377, and until that lands the message must not
-    /// promise something that will not happen.
+    /// Compaction must never be silent: the user has to be able to tell why
+    /// the agent stopped remembering the beginning of the conversation.
     fn report_context_fill(&mut self, profile_name: &str) {
         let threshold = self.compact_at_tokens_for(profile_name);
         let used = self.active_session().last_prompt_tokens;
@@ -1212,9 +1228,94 @@ impl App {
             "context reached the compaction threshold"
         );
         self.active_session_mut().context_full_notice_shown = true;
+
+        if boundary == 0 {
+            // Above the threshold but the whole history is the verbatim tail:
+            // there is nothing to fold, and promising otherwise would be a lie.
+            self.push_message(ChatBlock::System(format!(
+                "Context is at {used} prompt tokens, at or above the {threshold} threshold \
+                 for profile '{profile_name}', but the history is too short to compact."
+            )));
+            return;
+        }
+
         self.push_message(ChatBlock::System(format!(
             "Context is at {used} prompt tokens, at or above the {threshold} threshold \
-             for profile '{profile_name}'. History compaction is not enabled yet."
+             for profile '{profile_name}'. Compacting the first {boundary} blocks of history."
+        )));
+        self.active_session_mut().pending_compaction = Some(boundary);
+    }
+
+    /// Compact the history on the user's own initiative (Ctrl+K), without
+    /// waiting for the threshold.
+    ///
+    /// Deliberately independent of `compact_at_tokens`: the point is to fold
+    /// the history before moving on to a new phase of work, and that decision
+    /// is the user's. It therefore also works when compaction is disabled with
+    /// `compact_at_tokens = 0`.
+    fn request_manual_compaction(&mut self) {
+        if self.agent_running {
+            self.push_message(ChatBlock::System(
+                "Cannot compact while the agent is working - wait for it to finish.".into(),
+            ));
+            return;
+        }
+
+        let boundary = filar_core::compaction_boundary(
+            &self.active_session().messages,
+            filar_core::DEFAULT_KEEP_TURNS,
+        );
+        if boundary == 0 {
+            self.push_message(ChatBlock::System(
+                "Nothing to compact yet - the whole history is still recent.".into(),
+            ));
+            return;
+        }
+        if self.active_session().pending_compaction.is_some() {
+            return;
+        }
+
+        self.push_message(ChatBlock::System(format!(
+            "Compacting the first {boundary} blocks of history on request."
+        )));
+        self.active_session_mut().pending_compaction = Some(boundary);
+    }
+
+    /// Apply a summary produced by the runner, replacing the compacted head.
+    ///
+    /// `boundary` is echoed back from the request so a history that changed
+    /// while the summary was being produced cannot be cut at a stale index.
+    pub fn apply_compaction(&mut self, boundary: usize, summary: String) {
+        let before = self.active_session().messages.len();
+        if boundary == 0 || boundary > before {
+            self.active_session_mut().pending_compaction = None;
+            return;
+        }
+
+        let compacted = filar_core::compact_history(
+            &self.active_session().messages,
+            boundary,
+            &summary,
+        );
+        let after = compacted.len();
+        self.active_session_mut().messages = compacted;
+        self.active_session_mut().pending_compaction = None;
+        // Block indices moved, so any user collapse overrides now point at the
+        // wrong blocks.
+        self.collapsed_overrides.clear();
+        self.message_rev = self.message_rev.wrapping_add(1);
+        self.selection = None;
+
+        self.push_message(ChatBlock::System(format!(
+            "History compacted: {before} blocks to {after}. The summary is in the feed above."
+        )));
+    }
+
+    /// Report that compaction failed, leaving the history untouched.
+    pub fn report_compaction_failure(&mut self, error: String) {
+        self.active_session_mut().pending_compaction = None;
+        self.push_message(ChatBlock::System(format!(
+            "History compaction failed ({error}). Continuing with the full history."
         )));
     }
 
@@ -1979,6 +2080,13 @@ impl App {
                 }
                 _ => {}
             }
+            return;
+        }
+
+        // Ctrl+K — compact the history on request, without waiting for the
+        // threshold (#377). ЙЦУКЕН: K = л.
+        if ctrl_key('k', 'л') && self.mode == AppMode::Normal {
+            self.request_manual_compaction();
             return;
         }
 
@@ -3244,8 +3352,14 @@ impl App {
 
     /// Compute the default collapse state for a chat block.
     /// A Command block is collapsed by default if its output has more than 6 lines.
+    /// A Summary block is always collapsed by default: it is there to be
+    /// auditable, not to push the conversation off the screen.
     fn default_collapsed_for(msg: &ChatBlock) -> bool {
-        matches!(msg, ChatBlock::Command { output: Some(out), .. } if out.lines().count() > 6)
+        match msg {
+            ChatBlock::Command { output: Some(out), .. } => out.lines().count() > 6,
+            ChatBlock::Summary { .. } => true,
+            _ => false,
+        }
     }
 
     /// Compute the set of collapsed block indices from `collapsed_overrides`
@@ -7359,6 +7473,130 @@ mod tests {
         app.active_session_mut().last_prompt_tokens = Some(60_000);
         app.begin_agent_request("four".into());
         assert_eq!(app.active_session().messages.len(), after_first + 1);
+    }
+
+    #[test]
+    fn manual_compaction_works_even_when_the_threshold_is_disabled() {
+        // Ctrl+K is the user's own decision, so it must not depend on
+        // `compact_at_tokens` — including the `0` that turns automatic
+        // compaction off entirely.
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.profiles = vec![filar_core::LlmProfile {
+            name: "glm".into(), model: "g".into(), api_base_url: "u".into(),
+            max_tokens: 4096, key_env: "k".into(),
+            temperature: None, top_p: None, extra_body: None,
+            compact_at_tokens: 0,
+        }];
+        app.llm_profile = Some("glm".into());
+        app.default_profile_name = "glm".into();
+        // No usage reported at all: the automatic path cannot fire.
+        app.active_session_mut().last_prompt_tokens = None;
+
+        for i in 0..8 {
+            app.push_message(ChatBlock::User(format!("q{i}")));
+            app.push_message(ChatBlock::Agent(format!("a{i}")));
+        }
+
+        app.request_manual_compaction();
+        let boundary = app.active_session().pending_compaction;
+        assert!(
+            matches!(boundary, Some(n) if n > 0),
+            "manual compaction must arm regardless of the threshold, got {boundary:?}"
+        );
+        assert!(matches!(
+            app.active_session().messages.last(),
+            Some(ChatBlock::System(s)) if s.contains("on request")
+        ));
+    }
+
+    #[test]
+    fn manual_compaction_on_a_short_history_says_so_instead_of_arming() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.push_message(ChatBlock::User("only turn".into()));
+
+        app.request_manual_compaction();
+        assert_eq!(app.active_session().pending_compaction, None);
+        assert!(matches!(
+            app.active_session().messages.last(),
+            Some(ChatBlock::System(s)) if s.contains("Nothing to compact")
+        ));
+    }
+
+    #[test]
+    fn manual_compaction_is_refused_while_the_agent_is_working() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        for i in 0..8 {
+            app.push_message(ChatBlock::User(format!("q{i}")));
+            app.push_message(ChatBlock::Agent(format!("a{i}")));
+        }
+        app.agent_running = true;
+
+        app.request_manual_compaction();
+        assert_eq!(app.active_session().pending_compaction, None);
+    }
+
+    #[test]
+    fn applying_a_summary_replaces_the_head_and_keeps_the_tail() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        for i in 0..8 {
+            app.push_message(ChatBlock::User(format!("q{i}")));
+            app.push_message(ChatBlock::Agent(format!("a{i}")));
+        }
+        let before = app.active_session().messages.clone();
+        let boundary = filar_core::compaction_boundary(&before, filar_core::DEFAULT_KEEP_TURNS);
+        assert!(boundary > 0, "fixture must have something to compact");
+
+        app.apply_compaction(boundary, "earlier turns, briefly".into());
+
+        let after = app.active_session().messages.clone();
+        assert!(matches!(
+            &after[0],
+            ChatBlock::Summary { text, replaced_blocks }
+                if text == "earlier turns, briefly" && *replaced_blocks == boundary
+        ));
+        // Tail preserved verbatim; the trailing System line is the report.
+        let kept = &after[1..after.len() - 1];
+        let original_tail = &before[boundary..];
+        assert_eq!(
+            serde_json::to_string(kept).unwrap(),
+            serde_json::to_string(original_tail).unwrap()
+        );
+        assert_eq!(app.active_session().pending_compaction, None);
+    }
+
+    #[test]
+    fn a_failed_summary_leaves_the_history_untouched() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        for i in 0..8 {
+            app.push_message(ChatBlock::User(format!("q{i}")));
+        }
+        app.active_session_mut().pending_compaction = Some(4);
+        let before = app.active_session().messages.len();
+
+        app.report_compaction_failure("rate limited".into());
+
+        assert_eq!(app.active_session().pending_compaction, None);
+        assert_eq!(
+            app.active_session().messages.len(),
+            before + 1,
+            "only the failure notice is added"
+        );
+        assert!(matches!(
+            app.active_session().messages.last(),
+            Some(ChatBlock::System(s)) if s.contains("rate limited")
+        ));
+    }
+
+    #[test]
+    fn a_stale_boundary_is_ignored_rather_than_cutting_the_wrong_place() {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.push_message(ChatBlock::User("one".into()));
+        let before = app.active_session().messages.len();
+
+        app.apply_compaction(99, "summary of a history that no longer exists".into());
+
+        assert_eq!(app.active_session().messages.len(), before);
+        assert_eq!(app.active_session().pending_compaction, None);
     }
 
     #[test]

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -63,6 +63,17 @@ pub enum TuiEvent {
         /// The target the user wants to connect to.
         target: filar_core::SshTarget,
     },
+
+    /// The history was compacted: the head up to `boundary` is replaced by
+    /// `summary`, or left untouched when `summary` is an `Err` (#377).
+    ///
+    /// `boundary` is echoed back from the request so the app cannot cut a
+    /// history that changed while the summary was being produced.
+    HistoryCompacted {
+        session_id: SessionId,
+        boundary: usize,
+        summary: std::result::Result<String, String>,
+    },
 }
 
 #[cfg(test)]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1373,21 +1373,6 @@ async fn run_app(
                 }
             } => {
                 if let Some(event) = maybe_agent_event {
-                    // Compaction result: applied to the session it belongs to,
-                    // which may no longer be the active tab (#377).
-                    if let TuiEvent::HistoryCompacted { session_id, boundary, ref summary } = &event {
-                        if let Some(idx) = app.find_session_idx(*session_id) {
-                            let previous = app.active;
-                            app.active = idx;
-                            match summary {
-                                Ok(text) => app.apply_compaction(*boundary, text.clone()),
-                                Err(e) => app.report_compaction_failure(e.clone()),
-                            }
-                            app.active = previous;
-                        }
-                        needs_redraw = true;
-                        continue;
-                    }
                     // Intercept TransportChanged to update per-session info.
                     if let TuiEvent::TransportChanged { session_id, is_local, ref ssh_info, ref alias, .. } = &event {
                         if let Some(idx) = app.find_session_idx(*session_id) {
@@ -1769,8 +1754,8 @@ fn spawn_agent(
     cancellation: CancellationToken,
     secret_provider: Arc<dyn SecretProvider>,
     sid: SessionId,
-    /// Boundary index when the history must be compacted before this request
-    /// (#377). `None` means send it as is.
+    // Boundary index when the history must be compacted before this request
+    // (#377). `None` means send it as is.
     pending_compaction: Option<usize>,
 ) {
     let tx = event_tx.clone();

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -975,6 +975,10 @@ async fn run_app(
                         // Create a cancellation token for this agent run.
                         let cancel_token = CancellationToken::new();
                         app.cancellation = Some(cancel_token.clone());
+                        // Whether the history must be folded before this
+                        // request. Taken here so a stale flag cannot survive
+                        // into a later turn if the run fails.
+                        let pending_compaction = app.sessions[app.active].pending_compaction;
                         // Resolve the LLM client for this session's profile.
                         let profile_name = app.sessions[app.active]
                             .llm_profile
@@ -1040,7 +1044,12 @@ async fn run_app(
                             cancel_token,
                             config.secret_provider.clone(),
                             sid,
+                            pending_compaction,
                         );
+                        // Consumed by this run: the summary comes back as an
+                        // event, and a leftover flag would fold the history a
+                        // second time on the next turn.
+                        app.sessions[app.active].pending_compaction = None;
                     }
 
                     // Ctrl+T changes what's on screen — force immediate redraw.
@@ -1364,6 +1373,21 @@ async fn run_app(
                 }
             } => {
                 if let Some(event) = maybe_agent_event {
+                    // Compaction result: applied to the session it belongs to,
+                    // which may no longer be the active tab (#377).
+                    if let TuiEvent::HistoryCompacted { session_id, boundary, ref summary } = &event {
+                        if let Some(idx) = app.find_session_idx(*session_id) {
+                            let previous = app.active;
+                            app.active = idx;
+                            match summary {
+                                Ok(text) => app.apply_compaction(*boundary, text.clone()),
+                                Err(e) => app.report_compaction_failure(e.clone()),
+                            }
+                            app.active = previous;
+                        }
+                        needs_redraw = true;
+                        continue;
+                    }
                     // Intercept TransportChanged to update per-session info.
                     if let TuiEvent::TransportChanged { session_id, is_local, ref ssh_info, ref alias, .. } = &event {
                         if let Some(idx) = app.find_session_idx(*session_id) {
@@ -1691,6 +1715,43 @@ pub fn resize_all_models(app: &mut App, cols: u16, rows: u16) {
     }
 }
 
+/// Flatten the chat history into the messages sent to the model.
+///
+/// Extracted from `spawn_agent` so the mapping can be tested directly: whether
+/// a block reaches the model is a correctness property, not a detail. Note the
+/// two deliberate asymmetries — `System` blocks are feed-only chrome and are
+/// dropped, while `Summary` blocks stand in for the turns they replaced and
+/// must be sent (#377).
+fn history_to_messages(blocks: &[ChatBlock]) -> Vec<filar_agent::ChatMessage> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ChatBlock::User(text) => Some(filar_agent::ChatMessage::user(text)),
+            ChatBlock::Agent(text) => Some(filar_agent::ChatMessage::assistant(text)),
+            ChatBlock::Command {
+                command,
+                output,
+                approved,
+                ..
+            } => {
+                let output_text = output.as_deref().unwrap_or(
+                    if *approved { "(no output)" } else { "(denied by user)" },
+                );
+                Some(filar_agent::ChatMessage::assistant(format!(
+                    "Command: {command}\nOutput: {output_text}"
+                )))
+            }
+            ChatBlock::Error(text) => Some(filar_agent::ChatMessage::assistant(format!(
+                "Error: {text}"
+            ))),
+            ChatBlock::System(_) => None,
+            ChatBlock::Summary { text, .. } => Some(filar_agent::ChatMessage::user(format!(
+                "Summary of earlier turns in this session:\n{text}"
+            ))),
+        })
+        .collect()
+}
+
 /// Spawn the agent in a tokio task to process the user's input.
 #[allow(clippy::too_many_arguments)]
 fn spawn_agent(
@@ -1708,6 +1769,9 @@ fn spawn_agent(
     cancellation: CancellationToken,
     secret_provider: Arc<dyn SecretProvider>,
     sid: SessionId,
+    /// Boundary index when the history must be compacted before this request
+    /// (#377). `None` means send it as is.
+    pending_compaction: Option<usize>,
 ) {
     let tx = event_tx.clone();
     let confirmer = Arc::new(TuiConfirmer::new(event_tx.clone(), sid)) as Arc<dyn CommandConfirmer>;
@@ -1715,32 +1779,42 @@ fn spawn_agent(
     tokio::spawn(async move {
         let _ = tx.send(TuiEvent::Thinking);
 
-        let history: Vec<filar_agent::ChatMessage> = chat_history
-            .iter()
-            .filter_map(|block| match block {
-                ChatBlock::User(text) => Some(filar_agent::ChatMessage::user(text)),
-                ChatBlock::Agent(text) => Some(filar_agent::ChatMessage::assistant(text)),
-                ChatBlock::Command {
-                    command,
-                    output,
-                    approved,
-                    ..
-                } => {
-                    let output_text = output.as_deref().unwrap_or(
-                        if *approved { "(no output)" } else { "(denied by user)" },
-                    );
-                    Some(filar_agent::ChatMessage::assistant(format!(
-                        "Command: {command}\nOutput: {output_text}"
-                    )))
+        // Compaction runs here, before the agent is built, because this is
+        // where the LLM client lives and the spinner is already up. The
+        // summary uses the session's own profile, so its cost lands on the
+        // profile the user is actually working with.
+        let chat_history = match pending_compaction {
+            Some(boundary) if boundary > 0 && boundary <= chat_history.len() => {
+                let transcript =
+                    filar_core::transcript_for_summary(&chat_history[..boundary]);
+                match filar_agent::summarise_history(llm.as_ref(), &transcript).await {
+                    Ok(summary) => {
+                        let compacted =
+                            filar_core::compact_history(&chat_history, boundary, &summary);
+                        let _ = tx.send(TuiEvent::HistoryCompacted {
+                            session_id: sid,
+                            boundary,
+                            summary: Ok(summary),
+                        });
+                        compacted
+                    }
+                    Err(e) => {
+                        // The request still goes out on the full history: a
+                        // failed summary must not cost the user their turn.
+                        // Recovering from an outright context overflow is #378.
+                        let _ = tx.send(TuiEvent::HistoryCompacted {
+                            session_id: sid,
+                            boundary,
+                            summary: Err(e.to_string()),
+                        });
+                        chat_history
+                    }
                 }
-                ChatBlock::Error(text) => {
-                    Some(filar_agent::ChatMessage::assistant(format!(
-                        "Error: {text}"
-                    )))
-                }
-                ChatBlock::System(_) => None,
-            })
-            .collect();
+            }
+            _ => chat_history,
+        };
+
+        let history = history_to_messages(&chat_history);
 
         let tx_for_sink = tx.clone();
         let sink: filar_agent::EventSink = Arc::new(move |event: filar_agent::AgentEvent| {
@@ -1824,6 +1898,57 @@ async fn load_path_picker_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_summary_reaches_the_model_and_feed_chrome_does_not() {
+        // The trap this feature had to avoid: `System` blocks are filtered out
+        // when the history is flattened, so putting the summary in one would
+        // have made compaction a silent loss of the whole head (#377).
+        let blocks = vec![
+            ChatBlock::Summary {
+                text: "Restarted nginx, still 502. Config at /etc/nginx.".into(),
+                replaced_blocks: 12,
+            },
+            ChatBlock::System("History compacted: 14 blocks to 3.".into()),
+            ChatBlock::User("what next".into()),
+        ];
+
+        let messages = history_to_messages(&blocks);
+        let joined: String = messages.iter().map(|m| m.content.clone()).collect();
+
+        assert!(
+            joined.contains("Restarted nginx, still 502."),
+            "the summary must be part of what the model is sent"
+        );
+        assert!(
+            !joined.contains("History compacted: 14 blocks to 3."),
+            "feed-only system lines must stay out of the request"
+        );
+        assert_eq!(messages.len(), 2, "summary + user turn");
+    }
+
+    #[test]
+    fn a_command_and_its_outcome_still_reach_the_model_unchanged() {
+        // Guards the extraction of `history_to_messages` out of `spawn_agent`.
+        let blocks = vec![
+            ChatBlock::Command {
+                command: "systemctl restart nginx".into(),
+                explanation: "restart it".into(),
+                output: Some("done".into()),
+                approved: true,
+            },
+            ChatBlock::Command {
+                command: "rm -rf /var/log".into(),
+                explanation: String::new(),
+                output: None,
+                approved: false,
+            },
+        ];
+        let messages = history_to_messages(&blocks);
+        assert!(messages[0].content.contains("Command: systemctl restart nginx"));
+        assert!(messages[0].content.contains("Output: done"));
+        assert!(messages[1].content.contains("(denied by user)"));
+    }
 
     #[tokio::test]
     async fn recv_log_line_returns_sent_line_and_keeps_channel() {

--- a/crates/tui/src/ui/layout_cache.rs
+++ b/crates/tui/src/ui/layout_cache.rs
@@ -249,6 +249,39 @@ impl ChatLayoutCache {
                     ]);
                     self.push_spacer();
                 }
+
+                // The summary that replaced the compacted head (#377).
+                // Collapsed by default, expandable like command output: it is
+                // context the user may want to audit, not part of the
+                // conversation they actually had.
+                ChatBlock::Summary { text, replaced_blocks } => {
+                    let is_collapsed = collapsed.contains(&idx);
+                    let arrow = if is_collapsed { glyphs.collapse_arrow } else { glyphs.expand_arrow };
+
+                    self.push_header(idx, vec![
+                        Span::raw("  "),
+                        Span::styled(format!("{} ", arrow), theme.muted()),
+                        Span::styled(
+                            format!("History compacted - {replaced_blocks} blocks summarised"),
+                            theme.muted(),
+                        ),
+                    ]);
+
+                    if !is_collapsed {
+                        for line in strip_emoji(text).lines() {
+                            for wrapped in wrap_text(line, output_width) {
+                                self.push_output(idx, format!("  {} {}", glyphs.gutter, wrapped));
+                            }
+                        }
+                        self.push_output_toggle(idx, format!("  {} collapse", glyphs.expand_arrow));
+                    } else {
+                        self.push_output_toggle(
+                            idx,
+                            format!("  {} click to show the summary", glyphs.collapse_arrow),
+                        );
+                    }
+                    self.push_spacer();
+                }
             }
         }
 


### PR DESCRIPTION
Closes #377

Часть 2 из 4 по спецификации сжатия контекста, поверх #376.

## Что сделано

Голова истории, отрезанная по границе из #376, заменяется одним блоком-сводкой; хвост из последних обменов остаётся дословно. `Ctrl+K` делает то же самое по требованию пользователя, независимо от порога.

- `filar-core`: вариант `ChatBlock::Summary { text, replaced_blocks }`, чистые функции `compact_history` и `transcript_for_summary`.
- `filar-agent`: модуль `compaction` с системным промптом по тексту issue и вызовом `summarise_history` — без определений инструментов, чтобы сводчик не мог предложить команду; пустой ответ модели считается ошибкой, а не принимается молча.
- `filar-tui`: сводка доходит до модели, рендерится в ленте свёрнутым блоком с раскрытием, две системные строки до и после, ручной запуск на `Ctrl+K`.

## Решение по развилке из issue: как сводка попадает в историю

Взят вариант с новым вариантом `ChatBlock`, а не инъекция на этапе конвертации в `ChatMessage`.

Причины: сводку требуется показывать в ленте и давать посмотреть — сжатие, которое нельзя проверить глазами, это сжатие, которому нельзя доверять, а при инъекции рендерить нечего. И #379 понадобится конкретный блок для сохранения в сессии.

Обратная совместимость проверена в ту сторону, которая имеет значение: старые файлы сессий этого варианта просто не содержат, тест на чтение такого файла добавлен.

## Ловушка из issue

`ChatBlock::System` отфильтрован при сборке истории для модели, поэтому сводка в системном блоке до модели бы не дошла и сжатие стало бы молчаливой потерей всей головы. Конвертация вынесена из `spawn_agent` в отдельную `history_to_messages` именно поэтому: доходит блок до модели или нет — это свойство корректности, и теперь оно закрыто тестом, а не спрятано внутри спавнящейся задачи.

## Где выполняется запрос сводки

Внутри задачи агента, до сборки агента. `app.rs` синхронный, LLM-клиент живёт в раннере; отдельный асинхронный путь означал бы вторую машину состояний ради того же ожидания, а спиннер и так уже крутится. Результат возвращается событием `HistoryCompacted` и применяется к своей вкладке, даже если пользователь успел переключиться.

Модель — профиль сессии. Опциональная оптимизация с дешёвым профилем не делалась: она требует корректной атрибуции расхода профилю, который считал, а не текущему, и это риск для учёта `per_profile` в PR, где и без того новый системный промпт и новый вариант перечисления. Отмечено в PROGRESS как отдельная возможность.

## Отказ сводки

История остаётся нетронутой, запрос уходит на полной истории, в ленте честная строка. Восстановление после отказа провайдера по переполнению — это #378.

## Тесты

15 штук: 5 в `filar-core` (голова заменена одной сводкой; хвост совпадает побайтово; no-op когда сворачивать нечего; повторное сжатие складывает старую сводку, а не копит; транскрипт несёт результат команд, но не системные строки ленты), 2 в `filar-agent` на промпт, 2 в раннере (сводка доходит до модели, системные строки — нет), 6 в `app.rs` (ручной запуск при отключённом пороге, короткая история, отказ во время работы агента, применение сводки, путь отказа, устаревшая граница).

## Не проверено в окружении агента

**Ничего не собиралось и не запускалось: Rust-тулчейна в окружении нет** (`cargo` отсутствует, в apt только 1.75 при `rust-version = "1.85"`, `static.rust-lang.org` закрыт сетевой политикой контейнера).

Правка заметно крупнее предыдущей: затронут вариант перечисления, по которому есть `match` в нескольких местах, и изменена сигнатура `spawn_agent`. Все найденные `match` дополнены вручную, но без компилятора полноту гарантировать нельзя — CI здесь первая настоящая проверка.

Требование DoD «проверить, что тесты падают на старом коде» выполнено рассуждением, а не наблюдением: `ChatBlock::Summary`, `compact_history`, `history_to_messages` и `request_manual_compaction` на до-фиксном коде не существуют, поэтому соответствующие тесты там не компилируются.

### Ручная проверка — за человеком

TUI в окружении агента не запускается. Из DoD остаётся:

1. Порог 5000, разговор с несколькими командами: сжатие срабатывает, в ленте видны обе системные строки, работа продолжается.
2. После сжатия агент помнит, какие команды выполнялись и с каким результатом — проверить прямым вопросом.
3. `prompt_tokens` следующего запроса заметно меньше, чем до сжатия.
4. `Ctrl+K` работает, в том числе при `compact_at_tokens = 0`; на ЙЦУКЕН — `Ctrl+Л`.
5. Сводка в ленте раскрывается и сворачивается.

### Eval

Добавлен системный промпт, поэтому по AGENTS.md нужен прогон eval. Изменения лежат в `crates/agent/src/**`, так что `eval-smoke` должен подхватиться на этом PR автоматически — результат приложу к PR, когда workflow отработает.

### Безопасность

Новых каналов утечки секретов не появилось: сводка строится из тех же блоков истории, что уже уходят модели, ввод пароля в историю не пишется и в транскрипт не попадает. На удалённый хост ничего не пишется — вся работа локальная.

## Вне скоупа

Реактивный путь при переполнении и обработка отказов сводки (#378). Персистентность и переключение профиля (#379). Дешёвый профиль для сводки. Новый вариант `ChatBlock` стоит упомянуть в `docs/ENGINE_API.md` при нарезке следующего engine-тега — эмбеддеры с исчерпывающим `match` должны будут добавить ветку.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long chat histories are automatically compacted at the configured threshold.
  * Older turns are folded into a collapsed, expandable summary while recent turns remain unchanged.
  * Added manual compaction with `Ctrl+K`, regardless of the threshold.
  * Summaries preserve key facts, executed commands, hypotheses, and constraints.
  * Compaction status appears in the chat feed, and summaries are included in exports.

* **Bug Fixes**
  * Failed summary generation leaves the original history intact.
  * Stale summaries are no longer applied after cancellation or session restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->