### PR TITLE
test(core): merge the two FILAR_CONFIG tests into one

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5752,6 +5752,54 @@ was left out: `Ctrl+R` is reverse-i-search in a shell and would collide in
 interactive mode, so the key choice needs a decision of its own. Translating
 SGR into ratatui styles instead of discarding colour is a possible follow-up.
 
+## Issue #386: fix(core/tests) — two tests raced over the `FILAR_CONFIG` env var
+
+**Milestone:** 1.0.6. **Branch:** `fix/386-filar-config-test-race`.
+
+**Problem:** `load_default_prefers_filar_config_env` and
+`load_default_cwd_wins_over_app_data` both set `FILAR_CONFIG`. `cargo test` runs
+tests as threads of a single process and environment variables are per-process,
+so the two were mutually incompatible no matter what their `EnvGuard`s did: one
+could overwrite the other's path, or drop the variable before the other reached
+`load_default`, after which the lookup fell through the rest of the chain and the
+model assertion failed. Seen on CI for PR #382 — red on `windows-x86_64`, green
+on `macos-aarch64`, green again on a bare re-run.
+
+**Design:** merged the two into one test rather than putting a shared mutex
+around them (the second option in the issue, and the honest one). The second test
+did not test what its name claimed: its own comment conceded that CWD priority
+was out of reach because `default_base_dir` is OS-dependent, so it set
+`FILAR_CONFIG` to a temp path and asserted the model — the same assertion as the
+first test with a different string. Merging removes the race by construction:
+one test, one writer, nothing to serialise.
+
+Testing CWD priority for real was left alone deliberately. It needs
+`set_current_dir`, which is process-global in exactly the same way, so it would
+reintroduce this class of race rather than close it.
+
+**Done:** one test kept, carrying a doc comment that records why it must stay the
+only reader or writer of `FILAR_CONFIG` in the crate and that a second one needs
+a shared lock. Duplicate `EnvGuard`/`DirGuard` definitions inside the removed
+test body dropped in favour of the module-level ones. Audited the crate per the
+DoD: `FILAR_CONFIG` now appears only in `Config::load_default` and this test, and
+`load_default` has no other test caller. The `secrets.rs` tests touch env vars
+too, but private `FILAR_SECRET_TEST_*` names, one writer each.
+
+**Verification:** `cargo test -p filar-core` run 20× at default parallelism plus
+5× each at `--test-threads=1` and `--test-threads=16`, all green. The failure
+itself did not reproduce here in 30 pre-fix runs, which matches the issue: the
+window is narrow and it had only ever been seen on Windows.
+
+**Public contract:** none. Test-only change; no `CHANGELOG.md` entry, per the
+internal-changes rule in `AGENTS.md`.
+
+**Next steps:** an unrelated order-dependent test surfaced in the same run —
+`session::tests::default_base_dir_returns_os_data_parent_without_creating_filar`
+asserts that `dirs::data_dir()` already exists, which on a fresh Linux profile is
+only true after a sibling test has created `~/.local/share` via
+`SessionStore::new`. Invisible on Windows and macOS, where the directory always
+exists. Left out of this PR — different cause, needs its own issue.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -870,6 +870,13 @@ temperature = 5.0
         assert!(result.is_err(), "Config::load should reject temperature=5.0");
     }
 
+    /// The only test in this crate that touches `FILAR_CONFIG`.
+    ///
+    /// `cargo test` runs tests as threads of one process and environment
+    /// variables are per-process, so two tests setting this variable race each
+    /// other regardless of what their guards do. Keep it that way: a second
+    /// test that reads or writes `FILAR_CONFIG` (or calls `load_default`, which
+    /// reads it) must not be added without putting both behind a shared lock.
     #[test]
     fn load_default_prefers_filar_config_env() {
         let dir = std::env::temp_dir().join(format!("filar_cfg_test_{}", std::process::id()));
@@ -878,46 +885,13 @@ temperature = 5.0
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(&path, "[llm]\nmodel = \"env-model\"\napi_base_url = \"https://test.example.com\"\n").unwrap();
 
-        // Guard structs for cleanup.
-        struct DirGuard(std::path::PathBuf);
-        impl Drop for DirGuard { fn drop(&mut self) { let _ = std::fs::remove_dir_all(&self.0); } }
-        struct EnvGuard { key: &'static str, old: Option<String> }
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                match &self.old {
-                    Some(v) => std::env::set_var(self.key, v),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-
         let _dir_guard = DirGuard(dir);
         let old_val = std::env::var("FILAR_CONFIG").ok();
-        std::env::set_var("FILAR_CONFIG", path.to_str().unwrap());
+        std::env::set_var("FILAR_CONFIG", path.as_os_str());
         let _env_guard = EnvGuard { key: "FILAR_CONFIG", old: old_val };
 
         let cfg = Config::load_default().unwrap();
         assert_eq!(cfg.llm.model, "env-model", "FILAR_CONFIG must take priority");
-    }
-
-    #[test]
-    fn load_default_cwd_wins_over_app_data() {
-        // Write a local config.toml. Since `default_base_dir` is OS-dependent,
-        // we test the general priority chain by putting files in CWD only.
-        // FILAR_CONFIG → CWD order is tested above.
-        let dir = std::env::temp_dir().join(format!("filar_cfg_cwd_{}", std::process::id()));
-        let path = dir.join("config.toml");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(&path, "[llm]\nmodel = \"cwd-model\"\napi_base_url = \"https://test.example.com\"\n").unwrap();
-
-        let old = std::env::var("FILAR_CONFIG").ok();
-        std::env::set_var("FILAR_CONFIG", path.as_os_str());
-        let _env = EnvGuard { key: "FILAR_CONFIG", old };
-        let _dir = DirGuard(dir);
-
-        let cfg = Config::load_default().unwrap();
-        assert_eq!(cfg.llm.model, "cwd-model", "FILAR_CONFIG must find config via CWD path");
     }
 
     struct EnvGuard { key: &'static str, old: Option<String> }


### PR DESCRIPTION
Closes #386

## Summary

`load_default_prefers_filar_config_env` and `load_default_cwd_wins_over_app_data`
both wrote the same process-global `FILAR_CONFIG` variable while `cargo test`
ran them as threads of a single process. Their `EnvGuard`s could not help: one
test could overwrite the other's path, or drop the variable before the other
reached `load_default`, after which the lookup fell through the rest of the
chain and the model assertion failed.

Took the second option from the issue — merging the two tests rather than
serialising them behind a mutex — because the second test did not test what its
name claimed. Its own comment conceded that CWD priority was out of reach
(`default_base_dir` is OS-dependent), so it set `FILAR_CONFIG` to a temp path
and asserted the model: the same assertion as the first test with a different
string. One test, one writer, nothing left to serialise.

The surviving test carries a doc comment recording why it must stay the only
reader or writer of `FILAR_CONFIG` in the crate, and that adding a second one
requires a shared lock. Duplicate `EnvGuard`/`DirGuard` definitions inside the
removed test body are gone in favour of the module-level ones.

Per the DoD, audited the crate: `FILAR_CONFIG` now appears only in
`Config::load_default` and this one test, and `load_default` has no other test
caller. The `secrets.rs` tests do touch env vars, but private
`FILAR_SECRET_TEST_*` names with one writer each — no interaction.

Test-only change, so no `CHANGELOG.md` entry (internal-changes rule in
`AGENTS.md`). `PROGRESS.md` updated in this commit.

## Verified in the agent environment

A Rust toolchain was installed in the agent container this session, so unlike
previous PRs the build and tests **were** run here — on Linux, `rustc` 1.98.0:

- `cargo build --workspace` — green.
- `cargo test --workspace` — green (748 passed, 8 ignored).
- `cargo test -p filar-core` 20× at default parallelism, plus 5× each at
  `--test-threads=1` and `--test-threads=16` — green every run. This is the
  DoD item about order and parallelism independence.

## Not verified

- **The original failure did not reproduce here.** 30 pre-fix runs on Linux were
  all green. That matches the issue — the window is narrow and it had only ever
  been seen on `windows-x86_64`. The fix removes the race by construction rather
  than by observed repro, so CI on Windows and macOS is the real check.
- **No binary run.** Test-only change; `AGENTS.md` exempts test-only tasks from
  the user-scenario requirement.
- `#[ignore]` tests (docker-sshd) were not run, as usual.

## Out of scope

- Testing CWD priority for real. It needs `set_current_dir`, which is
  process-global in the same way as an env var, so it would reintroduce this
  class of race instead of closing it. Worth a separate issue if that coverage
  is wanted.
- A second order-dependent test surfaced during the runs:
  `session::tests::default_base_dir_returns_os_data_parent_without_creating_filar`
  asserts that `dirs::data_dir()` already exists, which on a fresh Linux profile
  is only true after a sibling test creates `~/.local/share` via
  `SessionStore::new`. It failed on the first run of the suite and passed
  afterwards. Different cause from #386, invisible on Windows and macOS where
  the directory always exists — left out of this PR; say the word and I'll file
  it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved configuration test reliability by eliminating a race involving the `FILAR_CONFIG` environment variable.
  * Consolidated conflicting configuration scenarios into a single test.
  * Added safeguards and documentation to prevent future environment-variable test conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->