### PR TITLE
feat(tui): compact and retry once on context overflow, handle summary failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
   you can expand. `Ctrl+K` compacts on request, regardless of the threshold
   ([#377](https://github.com/devlawey/filar/issues/377)).
 
+- Compaction no longer depends on `compact_at_tokens` being set correctly. When
+  the provider refuses a request because the context window is exceeded, the
+  history is compacted and the request is sent once more, so a threshold set
+  above the model's actual window is recovered from rather than fatal. A second
+  overflow is reported instead of retried
+  ([#378](https://github.com/devlawey/filar/issues/378)).
+
+- A summary that comes back empty, unusably short, or as an outright error no
+  longer costs you the history: the turn is sent with the full history and a
+  warning appears in the feed. When the context is still over the threshold
+  immediately after a compaction, the TUI now says the history cannot be reduced
+  further and suggests starting a new session, rather than compacting again to
+  no effect ([#378](https://github.com/devlawey/filar/issues/378)).
+
 ### Fixed
 
 - Deleting a launcher profile no longer removes its stored API key when the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5846,6 +5846,17 @@ Terms are now split into ones that can only mean the conversation
 length-shaped complaint (`input`, `prompt`). The mutex around the held error
 recovers from poisoning instead of unwrapping.
 
+The most consequential one arrived last and was nearly missed: the reactive
+path never persisted its own compaction. `pending_compaction` is `None` on that
+path, so `apply_compaction` discarded the summary as stale — the retry ran on a
+local compacted copy while the session kept the full history, and every
+following turn overflowed again, paying an overflow, a summary and a retry each
+time. The manual trace in the PR showed it (a turn after the retry was back up
+to 16 messages) and I read past it. A `TuiEvent::CompactionStarted` now arms the
+session before the summary request goes out; the channel is ordered, so it lands
+first, and the stale guard keeps working because anything that replaces the
+history in between clears the flag again.
+
 Declined: plumbing cancellation into `compact_for_request`, because the check
 before starting a reactive summary already exists in
 `should_retry_after_overflow` and interrupting one in flight would change the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5857,6 +5857,15 @@ session before the summary request goes out; the channel is ordered, so it lands
 first, and the stale guard keeps working because anything that replaces the
 history in between clears the flag again.
 
+A second round on that fix found the arming itself too weak. Checking
+`boundary <= messages.len()` does not tell a restored history from the one the
+boundary was computed against — restore a session of the same length while the
+summary is in flight and the old boundary would be armed on the new history and
+cut its tail off. Sessions now carry a `history_epoch`, bumped only when the
+history is replaced wholesale or the run is cancelled, never on an append. The
+runner captures it at spawn and sends it with `CompactionStarted`; the app
+refuses to arm if it has moved. The length check stays as a cheap bound.
+
 Declined: plumbing cancellation into `compact_for_request`, because the check
 before starting a reactive summary already exists in
 `should_retry_after_overflow` and interrupting one in flight would change the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5752,6 +5752,74 @@ was left out: `Ctrl+R` is reverse-i-search in a shell and would collide in
 interactive mode, so the key choice needs a decision of its own. Translating
 SGR into ratatui styles instead of discarding colour is a possible follow-up.
 
+## Issue #378: feat(tui/agent) — reactive compaction and summary-failure handling (3/4)
+
+**Milestone:** 1.0.6. **Branch:** `feat/378-reactive-compaction`.
+
+**Reactive path.** `compact_at_tokens` is set by hand, so it can be set above
+the model's real window — and then the request fails before compaction ever
+fires, which is precisely the case the feature was written for. The provider's
+refusal is now classified as `CoreError::ContextOverflow`, and the runner
+compacts and re-sends once.
+
+Classification lives in `ApiError::from_http_status`, following the
+`ToolsUnsupported` precedent: OpenAI-compatible providers share no code for
+this, so matching on the wording is the only portable option.
+`looks_like_context_overflow` is checked *before* the tool heuristic — an
+overflow body often mentions tools among what did not fit, and the overflow is
+the more specific diagnosis — and is restricted to non-429 4xx for the same
+reason the tool check is: a 5xx that happens to mention tokens is transient, and
+turning it into a non-retryable overflow would throw away a free recovery.
+Overflow is deliberately absent from `is_retryable()`; repeating the identical
+request earns the identical refusal, and only the owner of the history can make
+a retry mean anything.
+
+**Where the retry rule lives.** In `should_retry_after_overflow`, a free
+function, not inline in the spawned task. The loop around it ends in
+`agent.run`, so a lost condition there would either retry forever or never
+retry, and a test of the loop would be a test of the agent. This is the lesson
+from the #389 review applied before the fact rather than after it.
+
+**Suppressing the first error.** `Agent::run` emits `AgentEvent::Error` once,
+immediately before returning the same error, so the sink now holds it and the
+task forwards it only when the outcome is final. Without that the user would
+see a failure notice and then a successful answer for the same turn.
+
+**Summary failures.** Mostly already handled by #377, which sends the turn on
+the full history and warns. Added the length rule: `MIN_SUMMARY_CHARS = 40`.
+The prompt from #377 asks for executed commands first and established facts
+second, and neither fits in under a clause; the observed failure modes — an
+empty string, `OK`, `None.`, a refusal such as `I cannot summarize this.` (24
+chars) — all sit far below it. Chosen low on purpose: rejecting a real summary
+costs a warning and an uncompacted history, while accepting a non-summary
+silently destroys the head. A one-line summary of a trivial exchange clears 40
+comfortably, and there is a test pinning exactly that.
+
+**No second compaction in a row.** Two session flags:
+`compacted_without_relief` is set when a summary is applied and cleared when the
+context is next seen below the threshold; `compaction_exhausted` is set once the
+user has been told, so the notice does not repeat every turn. Both are cleared
+when a saved session is restored, since a restored history says nothing about
+what the previous one could be reduced to.
+
+**Done:** 11 tests added. Six real provider wordings classify as overflow; a
+5xx and a 429 mentioning tokens keep their own meaning; overflow is not
+retryable and survives into `CoreError`; empty and too-short summaries are
+failures while a short real one is not; the second compaction in a row is
+refused with a single notice and re-arms after the context drops; a failed
+summary leaves the history identical block for block; and the retry rule fires
+once and not on success, other errors, or cancellation. Confirmed by reverting:
+the re-compaction guard and the length rule each fail their test.
+
+**Public contract:** `CoreError` gains a variant. No exhaustive match on it
+exists in the workspace, so nothing breaks; the sanitiser in
+`transport/src/secret.rs` has a catch-all that would flatten it to `Other`, but
+that path carries command-execution errors, never LLM ones.
+
+**Next steps:** #387 must count the summary request's own tokens exactly once,
+and it now has two call sites to cover — the threshold path and the reactive
+one — both funnelled through `compact_for_request`, which is the place to do it.
+
 ## Issue #385: fix(gui) — validation only ever looked at the selected profile
 
 **Milestone:** 1.0.6. **Branch:** `fix/385-validate-all-profiles`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5820,6 +5820,44 @@ that path carries command-execution errors, never LLM ones.
 and it now has two call sites to cover — the threshold path and the reactive
 one — both funnelled through `compact_for_request`, which is the place to do it.
 
+**Review round (PR #390):** seven comments, five taken, two declined.
+
+The worst was self-inflicted. The retry notice was sent as
+`AgentEvent::Error`, and that handler is terminal: it sets `agent_running =
+false`, drops back to `Normal` and clears `self.cancellation`. A request was
+therefore left in flight that the user could no longer cancel, with the spinner
+off and the input unlocked — while the whole point of holding the first error
+back had been to avoid exactly this kind of false signal. A `TuiEvent::Notice`
+variant now carries feed-only text and touches no run state.
+
+The reactive path also did not know about the proactive one. If the threshold
+folded the head and the request still overflowed, the runner would fold again
+in the same turn, against the rule this issue sets. `already_compacted` is now
+seeded from whether `compact_for_request` actually shortened the history, which
+gets both halves right: a successful proactive fold uses the turn's one
+compaction, a failed one leaves the reactive path available.
+
+Two smaller ones were plain oversights: `apply_loaded_session` is a second
+restore path and did not clear the new flags (the first one did), and the
+overflow heuristic accepted `input` next to a bare `exceed`, which matches
+`input exceeds maximum file size` — an upload limit that compaction cannot fix.
+Terms are now split into ones that can only mean the conversation
+(`context length`, `token`, `messages`) and ones that need an explicitly
+length-shaped complaint (`input`, `prompt`). The mutex around the held error
+recovers from poisoning instead of unwrapping.
+
+Declined: plumbing cancellation into `compact_for_request`, because the check
+before starting a reactive summary already exists in
+`should_retry_after_overflow` and interrupting one in flight would change the
+public signature of `summarise_history`, which external embedders consume by
+tag — and #377's path has the same property. Also declined content-matching for
+refusals that clear `MIN_SUMMARY_CHARS`: the issue scopes this to a length
+threshold, and the #377 prompt tells the model to answer in the session's
+language, so a list of English refusal phrases would miss most of them while
+false-rejecting real summaries. The gap is real, so the doc comment now says
+plainly that this is a length check and nothing more, rather than implying
+refusals are caught.
+
 ## Issue #385: fix(gui) — validation only ever looked at the selected profile
 
 **Milestone:** 1.0.6. **Branch:** `fix/385-validate-all-profiles`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5866,6 +5866,15 @@ history is replaced wholesale or the run is cancelled, never on an append. The
 runner captures it at spawn and sends it with `CompactionStarted`; the app
 refuses to arm if it has moved. The length check stays as a cheap bound.
 
+A later round caught the reactive path ignoring session-level exhaustion:
+`already_retried` covers a single run, so the next turn started clean and would
+compact again after the user had been told the history cannot be reduced
+further. `compaction_exhausted` is now passed into `spawn_agent` and folded
+into `should_retry_after_overflow`, so the retry notice is not emitted either.
+Only that flag blocks the reactive path, not `compacted_without_relief`: the
+latter is derived from a hand-set threshold that may simply be wrong, which is
+the premise of the whole feature, whereas a provider refusal is ground truth.
+
 Declined: plumbing cancellation into `compact_for_request`, because the check
 before starting a reactive summary already exists in
 `should_retry_after_overflow` and interrupting one in flight would change the

--- a/crates/agent/src/compaction.rs
+++ b/crates/agent/src/compaction.rs
@@ -39,7 +39,7 @@ Write in the language the session is conducted in.";
 /// command and one established fact — the first two things
 /// [`COMPACTION_SYSTEM_PROMPT`] asks for — and that cannot be done in under a
 /// clause. The observed failure modes are all far below this: an empty string,
-/// `OK`, `None.`, or a refusal such as `I cannot summarize this.` (24 chars).
+/// `OK`, `None.`, a bare refusal.
 ///
 /// Deliberately low rather than generous. The cost of rejecting a real summary
 /// is a warning and an uncompacted history, which for a genuinely tiny history
@@ -47,6 +47,13 @@ Write in the language the session is conducted in.";
 /// whole head. A one-line summary of even a trivial exchange — "User asked for
 /// disk usage; agent ran df -h; root is 82% full." — clears it comfortably, so
 /// the false-rejection risk stays near zero.
+///
+/// **This is a length check and nothing more.** A *wordy* refusal — "I cannot
+/// summarize this conversation at this time." — is longer than the threshold
+/// and passes. Catching that needs content matching, which the prompt above
+/// makes language-dependent by asking the model to answer in the language of
+/// the session, so it is a separate mechanism rather than a bigger number
+/// here (raised in review of #390).
 pub const MIN_SUMMARY_CHARS: usize = 40;
 
 /// Ask the model to summarise `transcript`.

--- a/crates/agent/src/compaction.rs
+++ b/crates/agent/src/compaction.rs
@@ -33,6 +33,22 @@ Drop: full command output, reasoning, repetition, pleasantries.
 Do not speculate or add anything that is not in the transcript.
 Write in the language the session is conducted in.";
 
+/// Shortest summary treated as usable, in characters.
+///
+/// A summary that replaces many turns has to carry at least one executed
+/// command and one established fact — the first two things
+/// [`COMPACTION_SYSTEM_PROMPT`] asks for — and that cannot be done in under a
+/// clause. The observed failure modes are all far below this: an empty string,
+/// `OK`, `None.`, or a refusal such as `I cannot summarize this.` (24 chars).
+///
+/// Deliberately low rather than generous. The cost of rejecting a real summary
+/// is a warning and an uncompacted history, which for a genuinely tiny history
+/// is harmless; the cost of accepting a non-summary is the silent loss of the
+/// whole head. A one-line summary of even a trivial exchange — "User asked for
+/// disk usage; agent ran df -h; root is 82% full." — clears it comfortably, so
+/// the false-rejection risk stays near zero.
+pub const MIN_SUMMARY_CHARS: usize = 40;
+
 /// Ask the model to summarise `transcript`.
 ///
 /// Returns the brief that will replace the compacted head. The call carries no
@@ -40,8 +56,9 @@ Write in the language the session is conducted in.";
 /// plain [`LlmClient::chat`] rather than a streaming call: nothing renders the
 /// partial text, and the caller only needs the finished brief.
 ///
-/// An empty reply is reported as an error rather than silently accepted —
-/// replacing the head with an empty summary would lose it outright.
+/// A reply shorter than [`MIN_SUMMARY_CHARS`] — an empty string included — is
+/// reported as an error rather than silently accepted: replacing the head with
+/// a non-summary would lose it outright (#378).
 pub async fn summarise_history(llm: &dyn LlmClient, transcript: &str) -> Result<String> {
     let request = ChatRequest {
         messages: vec![
@@ -53,10 +70,13 @@ pub async fn summarise_history(llm: &dyn LlmClient, transcript: &str) -> Result<
 
     let response = llm.chat(&request).await?;
     let text = response.text.trim().to_string();
-    if text.is_empty() {
-        return Err(CoreError::Other(
-            "the model returned an empty summary".into(),
-        ));
+    if text.chars().count() < MIN_SUMMARY_CHARS {
+        // Treated exactly like an outright failure by the caller: the history
+        // is left alone and the user is warned (#378).
+        return Err(CoreError::Other(format!(
+            "the model returned a summary too short to be usable ({} chars)",
+            text.chars().count()
+        )));
     }
     Ok(text)
 }
@@ -81,5 +101,39 @@ mod tests {
     #[test]
     fn the_prompt_forbids_inventing_content() {
         assert!(COMPACTION_SYSTEM_PROMPT.contains("Do not speculate"));
+    }
+
+    struct FixedLlm(String);
+
+    #[async_trait::async_trait]
+    impl crate::LlmClient for FixedLlm {
+        async fn chat(&self, _request: &crate::ChatRequest) -> Result<crate::ChatResponse> {
+            Ok(crate::ChatResponse::text(self.0.clone()))
+        }
+    }
+
+    async fn summarise(reply: &str) -> Result<String> {
+        summarise_history(&FixedLlm(reply.to_string()), "User: hi\nAgent: hello\n").await
+    }
+
+    #[tokio::test]
+    async fn an_empty_or_too_short_reply_is_a_failure_not_a_summary() {
+        // Folding the head into any of these would destroy it while looking
+        // like a successful compaction (#378).
+        for reply in ["", "   ", "OK", "None.", "I cannot summarize this."] {
+            assert!(
+                summarise(reply).await.is_err(),
+                "must be rejected as a summary: {reply:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_short_but_real_summary_is_accepted() {
+        // The threshold has to clear a genuine one-line summary of a trivial
+        // history, or compaction would break on short sessions.
+        let real = "User asked for disk usage; agent ran df -h; root is 82% full.";
+        assert!(real.chars().count() >= MIN_SUMMARY_CHARS);
+        assert_eq!(summarise(real).await.unwrap(), real);
     }
 }

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -539,6 +539,8 @@ enum ApiError {
     Client(u16, String),
     /// Provider rejected tool/function calling — agent loop cannot run.
     ToolsUnsupported,
+    /// Provider refused the request: the context window is exceeded (#378).
+    ContextOverflow(String),
     /// Failed to parse the response body.
     Parse(String),
 }
@@ -549,6 +551,14 @@ impl ApiError {
         // Applying the heuristic to 5xx would turn transient failures into
         // non-retryable ToolsUnsupported.
         let is_client_4xx = (400..500).contains(&status_code) && status_code != 429;
+        // Checked before the tool heuristic: an overflow body often mentions
+        // tools as part of what did not fit, and the overflow is the more
+        // specific diagnosis. Same 4xx-only restriction, for the same reason —
+        // a 5xx that happens to mention length is transient, not an overflow.
+        if is_client_4xx && looks_like_context_overflow(&body_text) {
+            warn!(status_code, body = %body_text, "provider reports the context window is exceeded");
+            return ApiError::ContextOverflow(body_text);
+        }
         if is_client_4xx && looks_like_tools_unsupported(&body_text) {
             warn!(status_code, body = %body_text, "provider rejected tool calling");
             return ApiError::ToolsUnsupported;
@@ -560,6 +570,41 @@ impl ApiError {
             _ => ApiError::Client(status_code, body_text),
         }
     }
+}
+
+/// Heuristic: provider body says the conversation exceeds the context window.
+///
+/// OpenAI-compatible providers share no code for this. OpenAI itself returns
+/// `400` with `context_length_exceeded` and "maximum context length"; others
+/// phrase it as "too many tokens", "input is too long", "prompt is too long",
+/// "exceeds the maximum" or "reduce the length of the messages", and a few use
+/// `413`. Matching on the wording is therefore the only portable option — the
+/// same trade-off `looks_like_tools_unsupported` already makes.
+///
+/// A false positive costs one compaction and a retry; a false negative leaves
+/// the user with a failed turn, which is the worse of the two.
+fn looks_like_context_overflow(body: &str) -> bool {
+    let lower = body.to_lowercase();
+    if lower.contains("context_length_exceeded") || lower.contains("context length exceeded") {
+        return true;
+    }
+    let mentions_size = lower.contains("context length")
+        || lower.contains("context window")
+        || lower.contains("token")
+        || lower.contains("prompt")
+        || lower.contains("input")
+        || lower.contains("messages");
+    if !mentions_size {
+        return false;
+    }
+    lower.contains("too long")
+        || lower.contains("too many")
+        || lower.contains("too large")
+        || lower.contains("exceed")
+        || lower.contains("maximum context")
+        || lower.contains("max context")
+        || lower.contains("reduce the length")
+        || lower.contains("longer than")
 }
 
 /// Heuristic: provider body says the model/server cannot do tool calling.
@@ -582,6 +627,9 @@ impl std::fmt::Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ApiError::Connect(msg) => write!(f, "connection error: {msg}"),
+            ApiError::ContextOverflow(msg) => {
+                write!(f, "the conversation exceeds the model's context window: {msg}")
+            }
             ApiError::Network(msg) => write!(f, "network error: {msg}"),
             ApiError::Timeout(d) => write!(
                 f,
@@ -615,6 +663,9 @@ impl ApiError {
             ApiError::Timeout(_) | ApiError::ToolsUnsupported => {
                 CoreError::Other(self.to_string())
             }
+            // Kept as its own variant all the way to the TUI: it is the signal
+            // that compacting and retrying once is worth doing (#378).
+            ApiError::ContextOverflow(msg) => CoreError::ContextOverflow(msg.clone()),
             ApiError::Connect(msg) => CoreError::Other(format!("connection error: {msg}")),
             ApiError::Network(msg) => CoreError::Other(format!("network error: {msg}")),
             ApiError::Auth(msg) => CoreError::Other(format!("authentication error: {msg}")),
@@ -2142,5 +2193,66 @@ data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}
 
         assert_eq!(response.text, "abcd");
         assert_eq!(served.load(Ordering::SeqCst), 1, "no retry expected");
+    }
+}
+
+#[cfg(test)]
+mod context_overflow_tests {
+    use super::*;
+
+    /// Bodies collected from the phrasings OpenAI-compatible providers use.
+    /// Each must classify as an overflow, or the reactive path never fires
+    /// for that provider (#378).
+    #[test]
+    fn typical_provider_wordings_are_recognised() {
+        let bodies = [
+            r#"{"error":{"message":"This model's maximum context length is 8192 tokens. However, your messages resulted in 9231 tokens.","code":"context_length_exceeded"}}"#,
+            r#"{"error":{"message":"Input is too long for requested model."}}"#,
+            r#"{"error":{"message":"prompt is too long: 210000 tokens > 200000 maximum"}}"#,
+            r#"{"error":{"message":"Please reduce the length of the messages."}}"#,
+            r#"{"error":{"message":"too many tokens in the request"}}"#,
+            r#"{"error":{"message":"the context window was exceeded"}}"#,
+        ];
+        for body in bodies {
+            assert!(
+                matches!(
+                    ApiError::from_http_status(400, body.to_string()),
+                    ApiError::ContextOverflow(_)
+                ),
+                "not recognised as an overflow: {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_overflow_is_not_treated_as_a_transient_failure() {
+        // Blindly retrying the identical request gets the identical refusal.
+        // The retry is only meaningful once the history has been shortened,
+        // which is the TUI's job, not the transport's.
+        let err = ApiError::ContextOverflow("maximum context length".into());
+        assert!(!err.is_retryable());
+        assert!(matches!(
+            err.into_core_error(),
+            CoreError::ContextOverflow(_)
+        ));
+    }
+
+    #[test]
+    fn unrelated_failures_are_left_alone() {
+        assert!(!matches!(
+            ApiError::from_http_status(400, "invalid api key".into()),
+            ApiError::ContextOverflow(_)
+        ));
+        // A 5xx that happens to mention tokens is transient, and turning it
+        // into a non-retryable overflow would lose a free recovery.
+        assert!(matches!(
+            ApiError::from_http_status(503, "token service unavailable, too many".into()),
+            ApiError::Server(503, _)
+        ));
+        // 429 keeps its own meaning and its own retry.
+        assert!(matches!(
+            ApiError::from_http_status(429, "too many tokens per minute".into()),
+            ApiError::RateLimit(_)
+        ));
     }
 }

--- a/crates/agent/src/openai_compat.rs
+++ b/crates/agent/src/openai_compat.rs
@@ -588,23 +588,33 @@ fn looks_like_context_overflow(body: &str) -> bool {
     if lower.contains("context_length_exceeded") || lower.contains("context length exceeded") {
         return true;
     }
-    let mentions_size = lower.contains("context length")
+    // Terms that can only be about the conversation itself. Any complaint
+    // about size next to one of these is an overflow.
+    let names_the_context = lower.contains("context length")
         || lower.contains("context window")
         || lower.contains("token")
-        || lower.contains("prompt")
-        || lower.contains("input")
         || lower.contains("messages");
-    if !mentions_size {
-        return false;
-    }
-    lower.contains("too long")
+    // Terms that are about the request but not necessarily its length —
+    // "input exceeds maximum file size" is an upload limit, and compacting the
+    // history would not help it. These need an explicitly length-shaped
+    // complaint, not a bare "exceeds".
+    let names_the_request = lower.contains("prompt") || lower.contains("input");
+
+    let complains_about_size = lower.contains("too long")
         || lower.contains("too many")
         || lower.contains("too large")
         || lower.contains("exceed")
         || lower.contains("maximum context")
         || lower.contains("max context")
         || lower.contains("reduce the length")
+        || lower.contains("longer than");
+    let complains_about_length = lower.contains("too long")
+        || lower.contains("too many")
         || lower.contains("longer than")
+        || lower.contains("reduce the length");
+
+    (names_the_context && complains_about_size)
+        || (names_the_request && complains_about_length)
 }
 
 /// Heuristic: provider body says the model/server cannot do tool calling.
@@ -2235,6 +2245,26 @@ mod context_overflow_tests {
             err.into_core_error(),
             CoreError::ContextOverflow(_)
         ));
+    }
+
+    #[test]
+    fn a_size_limit_that_compaction_cannot_fix_is_not_an_overflow() {
+        // "input" plus "exceeds" is not enough: an upload limit says both, and
+        // compacting the conversation would not shorten a file (review of
+        // #390). Only an explicitly length-shaped complaint counts for the
+        // vaguer terms.
+        for body in [
+            r#"{"error":{"message":"input exceeds maximum file size"}}"#,
+            r#"{"error":{"message":"prompt exceeds the allowed number of images"}}"#,
+        ] {
+            assert!(
+                matches!(
+                    ApiError::from_http_status(400, body.to_string()),
+                    ApiError::Client(400, _)
+                ),
+                "must stay a plain client error: {body}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -28,6 +28,17 @@ pub enum CoreError {
     #[error("connection lost: {0}")]
     ConnectionLost(String),
 
+    /// The provider refused the request because the conversation no longer
+    /// fits the model's context window.
+    ///
+    /// Distinct from [`CoreError::Other`] because the caller can act on it:
+    /// repeating the same request is guaranteed to fail again, but the same
+    /// request over a shortened history may succeed. It is deliberately *not*
+    /// retryable at the transport level for that reason — only the owner of
+    /// the history can make the retry meaningful (#378).
+    #[error("context overflow: {0}")]
+    ContextOverflow(String),
+
     /// Generic error for cases that don't fit a more specific variant.
     #[error("{0}")]
     Other(String),

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -445,6 +445,16 @@ pub struct Session {
     /// the boundary index the head ends at. The runner performs the summary
     /// and hands it back; `None` means no compaction is due (#377).
     pub pending_compaction: Option<usize>,
+    /// Set when a compaction was applied and the context has not been seen
+    /// below the threshold since.
+    ///
+    /// A second compaction in that state cannot help: the history is already
+    /// a summary plus the verbatim tail, so folding again would spend a
+    /// request and a wait to remove almost nothing (#378).
+    pub compacted_without_relief: bool,
+    /// Set once the user has been told that compaction cannot shrink this
+    /// session further, so the notice is not repeated on every turn.
+    pub compaction_exhausted: bool,
     /// Cumulative output tokens generated for this session.
     pub tokens_out: u64,
     /// Cumulative cost in USD. Summed across all profiles.
@@ -780,6 +790,8 @@ impl Session {
             last_prompt_tokens: None,
             context_full_notice_shown: false,
             pending_compaction: None,
+            compacted_without_relief: false,
+            compaction_exhausted: false,
             tokens_out: 0,
             cost_usd: None,
             per_profile: HashMap::new(),
@@ -1143,6 +1155,10 @@ impl App {
             s.last_prompt_tokens = None;
             s.context_full_notice_shown = false;
             s.pending_compaction = None;
+            // A restored history is a different context: whatever the previous
+            // one could or could not be reduced to says nothing about it.
+            s.compacted_without_relief = false;
+            s.compaction_exhausted = false;
         }
         let default_name = if default_profile_name.is_empty() { "default" } else { default_profile_name };
         if let Some(profile) = llm_profile {
@@ -1207,8 +1223,30 @@ impl App {
 
         if !filar_core::should_compact(used, threshold) {
             // Back below the threshold (a new session, or a smaller request):
-            // arm the notice again.
-            self.active_session_mut().context_full_notice_shown = false;
+            // arm the notice again, and forget that the last compaction did
+            // not help — it evidently did, or the history has moved on.
+            let s = self.active_session_mut();
+            s.context_full_notice_shown = false;
+            s.compacted_without_relief = false;
+            s.compaction_exhausted = false;
+            return;
+        }
+        if self.active_session().compaction_exhausted {
+            // Already told them; saying it again every turn helps nobody.
+            return;
+        }
+        if self.active_session().compacted_without_relief {
+            // Still above the threshold immediately after a compaction: the
+            // head is already folded and what remains is the verbatim tail.
+            // Compacting again cannot reduce it, so say so once and stop
+            // rather than spending another summary request (#378).
+            let used = used.unwrap_or(0);
+            self.active_session_mut().compaction_exhausted = true;
+            self.push_message(ChatBlock::System(format!(
+                "Context is still at {used} prompt tokens after compacting, at or above the \
+                 {threshold} threshold for profile '{profile_name}'. The history cannot be \
+                 reduced further - start a new session to continue with a clean context."
+            )));
             return;
         }
         if self.active_session().context_full_notice_shown {
@@ -1315,6 +1353,9 @@ impl App {
         // the context back under the threshold — a large tail, a long summary —
         // would mean compaction never fires again for the rest of the session.
         self.active_session_mut().context_full_notice_shown = false;
+        // Until the context is measured below the threshold again, a further
+        // compaction is known to be pointless (#378).
+        self.active_session_mut().compacted_without_relief = true;
         // Block indices moved, so any user collapse overrides now point at the
         // wrong blocks.
         self.collapsed_overrides.clear();
@@ -7707,6 +7748,98 @@ mod tests {
         let before = app.active_session().messages.len();
         app.begin_agent_request("hello".into());
         assert_eq!(app.active_session().messages.len(), before);
+    }
+
+    /// An app with `profile` at `threshold` and a history long enough to have
+    /// a compactable head.
+    fn app_over_threshold(threshold: u64, used: u64) -> App {
+        let mut app = App::new("test".into(), CommandConfirmMode::Always);
+        app.profiles = vec![filar_core::LlmProfile {
+            name: "p".into(), model: "m".into(), api_base_url: "u".into(),
+            max_tokens: 4096, key_env: "k".into(),
+            temperature: None, top_p: None, extra_body: None,
+            compact_at_tokens: threshold,
+        }];
+        app.default_profile_name = "p".into();
+        for i in 0..20 {
+            app.push_message(ChatBlock::User(format!("turn {i}")));
+            app.push_message(ChatBlock::Agent(format!("reply {i}")));
+        }
+        app.active_session_mut().last_prompt_tokens = Some(used);
+        app
+    }
+
+    #[test]
+    fn a_second_compaction_is_not_attempted_when_the_first_did_not_help() {
+        // After a compaction the history is a summary plus the verbatim tail.
+        // If that is still over the threshold, folding again cannot shrink it,
+        // so a second attempt would spend a summary request and a wait to
+        // achieve nothing (#378).
+        let mut app = app_over_threshold(1_000, 5_000);
+
+        app.report_context_fill("p");
+        let boundary = app.active_session().pending_compaction.expect("first arms");
+
+        app.apply_compaction(boundary, "A real summary of the earlier turns here.".into());
+        assert!(app.active_session().compacted_without_relief);
+
+        // Still over the threshold on the next request.
+        app.active_session_mut().last_prompt_tokens = Some(5_000);
+        app.report_context_fill("p");
+
+        assert_eq!(
+            app.active_session().pending_compaction, None,
+            "compaction must not be armed a second time in a row"
+        );
+        assert!(
+            matches!(app.active_session().messages.last(),
+                Some(ChatBlock::System(s)) if s.contains("cannot be") && s.contains("new session")),
+            "the user must be told, got {:?}", app.active_session().messages.last()
+        );
+
+        // And the notice is not repeated on every following turn.
+        let after_notice = app.active_session().messages.len();
+        app.report_context_fill("p");
+        assert_eq!(app.active_session().messages.len(), after_notice);
+        assert_eq!(app.active_session().pending_compaction, None);
+    }
+
+    #[test]
+    fn dropping_back_under_the_threshold_re_arms_compaction() {
+        let mut app = app_over_threshold(1_000, 5_000);
+        app.report_context_fill("p");
+        let boundary = app.active_session().pending_compaction.expect("first arms");
+        app.apply_compaction(boundary, "A real summary of the earlier turns here.".into());
+
+        app.active_session_mut().last_prompt_tokens = Some(100);
+        app.report_context_fill("p");
+        assert!(!app.active_session().compacted_without_relief);
+        assert!(!app.active_session().compaction_exhausted);
+    }
+
+    #[test]
+    fn a_failed_summary_leaves_the_history_byte_for_byte_unchanged() {
+        // Losing the head because the summariser misbehaved would be worse
+        // than a long context, so the failure path must not touch it (#378).
+        let mut app = app_over_threshold(1_000, 5_000);
+        app.report_context_fill("p");
+        let before = app.active_session().messages.clone();
+
+        app.report_compaction_failure("the model returned a summary too short to be usable".into());
+
+        let after = &app.active_session().messages;
+        // Compared through the debug rendering: `ChatBlock` is not `PartialEq`,
+        // and "unchanged" here means every field of every block.
+        assert_eq!(
+            format!("{:?}", &after[..before.len()]),
+            format!("{before:?}"),
+            "every existing block must survive a failed summary untouched"
+        );
+        assert_eq!(app.active_session().pending_compaction, None);
+        assert!(
+            matches!(after.last(), Some(ChatBlock::System(s)) if s.contains("compaction failed")),
+            "the failure must be visible, got {:?}", after.last()
+        );
     }
 
     #[test]

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -3490,6 +3490,7 @@ impl App {
             TuiEvent::PasswordNeeded { session_id, .. } => *session_id,
             TuiEvent::HistoryCompacted { session_id, .. } => *session_id,
             TuiEvent::Notice { session_id, .. } => *session_id,
+            TuiEvent::CompactionStarted { session_id, .. } => *session_id,
         };
 
         // Dispatch to the originating session. Save the active index so we can
@@ -3707,6 +3708,13 @@ impl App {
             // Dispatch above already switched to the originating session, so
             // a summary that arrives while the user is on another tab still
             // lands on the history it was made from (#377).
+            TuiEvent::CompactionStarted { boundary, .. } => {
+                // Only arm what this history can actually be cut at; a
+                // boundary past its end means the history moved underneath.
+                if boundary > 0 && boundary <= self.active_session().messages.len() {
+                    self.active_session_mut().pending_compaction = Some(boundary);
+                }
+            }
             TuiEvent::Notice { text, .. } => {
                 // Feed-only: the run continues, so `agent_running`, the mode
                 // and the cancellation token are all left alone.
@@ -7813,6 +7821,55 @@ mod tests {
         let after_notice = app.active_session().messages.len();
         app.report_context_fill("p");
         assert_eq!(app.active_session().messages.len(), after_notice);
+        assert_eq!(app.active_session().pending_compaction, None);
+    }
+
+    #[test]
+    fn a_reactive_compaction_is_adopted_by_the_session() {
+        // The reactive path decides mid-run, so nothing armed
+        // `pending_compaction` and the summary that came back was rejected as
+        // stale: the retry ran on a compacted history the session never
+        // adopted, and the next turn overflowed all over again (review of
+        // #390). CompactionStarted is what closes that gap.
+        let mut app = app_over_threshold(1_000, 5_000);
+        let boundary = filar_core::compaction_boundary(
+            &app.active_session().messages,
+            filar_core::DEFAULT_KEEP_TURNS,
+        );
+        assert!(boundary > 0, "the fixture must have a compactable head");
+        let sid = app.active_session().id;
+        let before = app.active_session().messages.len();
+
+        app.handle_agent_event(TuiEvent::CompactionStarted { session_id: sid, boundary });
+        assert_eq!(app.active_session().pending_compaction, Some(boundary));
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+        });
+
+        assert!(
+            app.active_session().messages.len() < before,
+            "the session's own history must end up compacted, not just the runner's copy"
+        );
+        assert!(matches!(
+            app.active_session().messages.first(),
+            Some(ChatBlock::Summary { .. })
+        ));
+    }
+
+    #[test]
+    fn a_stale_reactive_boundary_is_still_refused() {
+        // Arming must not weaken the guard: a boundary past the end of the
+        // history means it moved underneath, and cutting there would lose
+        // turns.
+        let mut app = app_over_threshold(1_000, 5_000);
+        let sid = app.active_session().id;
+        let past_end = app.active_session().messages.len() + 5;
+
+        app.handle_agent_event(TuiEvent::CompactionStarted { session_id: sid, boundary: past_end });
+
         assert_eq!(app.active_session().pending_compaction, None);
     }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -455,6 +455,16 @@ pub struct Session {
     /// Set once the user has been told that compaction cannot shrink this
     /// session further, so the notice is not repeated on every turn.
     pub compaction_exhausted: bool,
+    /// Bumped whenever the history is replaced wholesale or the run is
+    /// cancelled — never on an append.
+    ///
+    /// A reactive compaction computes its boundary inside the runner, from a
+    /// copy of the history, and only arms the session afterwards. Comparing
+    /// lengths is not enough to tell whether that boundary still means
+    /// anything: a restored session of the same length would pass, and cutting
+    /// the new history at the old boundary would lose its tail. This counter
+    /// gives the boundary an identity to be checked against (review of #390).
+    pub history_epoch: u64,
     /// Cumulative output tokens generated for this session.
     pub tokens_out: u64,
     /// Cumulative cost in USD. Summed across all profiles.
@@ -790,6 +800,7 @@ impl Session {
             last_prompt_tokens: None,
             context_full_notice_shown: false,
             pending_compaction: None,
+            history_epoch: 0,
             compacted_without_relief: false,
             compaction_exhausted: false,
             tokens_out: 0,
@@ -1155,6 +1166,7 @@ impl App {
             s.last_prompt_tokens = None;
             s.context_full_notice_shown = false;
             s.pending_compaction = None;
+            s.history_epoch = s.history_epoch.wrapping_add(1);
             // A restored history is a different context: whatever the previous
             // one could or could not be reduced to says nothing about it.
             s.compacted_without_relief = false;
@@ -1562,6 +1574,8 @@ impl App {
         // A summary still in flight was made from the history this just
         // replaced, so it must not be applied to the restored one (#377).
         self.active_session_mut().pending_compaction = None;
+        let e = self.active_session().history_epoch.wrapping_add(1);
+        self.active_session_mut().history_epoch = e;
         self.active_session_mut().context_full_notice_shown = false;
         // The restored history is a different context: what the previous one
         // could or could not be reduced to says nothing about it, and keeping
@@ -1765,6 +1779,8 @@ impl App {
                 // just asked for the run to stop, so its result is discarded
                 // rather than applied to a history they may now edit (#377).
                 self.active_session_mut().pending_compaction = None;
+                let e = self.active_session().history_epoch.wrapping_add(1);
+                self.active_session_mut().history_epoch = e;
                 self.pending_ssh = None;
                 self.pending_ssh_password = None;
                 self.mode = AppMode::Normal;
@@ -3708,11 +3724,16 @@ impl App {
             // Dispatch above already switched to the originating session, so
             // a summary that arrives while the user is on another tab still
             // lands on the history it was made from (#377).
-            TuiEvent::CompactionStarted { boundary, .. } => {
-                // Only arm what this history can actually be cut at; a
-                // boundary past its end means the history moved underneath.
-                if boundary > 0 && boundary <= self.active_session().messages.len() {
+            TuiEvent::CompactionStarted { boundary, epoch, .. } => {
+                // The boundary was computed inside the runner, so it is only
+                // meaningful against the history it was computed from. The
+                // epoch changes when that history is replaced or the run is
+                // cancelled; the length check stays as a cheap sanity bound.
+                let s = self.active_session();
+                if epoch == s.history_epoch && boundary > 0 && boundary <= s.messages.len() {
                     self.active_session_mut().pending_compaction = Some(boundary);
+                } else {
+                    tracing::debug!(boundary, epoch, "ignoring a reactive compaction for a history that has moved");
                 }
             }
             TuiEvent::Notice { text, .. } => {
@@ -7840,7 +7861,8 @@ mod tests {
         let sid = app.active_session().id;
         let before = app.active_session().messages.len();
 
-        app.handle_agent_event(TuiEvent::CompactionStarted { session_id: sid, boundary });
+        let epoch = app.active_session().history_epoch;
+        app.handle_agent_event(TuiEvent::CompactionStarted { session_id: sid, boundary, epoch });
         assert_eq!(app.active_session().pending_compaction, Some(boundary));
 
         app.handle_agent_event(TuiEvent::HistoryCompacted {
@@ -7860,6 +7882,36 @@ mod tests {
     }
 
     #[test]
+    fn a_restored_history_of_the_same_length_refuses_the_reactive_boundary() {
+        // The length check alone let this through: restore a session with the
+        // same number of blocks while the summary is in flight, and the old
+        // boundary would be armed against the new history and cut its tail
+        // off (review of #390). The epoch is what distinguishes them.
+        let mut app = app_over_threshold(1_000, 5_000);
+        let sid = app.active_session().id;
+        let boundary = filar_core::compaction_boundary(
+            &app.active_session().messages,
+            filar_core::DEFAULT_KEEP_TURNS,
+        );
+        let epoch = app.active_session().history_epoch;
+        let same_length: Vec<ChatBlock> = (0..app.active_session().messages.len())
+            .map(|i| ChatBlock::User(format!("restored {i}")))
+            .collect();
+
+        // The user restores a different session of identical length.
+        app.active_session_mut().messages = same_length;
+        let bumped = app.active_session().history_epoch.wrapping_add(1);
+        app.active_session_mut().history_epoch = bumped;
+
+        app.handle_agent_event(TuiEvent::CompactionStarted { session_id: sid, boundary, epoch });
+
+        assert_eq!(
+            app.active_session().pending_compaction, None,
+            "a boundary from the previous history must not arm the new one"
+        );
+    }
+
+    #[test]
     fn a_stale_reactive_boundary_is_still_refused() {
         // Arming must not weaken the guard: a boundary past the end of the
         // history means it moved underneath, and cutting there would lose
@@ -7868,7 +7920,8 @@ mod tests {
         let sid = app.active_session().id;
         let past_end = app.active_session().messages.len() + 5;
 
-        app.handle_agent_event(TuiEvent::CompactionStarted { session_id: sid, boundary: past_end });
+        let epoch = app.active_session().history_epoch;
+        app.handle_agent_event(TuiEvent::CompactionStarted { session_id: sid, boundary: past_end, epoch });
 
         assert_eq!(app.active_session().pending_compaction, None);
     }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1563,6 +1563,12 @@ impl App {
         // replaced, so it must not be applied to the restored one (#377).
         self.active_session_mut().pending_compaction = None;
         self.active_session_mut().context_full_notice_shown = false;
+        // The restored history is a different context: what the previous one
+        // could or could not be reduced to says nothing about it, and keeping
+        // the flags would make the first over-threshold request here report
+        // that it cannot be compacted (#378).
+        self.active_session_mut().compacted_without_relief = false;
+        self.active_session_mut().compaction_exhausted = false;
         self.push_message(ChatBlock::System(
             "Session restored — history loaded from disk".into(),
         ));
@@ -3483,6 +3489,7 @@ impl App {
             TuiEvent::CwdChanged { session_id, .. } => *session_id,
             TuiEvent::PasswordNeeded { session_id, .. } => *session_id,
             TuiEvent::HistoryCompacted { session_id, .. } => *session_id,
+            TuiEvent::Notice { session_id, .. } => *session_id,
         };
 
         // Dispatch to the originating session. Save the active index so we can
@@ -3700,6 +3707,11 @@ impl App {
             // Dispatch above already switched to the originating session, so
             // a summary that arrives while the user is on another tab still
             // lands on the history it was made from (#377).
+            TuiEvent::Notice { text, .. } => {
+                // Feed-only: the run continues, so `agent_running`, the mode
+                // and the cancellation token are all left alone.
+                self.push_message(ChatBlock::System(text));
+            }
             TuiEvent::HistoryCompacted { boundary, summary, .. } => match summary {
                 Ok(text) => self.apply_compaction(boundary, text),
                 Err(e) => self.report_compaction_failure(e),
@@ -8294,6 +8306,8 @@ mod tests {
         app.llm_profile = Some("glm".into());
         app.active_session_mut().last_prompt_tokens = Some(250_000);
         app.active_session_mut().context_full_notice_shown = true;
+        app.active_session_mut().compacted_without_relief = true;
+        app.active_session_mut().compaction_exhausted = true;
 
         let session = filar_core::Session {
             id: "1".into(),
@@ -8315,6 +8329,11 @@ mod tests {
         };
         app.apply_loaded_session(session);
 
+        assert!(
+            !app.active_session().compacted_without_relief,
+            "a restored history must not inherit the previous one's verdict"
+        );
+        assert!(!app.active_session().compaction_exhausted);
         assert_eq!(app.active_session().last_prompt_tokens, None);
         assert!(!app.active_session().context_full_notice_shown);
 

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -75,6 +75,23 @@ pub enum TuiEvent {
         summary: std::result::Result<String, String>,
     },
 
+    /// A reactive compaction is about to be summarised — arm the session for
+    /// the result that follows.
+    ///
+    /// The threshold path arms `pending_compaction` in the app before the run
+    /// is spawned; the reactive path decides mid-run, so it has to say so.
+    /// Without this the `HistoryCompacted` that follows is rejected as stale,
+    /// the retry runs on a history the session never adopts, and every
+    /// subsequent turn overflows again (#378).
+    ///
+    /// The channel is ordered, so this always lands before the result it
+    /// arms, and the stale guard in `apply_compaction` still does its job:
+    /// anything that replaces the history in between clears the flag again.
+    CompactionStarted {
+        session_id: SessionId,
+        boundary: usize,
+    },
+
     /// A note for the feed that does not end the run.
     ///
     /// Deliberately separate from [`AgentEvent::Error`], which the app treats

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -74,6 +74,17 @@ pub enum TuiEvent {
         boundary: usize,
         summary: std::result::Result<String, String>,
     },
+
+    /// A note for the feed that does not end the run.
+    ///
+    /// Deliberately separate from [`AgentEvent::Error`], which the app treats
+    /// as final: it clears the cancellation token and marks the agent idle.
+    /// Reporting mid-run progress through that variant would leave a request
+    /// in flight that the user can no longer cancel (#378).
+    Notice {
+        session_id: SessionId,
+        text: String,
+    },
 }
 
 #[cfg(test)]

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -90,6 +90,9 @@ pub enum TuiEvent {
     CompactionStarted {
         session_id: SessionId,
         boundary: usize,
+        /// The session's `history_epoch` when the run was spawned. The app
+        /// refuses to arm if it has moved since.
+        epoch: u64,
     },
 
     /// A note for the feed that does not end the run.

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1038,6 +1038,7 @@ async fn run_app(
                             app.confirm_mode,
                             user_input,
                             app.messages.clone(),
+                            app.active_session().history_epoch,
                             agent_tx.clone(),
                             is_local,
                             ssh_info,
@@ -1748,6 +1749,7 @@ fn spawn_agent(
     confirm_mode: CommandConfirmMode,
     user_input: String,
     chat_history: Vec<ChatBlock>,
+    history_epoch: u64,
     event_tx: mpsc::UnboundedSender<TuiEvent>,
     is_local: bool,
     ssh_info: Option<String>,
@@ -1876,6 +1878,7 @@ fn spawn_agent(
             let _ = tx.send(TuiEvent::CompactionStarted {
                 session_id: sid,
                 boundary,
+                epoch: history_epoch,
             });
             chat_history =
                 compact_for_request(chat_history, Some(boundary), llm.as_ref(), &tx, sid).await;

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1870,6 +1870,13 @@ fn spawn_agent(
                     .to_string(),
             });
             let before = chat_history.len();
+            // Arm the session before the summary goes out, or the result that
+            // comes back is discarded as stale and only this local copy is
+            // ever compacted (review of #390).
+            let _ = tx.send(TuiEvent::CompactionStarted {
+                session_id: sid,
+                boundary,
+            });
             chat_history =
                 compact_for_request(chat_history, Some(boundary), llm.as_ref(), &tx, sid).await;
             if chat_history.len() >= before {

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1045,6 +1045,7 @@ async fn run_app(
                             cancel_token,
                             config.secret_provider.clone(),
                             sid,
+                            app.active_session().compaction_exhausted,
                             pending_compaction,
                         );
                         // Consumed by this run: the summary comes back as an
@@ -1756,6 +1757,10 @@ fn spawn_agent(
     cancellation: CancellationToken,
     secret_provider: Arc<dyn SecretProvider>,
     sid: SessionId,
+    // The session has already been told that compaction cannot shrink it any
+    // further. The reactive path honours that rather than quietly compacting
+    // behind the notice (review of #390).
+    compaction_exhausted: bool,
     // Boundary index when the history must be compacted before this request
     // (#377). `None` means send it as is.
     pending_compaction: Option<usize>,
@@ -1852,6 +1857,7 @@ fn spawn_agent(
                 overflow,
                 already_compacted,
                 cancellation.is_cancelled(),
+                compaction_exhausted,
             ) {
                 break;
             }
@@ -1912,13 +1918,19 @@ fn spawn_agent(
 ///   the same result over a shorter history, and a success has nothing to fix;
 /// - only once: the second attempt already ran on a compacted history, so a
 ///   third would send exactly what the second did;
-/// - never after a cancellation, which is the user asking for it to stop.
+/// - never after a cancellation, which is the user asking for it to stop;
+/// - never once the session is exhausted. `already_retried` covers a single
+///   run, so without this a later turn would start clean and compact again
+///   after the user had been told the history cannot be reduced further
+///   (review of #390). Checked here rather than at the compaction itself so
+///   the retry notice is not emitted either.
 fn should_retry_after_overflow(
     overflowed: bool,
     already_retried: bool,
     cancelled: bool,
+    compaction_exhausted: bool,
 ) -> bool {
-    overflowed && !already_retried && !cancelled
+    overflowed && !already_retried && !cancelled && !compaction_exhausted
 }
 
 /// Summarise the head of `chat_history` and fold it, reporting the outcome.
@@ -2007,21 +2019,21 @@ mod tests {
         // can be wrong: without it the very case the feature was written for
         // is the one it cannot handle (#378).
         assert!(
-            should_retry_after_overflow(true, false, false),
+            should_retry_after_overflow(true, false, false, false),
             "the first overflow must be compacted and retried"
         );
         assert!(
-            !should_retry_after_overflow(true, true, false),
+            !should_retry_after_overflow(true, true, false, false),
             "a second overflow must not start a third attempt"
         );
     }
 
     #[test]
     fn only_an_overflow_triggers_the_retry() {
-        assert!(!should_retry_after_overflow(false, false, false), "a success");
+        assert!(!should_retry_after_overflow(false, false, false, false), "a success");
         // Any other failure would fail identically over a shorter history, so
         // retrying it just costs the user another request.
-        assert!(!should_retry_after_overflow(false, true, false), "another error");
+        assert!(!should_retry_after_overflow(false, true, false, false), "another error");
     }
 
     #[test]
@@ -2032,18 +2044,31 @@ mod tests {
         // do (review of #390). The runner seeds `already_compacted` from
         // whether the history actually got shorter, so this is the same rule.
         assert!(
-            !should_retry_after_overflow(true, true, false),
+            !should_retry_after_overflow(true, true, false, false),
             "a turn that already compacted must not compact again"
         );
         // A *failed* proactive summary leaves the history unchanged and so
         // does not use the turn up.
-        assert!(should_retry_after_overflow(true, false, false));
+        assert!(should_retry_after_overflow(true, false, false, false));
+    }
+
+    #[test]
+    fn an_exhausted_session_is_not_compacted_behind_the_notice() {
+        // `already_retried` only covers one run, so a later turn would start
+        // clean and compact again even though the user had been told the
+        // session cannot be reduced further and to start a new one (review of
+        // #390). Every other condition here says "retry" - the exhausted flag
+        // alone must stop it.
+        assert!(
+            !should_retry_after_overflow(true, false, false, true),
+            "an exhausted session must not be compacted again"
+        );
     }
 
     #[test]
     fn a_cancelled_run_is_not_retried() {
         assert!(
-            !should_retry_after_overflow(true, false, true),
+            !should_retry_after_overflow(true, false, true, false),
             "cancellation is the user asking for it to stop"
         );
     }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1775,7 +1775,7 @@ fn spawn_agent(
         let held_for_sink = Arc::clone(&held_error);
         let sink: filar_agent::EventSink = Arc::new(move |event: filar_agent::AgentEvent| {
             if let filar_agent::AgentEvent::Error(msg) = &event {
-                *held_for_sink.lock().unwrap() = Some(msg.clone());
+                *held_for_sink.lock().unwrap_or_else(|p| p.into_inner()) = Some(msg.clone());
                 return;
             }
             let _ = tx_for_sink.send(TuiEvent::Agent {
@@ -1788,6 +1788,7 @@ fn spawn_agent(
         // where the LLM client lives and the spinner is already up. The
         // summary uses the session's own profile, so its cost lands on the
         // profile the user is actually working with.
+        let before_compaction = chat_history.len();
         let mut chat_history = compact_for_request(
             chat_history,
             pending_compaction,
@@ -1797,10 +1798,13 @@ fn spawn_agent(
         )
         .await;
 
-        // At most two attempts: the second only after a compaction that
-        // actually shortened the history. A third would repeat the second
-        // verbatim and fail the same way.
-        let mut compacted_reactively = false;
+        // At most two attempts, and at most one compaction per turn. The
+        // proactive pass counts: if the threshold already folded the head, a
+        // reactive fold would be the second compaction in a row, which the
+        // history cannot survive usefully and the user was not promised.
+        // A *failed* proactive summary leaves the history untouched and does
+        // not count, so the reactive path is still available then (#378).
+        let mut already_compacted = chat_history.len() < before_compaction;
         loop {
             let history = history_to_messages(&chat_history);
 
@@ -1835,7 +1839,7 @@ fn spawn_agent(
                 }
             };
 
-            *held_error.lock().unwrap() = None;
+            *held_error.lock().unwrap_or_else(|p| p.into_inner()) = None;
             // Run the agent loop. All events (Started, TextDelta,
             // CommandProposed, CommandFinished, Finished) are emitted via the
             // EventSink; Error is held back until the outcome is known.
@@ -1844,7 +1848,7 @@ fn spawn_agent(
             let overflow = matches!(outcome, Err(CoreError::ContextOverflow(_)));
             if !should_retry_after_overflow(
                 overflow,
-                compacted_reactively,
+                already_compacted,
                 cancellation.is_cancelled(),
             ) {
                 break;
@@ -1860,12 +1864,10 @@ fn spawn_agent(
                 // so the overflow stands.
                 break;
             }
-            let _ = tx.send(TuiEvent::Agent {
+            let _ = tx.send(TuiEvent::Notice {
                 session_id: sid,
-                event: filar_agent::AgentEvent::Error(
-                    "The context window overflowed. Compacting the history and retrying once."
-                        .to_string(),
-                ),
+                text: "The context window overflowed. Compacting the history and retrying once."
+                    .to_string(),
             });
             let before = chat_history.len();
             chat_history =
@@ -1875,10 +1877,10 @@ fn spawn_agent(
                 // retry would send exactly what just overflowed.
                 break;
             }
-            compacted_reactively = true;
+            already_compacted = true;
         }
 
-        let final_error = held_error.lock().unwrap().take();
+        let final_error = held_error.lock().unwrap_or_else(|p| p.into_inner()).take();
         if let Some(msg) = final_error {
             let _ = tx.send(TuiEvent::Agent {
                 session_id: sid,
@@ -2010,6 +2012,22 @@ mod tests {
         // Any other failure would fail identically over a shorter history, so
         // retrying it just costs the user another request.
         assert!(!should_retry_after_overflow(false, true, false), "another error");
+    }
+
+    #[test]
+    fn a_proactive_compaction_uses_up_the_turn_s_one_compaction() {
+        // The threshold path folds the head before the request goes out. If
+        // that request still overflows, a reactive fold would be the second
+        // compaction in a row - the thing the feature explicitly refuses to
+        // do (review of #390). The runner seeds `already_compacted` from
+        // whether the history actually got shorter, so this is the same rule.
+        assert!(
+            !should_retry_after_overflow(true, true, false),
+            "a turn that already compacted must not compact again"
+        );
+        // A *failed* proactive summary leaves the history unchanged and so
+        // does not use the turn up.
+        assert!(should_retry_after_overflow(true, false, false));
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1764,87 +1764,192 @@ fn spawn_agent(
     tokio::spawn(async move {
         let _ = tx.send(TuiEvent::Thinking);
 
-        // Compaction runs here, before the agent is built, because this is
-        // where the LLM client lives and the spinner is already up. The
-        // summary uses the session's own profile, so its cost lands on the
-        // profile the user is actually working with.
-        let chat_history = match pending_compaction {
-            Some(boundary) if boundary > 0 && boundary <= chat_history.len() => {
-                let transcript =
-                    filar_core::transcript_for_summary(&chat_history[..boundary]);
-                match filar_agent::summarise_history(llm.as_ref(), &transcript).await {
-                    Ok(summary) => {
-                        let compacted =
-                            filar_core::compact_history(&chat_history, boundary, &summary);
-                        let _ = tx.send(TuiEvent::HistoryCompacted {
-                            session_id: sid,
-                            boundary,
-                            summary: Ok(summary),
-                        });
-                        compacted
-                    }
-                    Err(e) => {
-                        // The request still goes out on the full history: a
-                        // failed summary must not cost the user their turn.
-                        // Recovering from an outright context overflow is #378.
-                        let _ = tx.send(TuiEvent::HistoryCompacted {
-                            session_id: sid,
-                            boundary,
-                            summary: Err(e.to_string()),
-                        });
-                        chat_history
-                    }
-                }
-            }
-            _ => chat_history,
-        };
-
-        let history = history_to_messages(&chat_history);
+        // `AgentEvent::Error` is emitted exactly once, by `Agent::run`, right
+        // before it returns the same error. Holding it here rather than
+        // forwarding it lets the reactive path below decide whether the user
+        // ever needs to see it: an overflow that is fixed by compacting and
+        // retrying is not a failure worth reporting (#378).
+        let held_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
 
         let tx_for_sink = tx.clone();
+        let held_for_sink = Arc::clone(&held_error);
         let sink: filar_agent::EventSink = Arc::new(move |event: filar_agent::AgentEvent| {
+            if let filar_agent::AgentEvent::Error(msg) = &event {
+                *held_for_sink.lock().unwrap() = Some(msg.clone());
+                return;
+            }
             let _ = tx_for_sink.send(TuiEvent::Agent {
                 session_id: sid,
                 event,
             });
         });
 
-        // Build the agent with appropriate system prompt.
-        let mut builder = AgentBuilder::new()
-            .llm(llm)
-            .executor(executor)
-            .confirmer(confirmer)
-            .confirm_mode(confirm_mode)
-            .event_sink(sink)
-            .cancellation(cancellation)
-            .secret_provider(secret_provider)
-            .arbiter_enabled(arbiter_enabled)
-            .arbiter_llm(arbiter_llm)
-            .arbiter_model_name(arbiter_model_name);
-        if is_local {
-            builder = builder.local_mode().arbiter_local_context();
-        } else {
-            builder = builder.ssh_mode(ssh_info.as_deref()).arbiter_ssh_context(ssh_info.clone());
-        }
-        builder = builder.session_id(sid.0.to_string());
+        // Compaction runs here, before the agent is built, because this is
+        // where the LLM client lives and the spinner is already up. The
+        // summary uses the session's own profile, so its cost lands on the
+        // profile the user is actually working with.
+        let mut chat_history = compact_for_request(
+            chat_history,
+            pending_compaction,
+            llm.as_ref(),
+            &tx,
+            sid,
+        )
+        .await;
 
-        let agent = match builder.build() {
-            Ok(a) => a,
-            Err(e) => {
-                let _ = tx.send(TuiEvent::Agent {
-                    session_id: sid,
-                    event: filar_agent::AgentEvent::Error(e.to_string()),
-                });
-                return;
+        // At most two attempts: the second only after a compaction that
+        // actually shortened the history. A third would repeat the second
+        // verbatim and fail the same way.
+        let mut compacted_reactively = false;
+        loop {
+            let history = history_to_messages(&chat_history);
+
+            let mut builder = AgentBuilder::new()
+                .llm(Arc::clone(&llm))
+                .executor(Arc::clone(&executor))
+                .confirmer(Arc::clone(&confirmer))
+                .confirm_mode(confirm_mode)
+                .event_sink(Arc::clone(&sink))
+                .cancellation(cancellation.clone())
+                .secret_provider(Arc::clone(&secret_provider))
+                .arbiter_enabled(arbiter_enabled)
+                .arbiter_llm(arbiter_llm.clone())
+                .arbiter_model_name(arbiter_model_name.clone());
+            if is_local {
+                builder = builder.local_mode().arbiter_local_context();
+            } else {
+                builder = builder
+                    .ssh_mode(ssh_info.as_deref())
+                    .arbiter_ssh_context(ssh_info.clone());
             }
-        };
+            builder = builder.session_id(sid.0.to_string());
 
-        // Run the agent loop. All events (Started, TextDelta, CommandProposed,
-        // CommandFinished, Finished, Error) are emitted via the EventSink.
-        // The run() wrapper emits Finished on Ok and Error on Err, so we
-        // don't need to send them again here.
-        let _ = agent.run(&user_input, &history).await;
+            let agent = match builder.build() {
+                Ok(a) => a,
+                Err(e) => {
+                    let _ = tx.send(TuiEvent::Agent {
+                        session_id: sid,
+                        event: filar_agent::AgentEvent::Error(e.to_string()),
+                    });
+                    return;
+                }
+            };
+
+            *held_error.lock().unwrap() = None;
+            // Run the agent loop. All events (Started, TextDelta,
+            // CommandProposed, CommandFinished, Finished) are emitted via the
+            // EventSink; Error is held back until the outcome is known.
+            let outcome = agent.run(&user_input, &history).await;
+
+            let overflow = matches!(outcome, Err(CoreError::ContextOverflow(_)));
+            if !should_retry_after_overflow(
+                overflow,
+                compacted_reactively,
+                cancellation.is_cancelled(),
+            ) {
+                break;
+            }
+
+            // The threshold was set too high for this model's window, or no
+            // usage figure ever arrived. Compact and try once more — this is
+            // what keeps the feature useful when the threshold is wrong.
+            let boundary =
+                filar_core::compaction_boundary(&chat_history, filar_core::DEFAULT_KEEP_TURNS);
+            if boundary == 0 {
+                // Nothing but the verbatim tail: compacting cannot shorten it,
+                // so the overflow stands.
+                break;
+            }
+            let _ = tx.send(TuiEvent::Agent {
+                session_id: sid,
+                event: filar_agent::AgentEvent::Error(
+                    "The context window overflowed. Compacting the history and retrying once."
+                        .to_string(),
+                ),
+            });
+            let before = chat_history.len();
+            chat_history =
+                compact_for_request(chat_history, Some(boundary), llm.as_ref(), &tx, sid).await;
+            if chat_history.len() >= before {
+                // The summary failed, so the history is unchanged and the
+                // retry would send exactly what just overflowed.
+                break;
+            }
+            compacted_reactively = true;
+        }
+
+        let final_error = held_error.lock().unwrap().take();
+        if let Some(msg) = final_error {
+            let _ = tx.send(TuiEvent::Agent {
+                session_id: sid,
+                event: filar_agent::AgentEvent::Error(msg),
+            });
+        }
     });
+}
+
+/// Whether an attempt that just finished should be retried over a compacted
+/// history.
+///
+/// The whole reactive rule lives here rather than inline in the task so it can
+/// be tested: the loop around it ends in `agent.run`, and a lost condition
+/// there would either retry forever or never retry at all, with nothing to
+/// catch it (#378).
+///
+/// - only a context overflow is worth retrying — every other failure returns
+///   the same result over a shorter history, and a success has nothing to fix;
+/// - only once: the second attempt already ran on a compacted history, so a
+///   third would send exactly what the second did;
+/// - never after a cancellation, which is the user asking for it to stop.
+fn should_retry_after_overflow(
+    overflowed: bool,
+    already_retried: bool,
+    cancelled: bool,
+) -> bool {
+    overflowed && !already_retried && !cancelled
+}
+
+/// Summarise the head of `chat_history` and fold it, reporting the outcome.
+///
+/// Returns the history to send. A failed or unusable summary returns it
+/// **unchanged**: losing the user's turn because the summariser misbehaved
+/// would be a worse outcome than a long context (#377, #378).
+async fn compact_for_request(
+    chat_history: Vec<ChatBlock>,
+    boundary: Option<usize>,
+    llm: &dyn LlmClient,
+    tx: &mpsc::UnboundedSender<TuiEvent>,
+    sid: SessionId,
+) -> Vec<ChatBlock> {
+    let Some(boundary) = boundary else {
+        return chat_history;
+    };
+    if boundary == 0 || boundary > chat_history.len() {
+        return chat_history;
+    }
+    let transcript = filar_core::transcript_for_summary(&chat_history[..boundary]);
+    match filar_agent::summarise_history(llm, &transcript).await {
+        Ok(summary) => {
+            let compacted = filar_core::compact_history(&chat_history, boundary, &summary);
+            let _ = tx.send(TuiEvent::HistoryCompacted {
+                session_id: sid,
+                boundary,
+                summary: Ok(summary),
+            });
+            compacted
+        }
+        Err(e) => {
+            // The request still goes out on the full history: a failed summary
+            // must not cost the user their turn. An empty or too-short reply
+            // arrives here as an error too (#378).
+            let _ = tx.send(TuiEvent::HistoryCompacted {
+                session_id: sid,
+                boundary,
+                summary: Err(e.to_string()),
+            });
+            chat_history
+        }
+    }
 }
 
 type PathPickerLoadResult = std::result::Result<(Vec<PathEntry>, bool), String>;
@@ -1883,6 +1988,37 @@ async fn load_path_picker_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_overflow_is_retried_exactly_once() {
+        // The reactive path exists because the threshold is set by hand and
+        // can be wrong: without it the very case the feature was written for
+        // is the one it cannot handle (#378).
+        assert!(
+            should_retry_after_overflow(true, false, false),
+            "the first overflow must be compacted and retried"
+        );
+        assert!(
+            !should_retry_after_overflow(true, true, false),
+            "a second overflow must not start a third attempt"
+        );
+    }
+
+    #[test]
+    fn only_an_overflow_triggers_the_retry() {
+        assert!(!should_retry_after_overflow(false, false, false), "a success");
+        // Any other failure would fail identically over a shorter history, so
+        // retrying it just costs the user another request.
+        assert!(!should_retry_after_overflow(false, true, false), "another error");
+    }
+
+    #[test]
+    fn a_cancelled_run_is_not_retried() {
+        assert!(
+            !should_retry_after_overflow(true, false, true),
+            "cancellation is the user asking for it to stop"
+        );
+    }
 
     #[test]
     fn the_summary_reaches_the_model_and_feed_chrome_does_not() {


### PR DESCRIPTION
Closes #378

## Reactive path

`compact_at_tokens` is set by hand, so it can sit above the model's real window
— and then the request fails before compaction ever fires, which is exactly the
case the feature was written for. The provider's refusal is now classified as
`CoreError::ContextOverflow`, and the runner compacts the history and re-sends
once.

Classification lives in `ApiError::from_http_status`, following the
`ToolsUnsupported` precedent the issue points at. `looks_like_context_overflow`
runs *before* the tool heuristic — an overflow body often mentions tools among
what did not fit, and the overflow is the more specific diagnosis — and is
restricted to non-429 4xx for the same reason the tool check is: a 5xx that
happens to mention tokens is transient, and turning it into a permanent failure
would throw away a free recovery.

Overflow is deliberately **not** in `is_retryable()`. Repeating the identical
request earns the identical refusal; only the owner of the history can make a
retry mean anything, which is why the retry lives in the TUI.

`Agent::run` emits `AgentEvent::Error` once, immediately before returning the
same error, so the sink now holds it and the task forwards it only when the
outcome is final. Otherwise the user would see a failure notice followed by a
successful answer for the same turn.

## Where the retry rule lives

In `should_retry_after_overflow`, a free function, not inline in the spawned
task. The loop around it ends in `agent.run`, so a lost condition there would
either retry forever or never retry, and a test of the loop would be a test of
the agent. This is the lesson from the #389 review applied before the fact.

## Summary failures

Mostly already handled by #377, which sends the turn on the full history and
warns. Added the length rule: `MIN_SUMMARY_CHARS = 40`.

The #377 prompt asks for executed commands first and established facts second,
and neither fits in under a clause. The observed failure modes — an empty
string, `OK`, `None.`, a refusal such as `I cannot summarize this.` (24 chars) —
all sit far below it. Chosen low on purpose: rejecting a real summary costs a
warning and an uncompacted history, while accepting a non-summary silently
destroys the head. A one-line summary of a trivial exchange clears 40
comfortably, and a test pins exactly that so the threshold cannot drift upward
unnoticed.

## No second compaction in a row

Two session flags. `compacted_without_relief` is set when a summary is applied
and cleared when the context is next seen below the threshold;
`compaction_exhausted` is set once the user has been told, so the notice does
not repeat every turn. Both are cleared when a saved session is restored — a
restored history says nothing about what the previous one could be reduced to.

## Tests

11 added; `cargo test --workspace` green.

- Six real provider wordings classify as an overflow; a 5xx and a 429 that
  mention tokens keep their own meaning; an overflow is not retryable and
  survives into `CoreError`.
- Empty and too-short summaries are failures; a short *real* one is not.
- The second compaction in a row is refused with a single notice, and compaction
  re-arms once the context drops back under the threshold.
- A failed summary leaves the history identical block for block.
- The retry rule fires once, and not on success, other errors, or cancellation.

Confirmed by reverting: the re-compaction guard and the length rule each fail
their test with the guard removed.

## Manual verification

Driven on the release binary, TUI on a pty, against a fake OpenAI-compatible
provider that returns a real `context_length_exceeded` 400. Provider-side call
log:

**Threshold above the model's window** — the scenario the reactive path exists
for:

    main#21  OVERFLOW  msgs=13
    summary  ok        msgs=2
    main#22  ok        msgs=12     <- compacted, retry succeeds

**Second overflow in a row** — the retry overflows too:

    main#21  OVERFLOW  msgs=13
    summary  ok        msgs=2
    main#22  OVERFLOW  msgs=12     <- retry, also refused
    main#23  ...                   <- next user turn; no third attempt, no second summary

## Not verified

- **The "summary fails, history survives" scenario could not be driven through
  the UI.** Reaching it needs the threshold path to arm compaction, and
  `context_full_notice_shown` is set on the first crossing while the history is
  still too short to compact; since the context never drops back under the
  threshold, it never re-arms and no summary is ever requested. That is #376/#377
  behaviour, untouched here — I did not widen the scope to change it. The path
  itself is covered by two unit tests (the agent rejects the reply, the app
  leaves the history identical). Worth its own issue if the one-shot notice is
  not intended.
- Linux only; nothing on Windows or macOS.
- The fake provider answers non-streaming JSON, so each turn shows several
  provider calls in the log. That is an artefact of the harness, not of filar;
  it does not affect the sequences above, which are read per turn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically compacts conversation history when the context window is too large, then retries the request once.
  - Preserves full history when compaction produces an unusable summary and continues with a warning.
  - Advises starting a new session when compaction cannot reduce the context enough.

- **Bug Fixes**
  - Prevents repeated compaction attempts and duplicate exhaustion notices.
  - Reports a second context overflow without retrying.
  - Distinguishes context-limit errors from unrelated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->