### PR TITLE
fix(gui): validate every profile before saving, not just the selected one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- Deleting a launcher profile no longer removes its stored API key when the
+  deletion cannot be saved. The remaining profiles are checked first, so a
+  malformed field elsewhere blocks the delete instead of leaving a profile in
+  `settings.json` whose credential is already gone
+  ([#385](https://github.com/devlawey/filar/issues/385)).
+
 - The GUI launcher no longer rewrites a malformed field as a default when the
   profile it sits in is not the selected one. `temperature`, `max_tokens`,
   `top_p` and `compact_at_tokens` are now checked across every profile before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- The GUI launcher no longer rewrites a malformed field as a default when the
+  profile it sits in is not the selected one. `temperature`, `max_tokens`,
+  `top_p` and `compact_at_tokens` are now checked across every profile before
+  anything is written, on save and on Launch alike, and the message names the
+  offending profile and field
+  ([#385](https://github.com/devlawey/filar/issues/385)).
+
 - The GUI launcher no longer resets a profile's `max_tokens` to 4096 and drops
   its `top_p` on every save. Both are now editable in the Models tab, validated
   before Launch, and carried through `settings.json` and `pending_launch.json`;

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5752,6 +5752,67 @@ was left out: `Ctrl+R` is reverse-i-search in a shell and would collide in
 interactive mode, so the key choice needs a decision of its own. Translating
 SGR into ratatui styles instead of discarding colour is a possible follow-up.
 
+## Issue #385: fix(gui) — validation only ever looked at the selected profile
+
+**Milestone:** 1.0.6. **Branch:** `fix/385-validate-all-profiles`.
+
+**Problem:** `do_launch` validated the selected profile, while `save_profiles`
+and the launch persistence path converted the *whole* list through
+`LlmProfileData::to_profile`, which falls back on unparseable input. A typo left
+in another profile was therefore rewritten as a default with no error on the
+next save — and clicking "+" saves. Predates #380 for `temperature` and
+`compact_at_tokens`; #380 added `max_tokens` and `top_p` to the same scheme.
+
+**Design:** took the first option in the issue — validate the whole list before
+every write — and not the fallible-`to_profile` one. Two shared functions:
+`validate_profile_fields` holds the per-field checks lifted verbatim out of
+`do_launch`, and `validate_all_profile_fields` runs them over the list and
+prefixes the message with the profile name. `save_profiles` refuses to write
+when it fails; `do_launch` runs the same check before its own name and
+keyless-URL checks, which stay selected-profile-only because names are not
+silently normalised.
+
+The concern about having nowhere to show the message turned out not to exist:
+`validation_error` renders in the fixed bottom panel, visible from every tab, so
+an error raised by "+" in Models is already on screen. That is what made the
+first option sufficient — the second option's cost was mostly this same UI
+question.
+
+`extra_body` is validated by the shared function too. It is in the same class
+(`serde_json::from_str(...).ok()` in `to_profile`) and was already checked for
+the selected profile, so leaving it out of the loop would have been arbitrary.
+
+**Refusing rather than preserving:** the DoD allows either. Preserving is not
+actually reachable — `settings.json` holds typed fields and `max_tokens = "abc"`
+has no representation there, so the only alternatives are a silent default and a
+refusal. Recorded in the `save_profiles` doc comment.
+
+`validation_error` is one slot shared with the "No SSH profile matches" warning
+from session selection, so a `profile_error_shown` flag now marks who wrote it;
+a successful save clears only its own message.
+
+**Testing note worth keeping:** the first version of the launch test called
+`do_launch` directly. With the guard reverted it did not fail — the call ran on
+to `std::process::exit(0)`, killing the test binary mid-run with a success code,
+and cargo reported the run as passing. A test that silently passes when the bug
+returns is worse than none, so the checks moved into `validate_launch`, which
+returns `bool` and is what the test calls. Both new tests were confirmed to fail
+when their guard is removed.
+
+**Done:** 5 tests added (40 pass in `filar-gui`, up from 35): save refused for
+each of the four fields in an *unselected* profile with the profile and field
+named, the same for launch, a valid-and-empty list accepted on both paths, and
+the unrelated-warning case. Tests only ever exercise the rejection path, which
+returns before `Settings::save` — the success path writes to the real OS data
+directory.
+
+**Public contract:** none. `CommandExecutor` / `LlmClient` untouched; no change
+to `settings.json` or `pending_launch.json` formats.
+
+**Next steps:** duplicate and empty profile names are still checked only for the
+selected profile at launch. Unlike the numeric fields they survive a save
+intact, so it is a UX gap rather than data loss — separate issue if wanted.
+
 ## Issue #386: fix(core/tests) — two tests raced over the `FILAR_CONFIG` env var
 
 **Milestone:** 1.0.6. **Branch:** `fix/386-filar-config-test-race`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5813,6 +5813,31 @@ to `settings.json` or `pending_launch.json` formats.
 selected profile at launch. Unlike the numeric fields they survive a save
 intact, so it is a UX gap rather than data loss — separate issue if wanted.
 
+**Review round (PR #389):** four comments, all fair, two of them real holes in
+the work above.
+
+The `profile_error_shown` flag was only half a solution. It was set in
+`set_profile_error` and cleared at the start of `validate_launch`, but nothing
+cleared it when the slot was overwritten by a *different* message — and
+`on_session_selected` does exactly that with the "No SSH profile matches"
+warning. Profile error shown, then a session clicked, then a successful save:
+the flag was still standing and the warning was wiped. The test written to
+prevent this only covered a slot that had never been ours, which is the case
+that cannot fail. Every write now goes through `set_profile_error`,
+`set_other_error` or `clear_error`, the last two dropping the flag, and the
+replacement test walks the reachable order.
+
+The second was a regression this branch introduced. The "X" delete handler
+called `delete_secret`, removed the profile from memory and only then called
+`save_profiles` — which can now refuse. The credential is gone from the OS
+store for good while `settings.json` still lists the profile, so it returns on
+restart without its API key. The handler now validates the list *without* the
+doomed profile first and touches nothing on failure. `validate_all_profile_fields`
+takes an iterator rather than a slice so the check needs no clone.
+
+Also added the missing profile-name assertion to the launch test, which the PR
+text had claimed was there.
+
 ## Issue #386: fix(core/tests) — two tests raced over the `FILAR_CONFIG` env var
 
 **Milestone:** 1.0.6. **Branch:** `fix/386-filar-config-test-race`.

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -156,6 +156,66 @@ fn parse_max_tokens(raw: &str) -> u32 {
     }
 }
 
+/// Validate the numeric and JSON fields of one profile as typed.
+///
+/// Returns the message to show, or `Ok(())` when every field either parses or
+/// is empty (empty means "use the default" for each of them).
+///
+/// These are exactly the fields [`LlmProfileData::to_profile`] converts with a
+/// fallback: an unparseable value there becomes `None` or a built-in default
+/// with no error, which is how a typo in one profile used to be swallowed on
+/// save (#385). Keep the two in step — a field that gains a fallback in
+/// `to_profile` needs a check here, or it will silently reset again.
+fn validate_profile_fields(p: &LlmProfileData) -> Result<(), String> {
+    if !p.temperature.trim().is_empty()
+        && !matches!(p.temperature.trim().parse::<f32>(), Ok(t) if t.is_finite() && (0.0..=2.0).contains(&t))
+    {
+        return Err(format!(
+            "Invalid temperature: '{}'. Expected [0.0, 2.0].",
+            p.temperature
+        ));
+    }
+    if !p.max_tokens.trim().is_empty()
+        && !matches!(p.max_tokens.trim().parse::<u32>(), Ok(n) if n > 0)
+    {
+        return Err(format!(
+            "Invalid max tokens: '{}'. Expected a whole number above 0.",
+            p.max_tokens
+        ));
+    }
+    if !p.top_p.trim().is_empty()
+        && !matches!(p.top_p.trim().parse::<f32>(), Ok(t) if t.is_finite() && t > 0.0 && t <= 1.0)
+    {
+        return Err(format!("Invalid top_p: '{}'. Expected (0.0, 1.0].", p.top_p));
+    }
+    if !p.compact_at_tokens.trim().is_empty() && p.compact_at_tokens.trim().parse::<u64>().is_err() {
+        return Err(format!(
+            "Invalid compaction threshold: '{}'. Expected a whole number of tokens (0 = off).",
+            p.compact_at_tokens
+        ));
+    }
+    if !p.extra_body.trim().is_empty()
+        && serde_json::from_str::<serde_json::Value>(&p.extra_body).is_err()
+    {
+        return Err("Invalid extra body JSON.".to_string());
+    }
+    Ok(())
+}
+
+/// Validate every profile, not just the selected one, naming the offender.
+///
+/// Every persistence path converts the whole list through
+/// [`LlmProfileData::to_profile`], so checking only the selected profile left
+/// the others free to be rewritten with defaults (#385).
+fn validate_all_profile_fields(profiles: &[LlmProfileData]) -> Result<(), String> {
+    for p in profiles {
+        if let Err(msg) = validate_profile_fields(p) {
+            return Err(format!("Profile \"{}\": {msg}", p.name));
+        }
+    }
+    Ok(())
+}
+
 /// Generate a unique profile name with the given prefix.
 /// Finds the first free number (profile-1, profile-2, ...) not already in use.
 fn unique_profile_name(existing: &[LlmProfileData], prefix: &str) -> String {
@@ -576,6 +636,12 @@ struct LauncherApp {
     /// Currently selected profile index.
     selected_profile: usize,
     validation_error: String,
+    /// Whether `validation_error` currently holds a profile-field message.
+    ///
+    /// The slot is shared with the session/SSH-target warning, so a successful
+    /// save clears only what profile validation itself put there instead of
+    /// wiping an unrelated warning.
+    profile_error_shown: bool,
     /// Directory for Ctrl+S session exports (`None` = CWD).
     save_dir: Option<std::path::PathBuf>,
     /// Reveal SSH password field (not persisted).
@@ -1086,7 +1152,35 @@ impl LauncherApp {
         });
     }
 
+    /// Show a profile-validation message and remember that it is ours.
+    fn set_profile_error(&mut self, msg: String) {
+        self.validation_error = msg;
+        self.profile_error_shown = true;
+    }
+
+    /// Drop a previously shown profile-validation message, leaving any other
+    /// warning (an unmatched SSH target, for one) on screen.
+    fn clear_profile_error(&mut self) {
+        if self.profile_error_shown {
+            self.validation_error.clear();
+            self.profile_error_shown = false;
+        }
+    }
+
+    /// Persist settings, refusing to write when any profile has a malformed
+    /// field.
+    ///
+    /// The whole list goes through [`LlmProfileData::to_profile`] below, which
+    /// converts with fallbacks, so *keeping* an invalid value is not an option:
+    /// `settings.json` holds typed fields and `max_tokens = "abc"` has no
+    /// representation there. The choice is between rewriting it as a default
+    /// silently and refusing with a message; this refuses (#385).
     fn save_profiles(&mut self) {
+        if let Err(msg) = validate_all_profile_fields(&self.profiles) {
+            self.set_profile_error(msg);
+            return;
+        }
+        self.clear_profile_error();
         let p = self.profiles.get(self.selected_profile);
         Settings {
             model: p.map_or_else(String::new, |x| x.model.clone()),
@@ -1102,68 +1196,55 @@ impl LauncherApp {
         }.save();
     }
 
-    fn do_launch(&mut self) {
+    /// Check everything that must hold before a launch, reporting the first
+    /// problem through `validation_error`.
+    ///
+    /// Split out of [`LauncherApp::do_launch`] so it can be tested: the rest of
+    /// `do_launch` ends in `std::process::exit`, which would take the test
+    /// harness with it — and, worse, exit `0`, so a lost check would look like
+    /// a passing run.
+    fn validate_launch(&mut self) -> bool {
         self.validation_error.clear();
+        self.profile_error_shown = false;
+        // Field checks cover every profile, not just the selected one: a launch
+        // writes the whole list to settings.json and pending_launch.json, so an
+        // unnoticed typo elsewhere would be normalised away (#385).
+        if let Err(msg) = validate_all_profile_fields(&self.profiles) {
+            self.set_profile_error(msg);
+            return false;
+        }
         let Some(p) = self.profiles.get(self.selected_profile) else {
             self.validation_error = "No profile selected".to_string();
-            return;
+            return false;
         };
         // Validate unique names and non-empty name.
         if p.name.trim().is_empty() {
             self.validation_error = "Profile name must not be empty.".to_string();
-            return;
+            return false;
         }
         if p.key_env.trim().is_empty() && p.api_base_url.trim().is_empty() {
             self.validation_error =
                 "Keyless (local) profile needs an API URL (e.g. http://localhost:11434/v1)."
                     .to_string();
-            return;
+            return false;
         }
         for (i, other) in self.profiles.iter().enumerate() {
             if i != self.selected_profile && other.name == p.name {
-                self.validation_error = format!("Duplicate profile name: \"{}\". Names must be unique.", p.name);
-                return;
+                self.validation_error =
+                    format!("Duplicate profile name: \"{}\". Names must be unique.", p.name);
+                return false;
             }
         }
-        if !p.temperature.trim().is_empty()
-            && !matches!(p.temperature.trim().parse::<f32>(), Ok(t) if t.is_finite() && (0.0..=2.0).contains(&t))
-        {
-            self.validation_error = format!("Invalid temperature: '{}'. Expected [0.0, 2.0].", p.temperature);
-        }
-        if self.validation_error.is_empty()
-            && !p.max_tokens.trim().is_empty()
-            && !matches!(p.max_tokens.trim().parse::<u32>(), Ok(n) if n > 0)
-        {
-            self.validation_error = format!(
-                "Invalid max tokens: '{}'. Expected a whole number above 0.",
-                p.max_tokens
-            );
-        }
-        if self.validation_error.is_empty()
-            && !p.top_p.trim().is_empty()
-            && !matches!(p.top_p.trim().parse::<f32>(), Ok(t) if t.is_finite() && t > 0.0 && t <= 1.0)
-        {
-            self.validation_error =
-                format!("Invalid top_p: '{}'. Expected (0.0, 1.0].", p.top_p);
-        }
-        if self.validation_error.is_empty()
-            && !p.compact_at_tokens.trim().is_empty()
-            && p.compact_at_tokens.trim().parse::<u64>().is_err()
-        {
-            self.validation_error = format!(
-                "Invalid compaction threshold: '{}'. Expected a whole number of tokens (0 = off).",
-                p.compact_at_tokens
-            );
-        }
-        if self.validation_error.is_empty()
-            && !p.extra_body.trim().is_empty()
-            && serde_json::from_str::<serde_json::Value>(&p.extra_body).is_err()
-        {
-            self.validation_error = "Invalid extra body JSON.".to_string();
-        }
-        if !self.validation_error.is_empty() {
+        true
+    }
+
+    fn do_launch(&mut self) {
+        if !self.validate_launch() {
             return;
         }
+        let Some(p) = self.profiles.get(self.selected_profile) else {
+            return;
+        };
         let target = if self.target_mode == 0 { "local" } else { "ssh" };
         let ssh = if self.target_mode > 0 {
             let slot = &self.ssh_slots[self.target_mode - 1];
@@ -1351,6 +1432,7 @@ pub fn run_launcher(config: &Config) {
         profiles,
         selected_profile,
         validation_error: String::new(),
+        profile_error_shown: false,
         save_dir: settings.save_dir.clone(),
         show_ssh_password: false,
         show_api_key: false,
@@ -1664,6 +1746,131 @@ mod tests {
         assert_eq!(parse_compact_at_tokens(" 65536 "), 65_536);
     }
 
+    /// Build a launcher holding `profiles`, with the first one selected.
+    fn app_with_profiles(profiles: Vec<LlmProfileData>) -> LauncherApp {
+        let mut app = make_app(make_meta(None, None, None, None));
+        app.profiles = profiles;
+        app.selected_profile = 0;
+        app
+    }
+
+    /// The four fields `to_profile` converts with a fallback, each with a value
+    /// that fails to parse and the wording the message must carry.
+    fn invalid_field_cases() -> Vec<(&'static str, LlmProfileData, &'static str)> {
+        vec![
+            (
+                "temperature",
+                LlmProfileData { name: "other".into(), temperature: "5".into(), ..edited_profile() },
+                "Invalid temperature",
+            ),
+            (
+                "max_tokens",
+                LlmProfileData { name: "other".into(), max_tokens: "abc".into(), ..edited_profile() },
+                "Invalid max tokens",
+            ),
+            (
+                "top_p",
+                LlmProfileData { name: "other".into(), top_p: "2.5".into(), ..edited_profile() },
+                "Invalid top_p",
+            ),
+            (
+                "compact_at_tokens",
+                LlmProfileData { name: "other".into(), compact_at_tokens: "-1".into(), ..edited_profile() },
+                "Invalid compaction threshold",
+            ),
+        ]
+    }
+
+    #[test]
+    fn save_is_blocked_by_an_invalid_field_in_an_unselected_profile() {
+        // The regression from #385: validation looked at the selected profile
+        // only, so a typo left in another one was rewritten as a default by the
+        // next save — adding a profile with "+" was enough to trigger it.
+        for (field, bad, expected) in invalid_field_cases() {
+            let selected = LlmProfileData { name: "selected".into(), ..edited_profile() };
+            let mut app = app_with_profiles(vec![selected, bad]);
+
+            app.save_profiles();
+
+            assert!(
+                app.validation_error.contains(expected),
+                "{field}: message must name the field, got {:?}",
+                app.validation_error
+            );
+            assert!(
+                app.validation_error.contains("other"),
+                "{field}: message must name the offending profile, got {:?}",
+                app.validation_error
+            );
+            assert!(
+                app.profile_error_shown,
+                "{field}: the error must be marked as ours so a later save can clear it"
+            );
+        }
+    }
+
+    #[test]
+    fn launch_is_blocked_by_an_invalid_field_in_an_unselected_profile() {
+        // Launch writes every profile to settings.json and pending_launch.json
+        // too, so it needs the same check. `validate_launch` is the part of
+        // `do_launch` that can be called here — the rest exits the process.
+        for (field, bad, expected) in invalid_field_cases() {
+            let selected = LlmProfileData { name: "selected".into(), ..edited_profile() };
+            let mut app = app_with_profiles(vec![selected, bad]);
+
+            assert!(!app.validate_launch(), "{field}: launch must be refused");
+            assert!(
+                app.validation_error.contains(expected),
+                "{field}: launch must report the field, got {:?}",
+                app.validation_error
+            );
+        }
+    }
+
+    #[test]
+    fn launch_accepts_a_list_where_every_profile_is_valid() {
+        let mut app = app_with_profiles(vec![
+            LlmProfileData { name: "one".into(), ..edited_profile() },
+            LlmProfileData { name: "two".into(), temperature: String::new(), ..edited_profile() },
+        ]);
+        assert!(app.validate_launch(), "got {:?}", app.validation_error);
+    }
+
+    #[test]
+    fn valid_and_empty_fields_pass_validation() {
+        let empty = LlmProfileData {
+            name: "blank".into(),
+            temperature: String::new(),
+            max_tokens: String::new(),
+            top_p: String::new(),
+            compact_at_tokens: String::new(),
+            extra_body: String::new(),
+            ..edited_profile()
+        };
+        assert!(validate_all_profile_fields(&[edited_profile(), empty]).is_ok());
+    }
+
+    #[test]
+    fn a_successful_save_leaves_an_unrelated_warning_alone() {
+        // `validation_error` is one slot shared with the SSH-target warning
+        // from session selection. Clearing a profile error must not take that
+        // with it.
+        let mut app = app_with_profiles(vec![edited_profile()]);
+        app.validation_error = "No SSH profile matches 'root@10.0.0.9'.".into();
+        app.profile_error_shown = false;
+
+        app.clear_profile_error();
+
+        assert_eq!(
+            app.validation_error, "No SSH profile matches 'root@10.0.0.9'.",
+            "an SSH warning is not ours to clear"
+        );
+
+        app.set_profile_error("Profile \"x\": Invalid top_p: '9'.".into());
+        app.clear_profile_error();
+        assert!(app.validation_error.is_empty(), "our own error must clear");
+    }
+
     #[test]
     fn launch_config_round_trips_arbiter_profile() {        let cfg = LaunchConfig {
             target: "local".into(),
@@ -1905,6 +2112,7 @@ mod tests {
             }],
             selected_profile: 0,
             validation_error: String::new(),
+            profile_error_shown: false,
             save_dir: None,
             show_ssh_password: false,
             show_api_key: false,

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -207,7 +207,9 @@ fn validate_profile_fields(p: &LlmProfileData) -> Result<(), String> {
 /// Every persistence path converts the whole list through
 /// [`LlmProfileData::to_profile`], so checking only the selected profile left
 /// the others free to be rewritten with defaults (#385).
-fn validate_all_profile_fields(profiles: &[LlmProfileData]) -> Result<(), String> {
+fn validate_all_profile_fields<'a>(
+    profiles: impl IntoIterator<Item = &'a LlmProfileData>,
+) -> Result<(), String> {
     for p in profiles {
         if let Err(msg) = validate_profile_fields(p) {
             return Err(format!("Profile \"{}\": {msg}", p.name));
@@ -862,18 +864,18 @@ impl LauncherApp {
                     s.host == host && slot_port == Some(port)
                 }) {
                     self.target_mode = slot_idx + 1;
-                    self.validation_error.clear();
+                    self.clear_error();
                 } else {
                     self.target_mode = 0;
-                    self.validation_error = format!(
+                    self.set_other_error(format!(
                         "No SSH profile matches '{}'. Select a target manually.",
                         meta.ssh_info.as_deref().unwrap_or_default()
-                    );
+                    ));
                 }
             }
             None => {
                 self.target_mode = 0;
-                self.validation_error.clear();
+                self.clear_error();
             }
         }
     }
@@ -990,11 +992,26 @@ impl LauncherApp {
                 self.save_profiles();
             }
             if self.profiles.len() > 1 && ui.button("X").on_hover_text("Delete profile").clicked() {
-                let removed = &self.profiles[self.selected_profile];
-                delete_secret(&removed.key_env);
-                self.profiles.remove(self.selected_profile);
-                self.selected_profile = self.selected_profile.min(self.profiles.len().saturating_sub(1));
-                self.save_profiles();
+                // Validate what the list *would* be before touching anything.
+                // `delete_secret` is irreversible and `save_profiles` may now
+                // refuse to write, which would strand the profile in
+                // settings.json with its API key already gone from the OS store.
+                let idx = self.selected_profile;
+                let remaining = self
+                    .profiles
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != idx)
+                    .map(|(_, p)| p);
+                match validate_all_profile_fields(remaining) {
+                    Err(msg) => self.set_profile_error(msg),
+                    Ok(()) => {
+                        delete_secret(&self.profiles[idx].key_env);
+                        self.profiles.remove(idx);
+                        self.selected_profile = idx.min(self.profiles.len().saturating_sub(1));
+                        self.save_profiles();
+                    }
+                }
             }
         });
         let mut show_api_key = self.show_api_key;
@@ -1153,17 +1170,33 @@ impl LauncherApp {
     }
 
     /// Show a profile-validation message and remember that it is ours.
+    ///
+    /// Every other write to `validation_error` must go through
+    /// [`LauncherApp::set_other_error`] or [`LauncherApp::clear_error`], which
+    /// drop the flag. Setting the text directly would leave the flag standing
+    /// over someone else's message, and the next successful save would erase it.
     fn set_profile_error(&mut self, msg: String) {
         self.validation_error = msg;
         self.profile_error_shown = true;
+    }
+
+    /// Show a message that did not come from profile validation.
+    fn set_other_error(&mut self, msg: String) {
+        self.validation_error = msg;
+        self.profile_error_shown = false;
+    }
+
+    /// Clear the slot whoever wrote it.
+    fn clear_error(&mut self) {
+        self.validation_error.clear();
+        self.profile_error_shown = false;
     }
 
     /// Drop a previously shown profile-validation message, leaving any other
     /// warning (an unmatched SSH target, for one) on screen.
     fn clear_profile_error(&mut self) {
         if self.profile_error_shown {
-            self.validation_error.clear();
-            self.profile_error_shown = false;
+            self.clear_error();
         }
     }
 
@@ -1204,8 +1237,7 @@ impl LauncherApp {
     /// harness with it — and, worse, exit `0`, so a lost check would look like
     /// a passing run.
     fn validate_launch(&mut self) -> bool {
-        self.validation_error.clear();
-        self.profile_error_shown = false;
+        self.clear_error();
         // Field checks cover every profile, not just the selected one: a launch
         // writes the whole list to settings.json and pending_launch.json, so an
         // unnoticed typo elsewhere would be normalised away (#385).
@@ -1214,26 +1246,32 @@ impl LauncherApp {
             return false;
         }
         let Some(p) = self.profiles.get(self.selected_profile) else {
-            self.validation_error = "No profile selected".to_string();
+            self.set_other_error("No profile selected".to_string());
             return false;
         };
         // Validate unique names and non-empty name.
         if p.name.trim().is_empty() {
-            self.validation_error = "Profile name must not be empty.".to_string();
+            self.set_other_error("Profile name must not be empty.".to_string());
             return false;
         }
         if p.key_env.trim().is_empty() && p.api_base_url.trim().is_empty() {
-            self.validation_error =
+            self.set_other_error(
                 "Keyless (local) profile needs an API URL (e.g. http://localhost:11434/v1)."
-                    .to_string();
+                    .to_string(),
+            );
             return false;
         }
-        for (i, other) in self.profiles.iter().enumerate() {
-            if i != self.selected_profile && other.name == p.name {
-                self.validation_error =
-                    format!("Duplicate profile name: \"{}\". Names must be unique.", p.name);
-                return false;
-            }
+        let duplicate = self
+            .profiles
+            .iter()
+            .enumerate()
+            .any(|(i, other)| i != self.selected_profile && other.name == p.name);
+        if duplicate {
+            let name = p.name.clone();
+            self.set_other_error(format!(
+                "Duplicate profile name: \"{name}\". Names must be unique."
+            ));
+            return false;
         }
         true
     }
@@ -1824,6 +1862,11 @@ mod tests {
                 "{field}: launch must report the field, got {:?}",
                 app.validation_error
             );
+            assert!(
+                app.validation_error.contains("other"),
+                "{field}: launch must name the offending profile, got {:?}",
+                app.validation_error
+            );
         }
     }
 
@@ -1856,8 +1899,7 @@ mod tests {
         // from session selection. Clearing a profile error must not take that
         // with it.
         let mut app = app_with_profiles(vec![edited_profile()]);
-        app.validation_error = "No SSH profile matches 'root@10.0.0.9'.".into();
-        app.profile_error_shown = false;
+        app.set_other_error("No SSH profile matches 'root@10.0.0.9'.".into());
 
         app.clear_profile_error();
 
@@ -1869,6 +1911,60 @@ mod tests {
         app.set_profile_error("Profile \"x\": Invalid top_p: '9'.".into());
         app.clear_profile_error();
         assert!(app.validation_error.is_empty(), "our own error must clear");
+    }
+
+    #[test]
+    fn a_warning_arriving_after_a_profile_error_survives_the_next_save() {
+        // The first version of the test above only covered a slot that was
+        // never ours. The reachable case is the other order: a profile error is
+        // shown, the user then clicks a session whose SSH target does not
+        // match, and that warning overwrites the text. If the flag stayed set,
+        // the next successful save would wipe the warning (review of #389).
+        let mut app = app_with_profiles(vec![edited_profile()]);
+        app.set_profile_error("Profile \"x\": Invalid top_p: '9'.".into());
+
+        app.set_other_error("No SSH profile matches 'root@10.0.0.9'.".into());
+        app.clear_profile_error();
+
+        assert_eq!(
+            app.validation_error, "No SSH profile matches 'root@10.0.0.9'.",
+            "the warning that replaced our error is not ours to clear"
+        );
+    }
+
+    #[test]
+    fn deleting_a_profile_is_refused_before_the_credential_is_dropped() {
+        // `delete_secret` cannot be undone and `save_profiles` can now refuse,
+        // so the list has to be checked *without* the doomed profile before
+        // anything is removed — otherwise settings.json keeps a profile whose
+        // API key is already gone from the OS store (review of #389).
+        let doomed = LlmProfileData { name: "doomed".into(), ..edited_profile() };
+        let broken = LlmProfileData {
+            name: "broken".into(),
+            max_tokens: "abc".into(),
+            ..edited_profile()
+        };
+        let profiles = vec![doomed, broken];
+
+        // What the delete handler checks: everything except the selected entry.
+        let remaining = profiles.iter().enumerate().filter(|(i, _)| *i != 0).map(|(_, p)| p);
+        let verdict = validate_all_profile_fields(remaining);
+
+        assert!(
+            verdict.is_err(),
+            "an invalid profile elsewhere must block the delete before delete_secret runs"
+        );
+        assert!(verdict.unwrap_err().contains("broken"));
+    }
+
+    #[test]
+    fn deleting_a_profile_is_allowed_when_the_rest_are_valid() {
+        let profiles = vec![
+            LlmProfileData { name: "doomed".into(), ..edited_profile() },
+            LlmProfileData { name: "fine".into(), ..edited_profile() },
+        ];
+        let remaining = profiles.iter().enumerate().filter(|(i, _)| *i != 0).map(|(_, p)| p);
+        assert!(validate_all_profile_fields(remaining).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Closes #385

## Summary

`do_launch` validated the selected profile, while `save_profiles` and the launch
persistence path converted the *whole* list through `LlmProfileData::to_profile`,
which falls back on unparseable input. A typo left in another profile was
rewritten as a default with no error on the next save — and clicking "+" saves.

Took the first option from the issue: validate the whole list before every
write. Two shared functions — `validate_profile_fields` holds the per-field
checks lifted out of `do_launch` unchanged, and `validate_all_profile_fields`
runs them over the list and prefixes the message with the profile name.
`save_profiles` refuses to write when it fails. `do_launch` runs the same check
before its name and keyless-URL checks, which stay selected-profile-only since
names are not silently normalised.

The worry about having nowhere to show the message did not survive contact with
the code: `validation_error` renders in the fixed bottom panel, visible from
every tab, so an error raised by "+" in Models is already on screen. That is
what makes the first option sufficient — the second option's cost was largely
this same UI question.

`extra_body` is covered by the shared function too. It is in the same class
(`serde_json::from_str(...).ok()` in `to_profile`) and was already checked for
the selected profile, so leaving it out of the loop would have been arbitrary.

## Refusing rather than preserving

The DoD allows either "survives `save_profiles`" or "blocks it with a clear
error". Preserving is not reachable: `settings.json` holds typed fields and
`max_tokens = "abc"` has no representation there. The real choice is between a
silent default and a refusal, and this refuses. Noted in the `save_profiles` doc
comment so the next reader does not re-litigate it.

`validation_error` is one slot shared with the "No SSH profile matches" warning
from session selection, so a `profile_error_shown` flag now records who wrote
it; a successful save clears only its own message.

## A test that passed while the bug was back

Worth flagging, since it nearly went in. The first version of the launch test
called `do_launch` directly. Reverting the guard to check the test did **not**
make it fail: the call ran on to `std::process::exit(0)`, which killed the test
binary mid-run with a success code, and cargo reported the whole run as passing.

So the launch checks moved into `validate_launch`, which returns `bool` and is
what the test calls. Both new guards were then re-confirmed by reverting each
one and watching the matching test fail properly.

## Tests

`filar-gui` goes from 35 to 40 tests:

- save refused for each of the four fields (`temperature`, `max_tokens`,
  `top_p`, `compact_at_tokens`) set to an invalid value in an **unselected**
  profile, asserting the message names both the profile and the field;
- the same four for the launch path;
- a list where every profile is valid passes both paths;
- clearing a profile error leaves an unrelated SSH warning on screen.

Tests only ever exercise the rejection path, which returns before
`Settings::save` — the success path writes into the real OS data directory.

## Verified here

- `cargo build --workspace`, `cargo test --workspace` — green, 748 → 753 passed,
  8 ignored.
- `cargo build --release -p filar-app` — green; the binary starts, loads config
  and enters GUI-only mode.

## The repro from the issue, run against the built binary

Driving the launcher turned out to be possible after all: `Xvfb` plus `xdotool`,
with the release binary and a seeded two-profile `settings.json`. Steps 1–4 from
the issue, performed on the real GUI:

1. Two profiles, `first` selected.
2. Switched to `second`, replaced `max_tokens` (`8000`) with `abc`.
3. Switched back to `first`, clicked "+".

Result — the launcher shows, in red in the bottom panel:

    Profile "second": Invalid max tokens: 'abc'. Expected a whole number above 0.

and `settings.json` is untouched: still exactly `first` and `second`, with
`second.max_tokens` still `8000` rather than `4096`, and the new profile not
persisted. Before this change the same steps wrote the default silently with no
message.

## Not verified

- Nothing on Windows or macOS; Linux under a virtual framebuffer only. The
  layout is the same code path, but the check ran on one platform.
- The other three fields were exercised in tests, not through the GUI; only
  `max_tokens` was driven by hand.

## Out of scope

Duplicate and empty profile names are still validated for the selected profile
only, at launch. Unlike the numeric fields they survive a save intact, so it is
a UX gap rather than data loss — happy to file it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Launcher settings now validate all profiles when saving or launching, including numeric fields and extra JSON data.
  - Deleting a profile is prevented if another profile contains invalid settings, helping preserve stored credentials.
  - Profile validation errors no longer incorrectly override or persist alongside unrelated warnings.
  - Improved handling of profile names and validation feedback during launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->