### PR TITLE
feat(tui): count the summarising call's token usage (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,9 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
-- The cost a session reports now includes the requests it makes to compact its
-  own history. Each summary was billed but counted nowhere, so on a long session
-  the reported figure was short by the whole compacted head every time. A
-  summary the model returns unusably short is counted too, since it was paid for
-  either way ([#387](https://github.com/devlawey/filar/issues/387)).
+- Session cost now includes the requests made to compact the history, counting
+  a summary the model returns unusably short as well, since it is billed either
+  way ([#387](https://github.com/devlawey/filar/issues/387)).
 
 - Deleting a launcher profile no longer removes its stored API key when the
   deletion cannot be saved. The remaining profiles are checked first, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- The cost a session reports now includes the requests it makes to compact its
+  own history. Each summary was billed but counted nowhere, so on a long session
+  the reported figure was short by the whole compacted head every time. A
+  summary the model returns unusably short is counted too, since it was paid for
+  either way ([#387](https://github.com/devlawey/filar/issues/387)).
+
 - Deleting a launcher profile no longer removes its stored API key when the
   deletion cannot be saved. The remaining profiles are checked first, so a
   malformed field elsewhere blocks the delete instead of leaving a profile in

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6059,41 +6059,60 @@ guard rejects a result whose history has moved. Charging from there would either
 double the figures or drop them exactly when the user was billed. Both cases
 have tests.
 
-**Attribution.** `pending_llm_profile`, the profile the request was sent under —
-correct today because the summary runs on the session's own profile inside the
-same agent task. The cheap-profile option from the #377 spec was **not**
-implemented: nothing in the repo defines how such a profile would be configured
-or selected, and inventing that is outside this issue. When it lands, the
-profile that computed the summary has to travel on the event, because the value
-read here would then be the wrong one. Noted in the doc comment on
-`record_summary_usage` so the next person meets it there.
+**Attribution.** The profile is captured when the run is spawned and travels on
+the event. The first cut read `pending_llm_profile` when the result arrived,
+which review of PR #391 showed to be wrong: `cancel_work` does not abort the
+summarising call — nothing in `compact_for_request` consults the cancellation
+token — so a summary can still be in flight while the user switches profile and
+sends another turn, and `begin_agent_request` overwrites the field before the
+result lands. The session total is owed either way, but `per_profile` would have
+charged a profile that never computed it. `spawn_agent` now takes
+`profile_name`, and this is also where a cheap-profile summariser would plug in:
+it would set that field and nothing downstream would change.
 
 **Done:** 4 tests in `filar-agent` (usage survives an accepted summary, survives
-a rejected one, absent when no response came back) and 5 in `app.rs` (counted
+a rejected one, absent when no response came back) and 6 in `app.rs` (counted
 once in session and `per_profile`, no double count on re-application, an
 unusable summary is still paid for, the compaction trigger does not move, a
-provider reporting no usage changes nothing).
+provider reporting no usage changes nothing, and a summary in flight across a
+cancel plus profile switch is billed to the profile that computed it).
 
 **Public contract:** `filar-agent::summarise_history` changes signature —
 `Result<String>` → the new `SummaryOutcome`. Breaking for embedders that call it
 directly, though `ENGINE_API.md` does not document it, so nothing there goes
-stale. `TuiEvent::HistoryCompacted` gains a field; `filar-tui` is not an engine
-crate. `CommandExecutor` and `LlmClient` untouched. `COMPACTION_SYSTEM_PROMPT`
-unchanged, so eval behaviour should be unaffected — but the change is inside
-`crates/agent/src/**`, which triggers `eval-smoke` regardless.
+stale. `TuiEvent::HistoryCompacted` gains two fields; `filar-tui` is not an
+engine crate. `CommandExecutor` and `LlmClient` untouched.
+`COMPACTION_SYSTEM_PROMPT` unchanged, so eval behaviour should be unaffected —
+but the change is inside `crates/agent/src/**`, which triggers `eval-smoke`
+regardless, and it passed on the first commit.
 
 **Verification:** `cargo build --workspace`, `cargo test --workspace` and
 `cargo build --release` were all run here — the container now has a Rust
 toolchain, which the skill's `reference/environment.md` still says is
-impossible. The four positive tests were confirmed to fail with the accounting
-call removed. The TUI itself was not driven: no interactive terminal in this
-environment, so the cost-line check is the human's.
+impossible. The positive tests were confirmed to fail with the accounting call
+removed, and the attribution test to fail against the `pending_llm_profile`
+version. The TUI itself was not driven: no interactive terminal in this
+environment, so the cost-line check is the human's. Review asked for that run to
+be performed and recorded instead; it cannot be, and AGENTS.md says to say so
+rather than close the requirement quietly.
+
+**Review (PR #391).** Two findings taken. The profile race above, and a
+changelog entry too long for the one-line rule in AGENTS.md. Three declined. A
+claimed panic in `record_summary_usage` on a closed session, and a claim that
+the handler does not dispatch by `session_id`: `handle_agent_event` resolves the
+session with `find_session_idx` and returns early when it is gone, before any
+arm runs. A `String` clone per compaction called redundant — it mirrors the
+neighbouring `TokenUsage` arm and sits next to a network round trip; the
+attribution fix removed it anyway. And the request for TUI results that cannot
+be produced here.
 
 **Next steps:** #379 (4/4) is the last open task of 1.0.6, and it is larger than
 it reads — `apply_compaction` replaces `Session::messages`, so the transcript's
 "full history including the folded part" does not hold by construction and has
-to be built. The cheap-profile summariser remains open and now has a named place
-to hook into.
+to be built. The cheap-profile summariser remains open and now has its hook. A
+separate defect surfaced in review and is **not** fixed here: the summarising
+call ignores the cancellation token, so Ctrl+Z leaves the user paying for a
+request whose result is then discarded. Needs its own issue.
 
 ## Release v1.0.5 (2026-08-27)
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6021,6 +6021,80 @@ only true after a sibling test has created `~/.local/share` via
 `SessionStore::new`. Invisible on Windows and macOS, where the directory always
 exists. Left out of this PR — different cause, needs its own issue.
 
+## Issue #387: feat(tui/agent) — the summarising call is now paid for
+
+**Milestone:** 1.0.6. **Branch:** `feat/387-summary-token-usage`. Raised in
+review of PR #384 and deferred from #377 as its own task.
+
+**Problem:** compaction sends a real request to the model and the reply was the
+only thing kept from it. `summarise_history` returned `Result<String>`, so the
+`usage` on the `ChatResponse` was dropped on the floor: neither the session's
+`tokens_in` / `tokens_out` / `cost_usd` nor `per_profile` saw it. On a long
+session the input of every summary is the entire head being folded, so the
+figure shown to the user was short by a large amount and grew shorter with use.
+
+**Shape.** `summarise_history` now returns `SummaryOutcome { usage, summary }`
+instead of `Result<String>`. Usage and summary are separated because they are
+owed to different places: whether the brief is usable decides only whether the
+head is folded, while the request was billed before anyone could judge it. A
+reply rejected as too short (#378) therefore comes back with its usage intact;
+a call that failed before a response existed reports `None` rather than a
+fabricated zero. The runner passes it through on `TuiEvent::HistoryCompacted`,
+which gained a `usage` field.
+
+**Where it is counted, and why not the obvious place.** Not through
+`AgentEvent::TokenUsage`. That arm also records `last_prompt_tokens` — the
+measured size of the context actually sent, and the trigger compaction fires on
+(#376). A summary's prompt is the head being folded, in a request of its own, so
+routing it there would move the trigger by an amount unrelated to how full the
+session's context is, and could re-arm compaction immediately after one just
+ran. Arbiter usage is excluded from that same figure for the same reason, so the
+new `App::record_summary_usage` follows the arbiter's precedent: session totals
+and `per_profile`, no `last_prompt_tokens`, no `last_served_model`.
+
+**Counted once.** In the `HistoryCompacted` arm, before the summary is judged,
+rather than inside `apply_compaction`. The two look equivalent and are not:
+`apply_compaction` is reachable again with the same boundary, and its stale
+guard rejects a result whose history has moved. Charging from there would either
+double the figures or drop them exactly when the user was billed. Both cases
+have tests.
+
+**Attribution.** `pending_llm_profile`, the profile the request was sent under —
+correct today because the summary runs on the session's own profile inside the
+same agent task. The cheap-profile option from the #377 spec was **not**
+implemented: nothing in the repo defines how such a profile would be configured
+or selected, and inventing that is outside this issue. When it lands, the
+profile that computed the summary has to travel on the event, because the value
+read here would then be the wrong one. Noted in the doc comment on
+`record_summary_usage` so the next person meets it there.
+
+**Done:** 4 tests in `filar-agent` (usage survives an accepted summary, survives
+a rejected one, absent when no response came back) and 5 in `app.rs` (counted
+once in session and `per_profile`, no double count on re-application, an
+unusable summary is still paid for, the compaction trigger does not move, a
+provider reporting no usage changes nothing).
+
+**Public contract:** `filar-agent::summarise_history` changes signature —
+`Result<String>` → the new `SummaryOutcome`. Breaking for embedders that call it
+directly, though `ENGINE_API.md` does not document it, so nothing there goes
+stale. `TuiEvent::HistoryCompacted` gains a field; `filar-tui` is not an engine
+crate. `CommandExecutor` and `LlmClient` untouched. `COMPACTION_SYSTEM_PROMPT`
+unchanged, so eval behaviour should be unaffected — but the change is inside
+`crates/agent/src/**`, which triggers `eval-smoke` regardless.
+
+**Verification:** `cargo build --workspace`, `cargo test --workspace` and
+`cargo build --release` were all run here — the container now has a Rust
+toolchain, which the skill's `reference/environment.md` still says is
+impossible. The four positive tests were confirmed to fail with the accounting
+call removed. The TUI itself was not driven: no interactive terminal in this
+environment, so the cost-line check is the human's.
+
+**Next steps:** #379 (4/4) is the last open task of 1.0.6, and it is larger than
+it reads — `apply_compaction` replaces `Session::messages`, so the transcript's
+"full history including the folded part" does not hold by construction and has
+to be built. The cheap-profile summariser remains open and now has a named place
+to hook into.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6071,11 +6071,12 @@ charged a profile that never computed it. `spawn_agent` now takes
 it would set that field and nothing downstream would change.
 
 **Done:** 4 tests in `filar-agent` (usage survives an accepted summary, survives
-a rejected one, absent when no response came back) and 6 in `app.rs` (counted
+a rejected one, absent when no response came back) and 7 in `app.rs` (counted
 once in session and `per_profile`, no double count on re-application, an
 unusable summary is still paid for, the compaction trigger does not move, a
 provider reporting no usage changes nothing, and a summary in flight across a
-cancel plus profile switch is billed to the profile that computed it).
+cancel plus profile switch is billed to the profile that computed it, and the
+cost lands in the session that compacted rather than the visible tab).
 
 **Public contract:** `filar-agent::summarise_history` changes signature —
 `Result<String>` → the new `SummaryOutcome`. Breaking for embedders that call it
@@ -6105,6 +6106,15 @@ arm runs. A `String` clone per compaction called redundant — it mirrors the
 neighbouring `TokenUsage` arm and sits next to a network round trip; the
 attribution fix removed it anyway. And the request for TUI results that cannot
 be produced here.
+
+Second round re-raised the session-attribution claim as a blocker: that
+`active_session_mut()` means the tab the user is looking at, so a tab switch
+between the event and its handling would charge the wrong session. It does not.
+`handle_agent_event` points `active` at the originating session before the match
+and restores the original tab at the end — which is the fix the review itself
+proposed as an alternative. Declined again, but pinned with a test
+(`summary_usage_lands_in_the_session_that_compacted_not_the_visible_tab`) so the
+question is settled by the suite rather than re-argued each round.
 
 **Next steps:** #379 (4/4) is the last open task of 1.0.6, and it is larger than
 it reads — `apply_compaction` replaces `Session::messages`, so the transcript's

--- a/crates/agent/src/compaction.rs
+++ b/crates/agent/src/compaction.rs
@@ -6,7 +6,7 @@
 //! It is a single, self-contained LLM call with no tools: the summariser must
 //! not be able to run anything on the host.
 
-use crate::{ChatMessage, ChatRequest, LlmClient, MessageRole};
+use crate::{ChatMessage, ChatRequest, LlmClient, MessageRole, TokenUsage};
 use filar_core::{CoreError, Result};
 
 /// System prompt for the summarising call.
@@ -56,17 +56,37 @@ Write in the language the session is conducted in.";
 /// here (raised in review of #390).
 pub const MIN_SUMMARY_CHARS: usize = 40;
 
+/// What a summarising call produced and what it cost.
+///
+/// The two are kept apart because they are owed to different places. The
+/// summary decides whether the head is folded; the usage is owed to the
+/// session's token and cost counters either way, since the request was billed
+/// before anyone could judge the reply. Returning only the brief is what left
+/// the reported cost short of every summary the session ever paid for (#387).
+///
+/// `usage` is `None` when the provider reported none, and when the call failed
+/// before a response existed at all.
+#[derive(Debug)]
+pub struct SummaryOutcome {
+    /// Token usage the summarising request itself consumed.
+    pub usage: Option<TokenUsage>,
+    /// The brief, or why there isn't one.
+    pub summary: Result<String>,
+}
+
 /// Ask the model to summarise `transcript`.
 ///
-/// Returns the brief that will replace the compacted head. The call carries no
-/// tool definitions, so the summariser cannot propose commands, and it is a
-/// plain [`LlmClient::chat`] rather than a streaming call: nothing renders the
-/// partial text, and the caller only needs the finished brief.
+/// Returns the brief that will replace the compacted head, together with what
+/// the call cost. The call carries no tool definitions, so the summariser
+/// cannot propose commands, and it is a plain [`LlmClient::chat`] rather than a
+/// streaming call: nothing renders the partial text, and the caller only needs
+/// the finished brief.
 ///
 /// A reply shorter than [`MIN_SUMMARY_CHARS`] — an empty string included — is
 /// reported as an error rather than silently accepted: replacing the head with
-/// a non-summary would lose it outright (#378).
-pub async fn summarise_history(llm: &dyn LlmClient, transcript: &str) -> Result<String> {
+/// a non-summary would lose it outright (#378). Such a reply still carries its
+/// usage back, because it was paid for like any other.
+pub async fn summarise_history(llm: &dyn LlmClient, transcript: &str) -> SummaryOutcome {
     let request = ChatRequest {
         messages: vec![
             ChatMessage::new(MessageRole::System, COMPACTION_SYSTEM_PROMPT),
@@ -75,17 +95,25 @@ pub async fn summarise_history(llm: &dyn LlmClient, transcript: &str) -> Result<
         tools: Vec::new(),
     };
 
-    let response = llm.chat(&request).await?;
+    let response = match llm.chat(&request).await {
+        Ok(response) => response,
+        // No response, so nothing was billed that we know of.
+        Err(e) => return SummaryOutcome { usage: None, summary: Err(e) },
+    };
+    let usage = response.usage.clone();
     let text = response.text.trim().to_string();
     if text.chars().count() < MIN_SUMMARY_CHARS {
         // Treated exactly like an outright failure by the caller: the history
         // is left alone and the user is warned (#378).
-        return Err(CoreError::Other(format!(
-            "the model returned a summary too short to be usable ({} chars)",
-            text.chars().count()
-        )));
+        return SummaryOutcome {
+            usage,
+            summary: Err(CoreError::Other(format!(
+                "the model returned a summary too short to be usable ({} chars)",
+                text.chars().count()
+            ))),
+        };
     }
-    Ok(text)
+    SummaryOutcome { usage, summary: Ok(text) }
 }
 
 #[cfg(test)]
@@ -110,17 +138,42 @@ mod tests {
         assert!(COMPACTION_SYSTEM_PROMPT.contains("Do not speculate"));
     }
 
-    struct FixedLlm(String);
+    struct FixedLlm(String, Option<TokenUsage>);
 
     #[async_trait::async_trait]
     impl crate::LlmClient for FixedLlm {
         async fn chat(&self, _request: &crate::ChatRequest) -> Result<crate::ChatResponse> {
-            Ok(crate::ChatResponse::text(self.0.clone()))
+            let mut response = crate::ChatResponse::text(self.0.clone());
+            response.usage = self.1.clone();
+            Ok(response)
+        }
+    }
+
+    struct FailingLlm;
+
+    #[async_trait::async_trait]
+    impl crate::LlmClient for FailingLlm {
+        async fn chat(&self, _request: &crate::ChatRequest) -> Result<crate::ChatResponse> {
+            Err(CoreError::Other("provider is down".into()))
+        }
+    }
+
+    fn usage(prompt: u64, completion: u64) -> TokenUsage {
+        TokenUsage {
+            prompt_tokens: Some(prompt),
+            completion_tokens: Some(completion),
+            total_tokens: Some(prompt + completion),
+            cost: Some(0.5),
         }
     }
 
     async fn summarise(reply: &str) -> Result<String> {
-        summarise_history(&FixedLlm(reply.to_string()), "User: hi\nAgent: hello\n").await
+        summarise_with_usage(reply, None).await.summary
+    }
+
+    async fn summarise_with_usage(reply: &str, usage: Option<TokenUsage>) -> SummaryOutcome {
+        let llm = FixedLlm(reply.to_string(), usage);
+        summarise_history(&llm, "User: hi\nAgent: hello\n").await
     }
 
     #[tokio::test]
@@ -133,6 +186,37 @@ mod tests {
                 "must be rejected as a summary: {reply:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn a_rejected_summary_still_reports_what_it_cost() {
+        // The request was billed before the reply could be judged unusable.
+        // Dropping its usage here is how the session's cost went short (#387).
+        let outcome = summarise_with_usage("OK", Some(usage(9_000, 5))).await;
+        assert!(outcome.summary.is_err(), "too short to be a summary");
+        let u = outcome.usage.expect("usage must survive the rejection");
+        assert_eq!(u.prompt_tokens, Some(9_000));
+        assert_eq!(u.completion_tokens, Some(5));
+        assert_eq!(u.cost, Some(0.5));
+    }
+
+    #[tokio::test]
+    async fn an_accepted_summary_reports_what_it_cost() {
+        let real = "User asked for disk usage; agent ran df -h; root is 82% full.";
+        let outcome = summarise_with_usage(real, Some(usage(9_000, 120))).await;
+        assert_eq!(outcome.summary.unwrap(), real);
+        let u = outcome.usage.expect("usage must come back with the summary");
+        assert_eq!(u.prompt_tokens, Some(9_000));
+        assert_eq!(u.completion_tokens, Some(120));
+    }
+
+    #[tokio::test]
+    async fn a_call_that_never_returned_a_response_reports_no_usage() {
+        // Nothing to attribute: inventing a zero here would be indistinguishable
+        // from a provider that reports no usage.
+        let outcome = summarise_history(&FailingLlm, "User: hi\n").await;
+        assert!(outcome.summary.is_err());
+        assert!(outcome.usage.is_none());
     }
 
     #[tokio::test]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -20,7 +20,7 @@ pub mod tools;
 // Re-export key types for convenience.
 pub use agent::{Agent, AgentBuilder};
 pub use arbiter::{ArbiterContext, ArbiterVerdict, ARBITER_TIMEOUT_SECS};
-pub use compaction::{summarise_history, COMPACTION_SYSTEM_PROMPT};
+pub use compaction::{summarise_history, SummaryOutcome, COMPACTION_SYSTEM_PROMPT};
 pub use events::{AgentEvent, EventSink};
 pub use openai_compat::OpenAiCompatClient;
 pub use security::{CliConfirmer, CommandConfirmer, ConfirmDecision};

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -8069,6 +8069,35 @@ mod tests {
     }
 
     #[test]
+    fn summary_usage_lands_in_the_session_that_compacted_not_the_visible_tab() {
+        // `record_summary_usage` reaches for `active_session_mut()`, which
+        // reads as "whatever tab the user is looking at" — it is not.
+        // `handle_agent_event` resolves `session_id` and points `active` at it
+        // before any arm runs, restoring the original tab afterwards. Raised
+        // twice in review of #391, so it is pinned here rather than argued
+        // again.
+        let (mut app, sid, boundary) = app_awaiting_summary();
+        app.new_tab();
+        let other_tab = app.active;
+        assert_ne!(app.sessions[other_tab].id, sid, "the fixture needs two tabs");
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: Some(summary_usage(9_000, 120, Some(0.25))),
+            profile: "p".into(),
+        });
+
+        let compacted = app.sessions.iter().find(|s| s.id == sid).expect("session alive");
+        assert_eq!(compacted.tokens_in, 9_000);
+        assert_eq!(compacted.per_profile["p"].tokens_in, 9_000);
+        assert_eq!(app.sessions[other_tab].tokens_in, 0, "the visible tab pays nothing");
+        assert!(app.sessions[other_tab].per_profile.is_empty());
+        assert_eq!(app.active, other_tab, "the user's tab must be where it was");
+    }
+
+    #[test]
     fn a_reactive_compaction_is_adopted_by_the_session() {
         // The reactive path decides mid-run, so nothing armed
         // `pending_compaction` and the summary that came back was rejected as

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1380,6 +1380,42 @@ impl App {
     }
 
     /// Report that compaction failed, leaving the history untouched.
+    /// Add a summarising call's token usage to the session that paid for it.
+    ///
+    /// Deliberately not routed through [`filar_agent::AgentEvent::TokenUsage`].
+    /// That arm also records `last_prompt_tokens` — the measured size of the
+    /// context actually sent, and the trigger compaction fires on (#376). A
+    /// summary's prompt is the head being folded, sent as its own request, so
+    /// feeding it in there would move the trigger by an amount that has nothing
+    /// to do with how full the session's context is. Arbiter usage is left out
+    /// of that figure for the same reason.
+    ///
+    /// Attribution follows `pending_llm_profile`, the profile the session was
+    /// sent with, because the summary is produced by that same profile inside
+    /// the same agent task. Should the summariser ever move to a separate cheap
+    /// profile, the profile that computed it has to travel with the event
+    /// instead — the value read here would then be the wrong one.
+    fn record_summary_usage(&mut self, usage: &filar_agent::TokenUsage) {
+        let tokens_in = usage.prompt_tokens.unwrap_or(0);
+        let tokens_out = usage.completion_tokens.unwrap_or(0);
+        let cost = usage.cost;
+        let fallback_profile = self.default_profile_name.clone();
+        let s = self.active_session_mut();
+        s.tokens_in += tokens_in;
+        s.tokens_out += tokens_out;
+        if let Some(c) = cost {
+            let total = s.cost_usd.unwrap_or(0.0) + c;
+            s.cost_usd = Some((total * 10000.0).round() / 10000.0);
+        }
+        let profile_key = s.pending_llm_profile.clone().unwrap_or_else(|| {
+            warn!("pending_llm_profile is None — summary usage attributed to default profile");
+            fallback_profile
+        });
+        let pu = s.per_profile.entry(profile_key).or_default();
+        pu.tokens_in += tokens_in;
+        pu.tokens_out += tokens_out;
+    }
+
     pub fn report_compaction_failure(&mut self, error: String) {
         self.active_session_mut().pending_compaction = None;
         self.push_message(ChatBlock::System(format!(
@@ -3741,10 +3777,21 @@ impl App {
                 // and the cancellation token are all left alone.
                 self.push_message(ChatBlock::System(text));
             }
-            TuiEvent::HistoryCompacted { boundary, summary, .. } => match summary {
-                Ok(text) => self.apply_compaction(boundary, text),
-                Err(e) => self.report_compaction_failure(e),
-            },
+            TuiEvent::HistoryCompacted { boundary, summary, usage, .. } => {
+                // Counted here, before the summary is judged: the tokens were
+                // spent by the time this event exists, so an unusable summary
+                // and one that no longer fits the history are both owed for.
+                // This is also the only place it happens — `apply_compaction`
+                // below can be reached again with the same boundary, and
+                // charging from there would double the figures (#387).
+                if let Some(u) = usage {
+                    self.record_summary_usage(&u);
+                }
+                match summary {
+                    Ok(text) => self.apply_compaction(boundary, text),
+                    Err(e) => self.report_compaction_failure(e),
+                }
+            }
         }
         // Auto-scroll to bottom on new content (unless user scrolled up during streaming).
         if auto_scroll {
@@ -7845,6 +7892,134 @@ mod tests {
         assert_eq!(app.active_session().pending_compaction, None);
     }
 
+    fn summary_usage(prompt: u64, completion: u64, cost: Option<f64>) -> filar_agent::TokenUsage {
+        filar_agent::TokenUsage {
+            prompt_tokens: Some(prompt),
+            completion_tokens: Some(completion),
+            total_tokens: Some(prompt + completion),
+            cost,
+        }
+    }
+
+    /// An app armed for compaction with `p` as the profile the request was
+    /// sent under, which is what the summary's usage must be attributed to.
+    fn app_awaiting_summary() -> (App, SessionId, usize) {
+        let mut app = app_over_threshold(1_000, 5_000);
+        let sid = app.active_session().id;
+        app.active_session_mut().pending_llm_profile = Some("p".into());
+        app.report_context_fill("p");
+        let boundary = app.active_session().pending_compaction.expect("compaction armed");
+        (app, sid, boundary)
+    }
+
+    #[test]
+    fn summary_usage_is_counted_once_in_the_session_and_the_profile() {
+        // The summarising call is a real request the user pays for, and its
+        // cost was going nowhere: the session's reported total was short by
+        // every summary it had ever produced (#387).
+        let (mut app, sid, boundary) = app_awaiting_summary();
+        let before_in = app.active_session().tokens_in;
+        let before_out = app.active_session().tokens_out;
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: Some(summary_usage(9_000, 120, Some(0.25))),
+        });
+
+        assert_eq!(app.active_session().tokens_in, before_in + 9_000);
+        assert_eq!(app.active_session().tokens_out, before_out + 120);
+        assert_eq!(app.active_session().cost_usd, Some(0.25));
+        let pu = app.active_session().per_profile.get("p").expect("attributed to the sending profile");
+        assert_eq!(pu.tokens_in, 9_000);
+        assert_eq!(pu.tokens_out, 120);
+    }
+
+    #[test]
+    fn a_summary_applied_twice_is_not_paid_for_twice() {
+        // The second delivery is stale — `pending_compaction` was cleared by
+        // the first — and must not add to the figures again. Charging from
+        // inside `apply_compaction` would have looked equivalent and been
+        // wrong here (#387).
+        let (mut app, sid, boundary) = app_awaiting_summary();
+        let summary = "A real summary of the earlier turns of this session.";
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok(summary.into()),
+            usage: Some(summary_usage(9_000, 120, Some(0.25))),
+        });
+        let after_first = app.active_session().tokens_in;
+        let blocks = app.active_session().messages.len();
+
+        // Applying the same result again: no usage rides along a second time,
+        // and the history is left alone.
+        app.apply_compaction(boundary, summary.into());
+
+        assert_eq!(app.active_session().tokens_in, after_first, "no double count");
+        assert_eq!(app.active_session().per_profile["p"].tokens_in, 9_000);
+        assert_eq!(app.active_session().cost_usd, Some(0.25));
+        assert_eq!(app.active_session().messages.len(), blocks, "history untouched");
+    }
+
+    #[test]
+    fn an_unusable_summary_is_still_paid_for() {
+        // The provider billed the request before anyone could tell the reply
+        // was too short to use (#378 failure path, #387 accounting).
+        let (mut app, sid, boundary) = app_awaiting_summary();
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Err("the model returned a summary too short to be usable".into()),
+            usage: Some(summary_usage(9_000, 3, Some(0.2))),
+        });
+
+        assert_eq!(app.active_session().tokens_in, 9_000);
+        assert_eq!(app.active_session().per_profile["p"].tokens_in, 9_000);
+        assert_eq!(app.active_session().cost_usd, Some(0.2));
+    }
+
+    #[test]
+    fn summary_usage_does_not_move_the_compaction_trigger() {
+        // `last_prompt_tokens` is the size of the context that was sent, and
+        // it is what compaction fires on (#376). The summary's prompt is the
+        // head being folded, in a request of its own, so letting it in there
+        // would move the trigger for reasons unrelated to how full the
+        // session's context is — the same reason arbiter usage is excluded.
+        let (mut app, sid, boundary) = app_awaiting_summary();
+        let before = app.active_session().last_prompt_tokens;
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: Some(summary_usage(9_000, 120, None)),
+        });
+
+        assert_eq!(app.active_session().last_prompt_tokens, before);
+        assert_eq!(app.active_session().tokens_in, 9_000, "but it is still counted");
+    }
+
+    #[test]
+    fn a_summary_with_no_reported_usage_changes_no_figures() {
+        // Providers that report no usage must not turn into zero-token rows.
+        let (mut app, sid, boundary) = app_awaiting_summary();
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: None,
+        });
+
+        assert_eq!(app.active_session().tokens_in, 0);
+        assert_eq!(app.active_session().cost_usd, None);
+        assert!(app.active_session().per_profile.is_empty());
+    }
+
     #[test]
     fn a_reactive_compaction_is_adopted_by_the_session() {
         // The reactive path decides mid-run, so nothing armed
@@ -7869,6 +8044,7 @@ mod tests {
             session_id: sid,
             boundary,
             summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: None,
         });
 
         assert!(

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1390,16 +1390,18 @@ impl App {
     /// to do with how full the session's context is. Arbiter usage is left out
     /// of that figure for the same reason.
     ///
-    /// Attribution follows `pending_llm_profile`, the profile the session was
-    /// sent with, because the summary is produced by that same profile inside
-    /// the same agent task. Should the summariser ever move to a separate cheap
-    /// profile, the profile that computed it has to travel with the event
-    /// instead — the value read here would then be the wrong one.
-    fn record_summary_usage(&mut self, usage: &filar_agent::TokenUsage) {
+    /// `profile` is the one the run was spawned with, carried on the event
+    /// rather than read from `pending_llm_profile` here. Cancelling a turn does
+    /// not abort the summarising call, so it can still be in flight while the
+    /// user switches profile and sends another turn — which overwrites
+    /// `pending_llm_profile` and would put this cost on a profile that never
+    /// computed it (review of #391). Passing it also leaves the cheap-profile
+    /// summariser from the #377 spec a place to plug into: it would set this
+    /// field and nothing here would change.
+    fn record_summary_usage(&mut self, usage: &filar_agent::TokenUsage, profile: String) {
         let tokens_in = usage.prompt_tokens.unwrap_or(0);
         let tokens_out = usage.completion_tokens.unwrap_or(0);
         let cost = usage.cost;
-        let fallback_profile = self.default_profile_name.clone();
         let s = self.active_session_mut();
         s.tokens_in += tokens_in;
         s.tokens_out += tokens_out;
@@ -1407,11 +1409,7 @@ impl App {
             let total = s.cost_usd.unwrap_or(0.0) + c;
             s.cost_usd = Some((total * 10000.0).round() / 10000.0);
         }
-        let profile_key = s.pending_llm_profile.clone().unwrap_or_else(|| {
-            warn!("pending_llm_profile is None — summary usage attributed to default profile");
-            fallback_profile
-        });
-        let pu = s.per_profile.entry(profile_key).or_default();
+        let pu = s.per_profile.entry(profile).or_default();
         pu.tokens_in += tokens_in;
         pu.tokens_out += tokens_out;
     }
@@ -3777,7 +3775,7 @@ impl App {
                 // and the cancellation token are all left alone.
                 self.push_message(ChatBlock::System(text));
             }
-            TuiEvent::HistoryCompacted { boundary, summary, usage, .. } => {
+            TuiEvent::HistoryCompacted { boundary, summary, usage, profile, .. } => {
                 // Counted here, before the summary is judged: the tokens were
                 // spent by the time this event exists, so an unusable summary
                 // and one that no longer fits the history are both owed for.
@@ -3785,7 +3783,7 @@ impl App {
                 // below can be reached again with the same boundary, and
                 // charging from there would double the figures (#387).
                 if let Some(u) = usage {
-                    self.record_summary_usage(&u);
+                    self.record_summary_usage(&u, profile);
                 }
                 match summary {
                     Ok(text) => self.apply_compaction(boundary, text),
@@ -7926,6 +7924,7 @@ mod tests {
             boundary,
             summary: Ok("A real summary of the earlier turns of this session.".into()),
             usage: Some(summary_usage(9_000, 120, Some(0.25))),
+            profile: "p".into(),
         });
 
         assert_eq!(app.active_session().tokens_in, before_in + 9_000);
@@ -7950,6 +7949,7 @@ mod tests {
             boundary,
             summary: Ok(summary.into()),
             usage: Some(summary_usage(9_000, 120, Some(0.25))),
+            profile: "p".into(),
         });
         let after_first = app.active_session().tokens_in;
         let blocks = app.active_session().messages.len();
@@ -7975,6 +7975,7 @@ mod tests {
             boundary,
             summary: Err("the model returned a summary too short to be usable".into()),
             usage: Some(summary_usage(9_000, 3, Some(0.2))),
+            profile: "p".into(),
         });
 
         assert_eq!(app.active_session().tokens_in, 9_000);
@@ -7997,6 +7998,7 @@ mod tests {
             boundary,
             summary: Ok("A real summary of the earlier turns of this session.".into()),
             usage: Some(summary_usage(9_000, 120, None)),
+            profile: "p".into(),
         });
 
         assert_eq!(app.active_session().last_prompt_tokens, before);
@@ -8013,11 +8015,57 @@ mod tests {
             boundary,
             summary: Ok("A real summary of the earlier turns of this session.".into()),
             usage: None,
+            profile: "p".into(),
         });
 
         assert_eq!(app.active_session().tokens_in, 0);
         assert_eq!(app.active_session().cost_usd, None);
         assert!(app.active_session().per_profile.is_empty());
+    }
+
+    #[test]
+    fn a_summary_in_flight_is_billed_to_the_profile_that_computed_it() {
+        // Cancelling a turn does not abort the summarising call, so it can
+        // still be in flight while the user switches profile and sends another
+        // turn. Reading `pending_llm_profile` when the result lands would then
+        // charge the head of a `p` session to `other` (review of #391).
+        let (mut app, sid, boundary) = app_awaiting_summary();
+        app.profiles.push(filar_core::LlmProfile {
+            name: "other".into(), model: "m2".into(), api_base_url: "u".into(),
+            max_tokens: 4096, key_env: "k".into(),
+            temperature: None, top_p: None, extra_body: None,
+            compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
+        });
+
+        // Ctrl+Z, then Ctrl+L to `other`, then a new turn: the session now
+        // points at a profile that had nothing to do with the summary.
+        app.mode = AppMode::Thinking;
+        app.cancel_work();
+        app.llm_profile = Some("other".into());
+        app.begin_agent_request("another question".into());
+        assert_eq!(
+            app.active_session().pending_llm_profile.as_deref(),
+            Some("other"),
+            "the fixture must actually have moved the session's profile on"
+        );
+
+        // The summary from the cancelled run finally comes back.
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: Some(summary_usage(9_000, 120, Some(0.25))),
+            profile: "p".into(),
+        });
+
+        assert_eq!(app.active_session().per_profile["p"].tokens_in, 9_000);
+        let other = app.active_session().per_profile.get("other");
+        assert!(
+            other.map_or(true, |u| u.tokens_in == 0 && u.tokens_out == 0),
+            "the profile that never computed the summary must not be charged for it"
+        );
+        // The session total is owed either way — the request was billed.
+        assert_eq!(app.active_session().tokens_in, 9_000);
     }
 
     #[test]
@@ -8045,6 +8093,7 @@ mod tests {
             boundary,
             summary: Ok("A real summary of the earlier turns of this session.".into()),
             usage: None,
+            profile: "p".into(),
         });
 
         assert!(

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -69,10 +69,17 @@ pub enum TuiEvent {
     ///
     /// `boundary` is echoed back from the request so the app cannot cut a
     /// history that changed while the summary was being produced.
+    ///
+    /// `usage` is what the summarising request itself cost. It rides along with
+    /// the result rather than going through [`filar_agent::AgentEvent::TokenUsage`]
+    /// because that path also records the size of the context that was sent,
+    /// which drives compaction — and a summary's prompt is the head being
+    /// folded, not the session's context (#387).
     HistoryCompacted {
         session_id: SessionId,
         boundary: usize,
         summary: std::result::Result<String, String>,
+        usage: Option<filar_agent::TokenUsage>,
     },
 
     /// A reactive compaction is about to be summarised — arm the session for

--- a/crates/tui/src/event.rs
+++ b/crates/tui/src/event.rs
@@ -70,16 +70,21 @@ pub enum TuiEvent {
     /// `boundary` is echoed back from the request so the app cannot cut a
     /// history that changed while the summary was being produced.
     ///
-    /// `usage` is what the summarising request itself cost. It rides along with
-    /// the result rather than going through [`filar_agent::AgentEvent::TokenUsage`]
-    /// because that path also records the size of the context that was sent,
-    /// which drives compaction — and a summary's prompt is the head being
-    /// folded, not the session's context (#387).
+    /// `usage` is what the summarising request itself cost, and `profile` is
+    /// the profile that computed it, captured when the run was spawned. Both
+    /// ride along with the result rather than being read from the session when
+    /// it arrives: the usage would otherwise go through
+    /// [`filar_agent::AgentEvent::TokenUsage`], which also records the size of
+    /// the context that was sent and drives compaction — and a summary's prompt
+    /// is the head being folded, not the session's context. The profile would
+    /// otherwise be read from `pending_llm_profile`, which a later turn can
+    /// already have overwritten by then (#387).
     HistoryCompacted {
         session_id: SessionId,
         boundary: usize,
         summary: std::result::Result<String, String>,
         usage: Option<filar_agent::TokenUsage>,
+        profile: String,
     },
 
     /// A reactive compaction is about to be summarised — arm the session for

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1045,6 +1045,7 @@ async fn run_app(
                             cancel_token,
                             config.secret_provider.clone(),
                             sid,
+                            profile_name.clone(),
                             app.active_session().compaction_exhausted,
                             pending_compaction,
                         );
@@ -1757,6 +1758,11 @@ fn spawn_agent(
     cancellation: CancellationToken,
     secret_provider: Arc<dyn SecretProvider>,
     sid: SessionId,
+    // The profile this run was resolved from. Travels with the summary result
+    // so the cost of compaction is attributed to the profile that computed it,
+    // even if the session has moved on to another one by the time it lands
+    // (#387).
+    profile_name: String,
     // The session has already been told that compaction cannot shrink it any
     // further. The reactive path honours that rather than quietly compacting
     // behind the notice (review of #390).
@@ -1802,6 +1808,7 @@ fn spawn_agent(
             llm.as_ref(),
             &tx,
             sid,
+            &profile_name,
         )
         .await;
 
@@ -1886,8 +1893,15 @@ fn spawn_agent(
                 boundary,
                 epoch: history_epoch,
             });
-            chat_history =
-                compact_for_request(chat_history, Some(boundary), llm.as_ref(), &tx, sid).await;
+            chat_history = compact_for_request(
+                chat_history,
+                Some(boundary),
+                llm.as_ref(),
+                &tx,
+                sid,
+                &profile_name,
+            )
+            .await;
             if chat_history.len() >= before {
                 // The summary failed, so the history is unchanged and the
                 // retry would send exactly what just overflowed.
@@ -1944,6 +1958,7 @@ async fn compact_for_request(
     llm: &dyn LlmClient,
     tx: &mpsc::UnboundedSender<TuiEvent>,
     sid: SessionId,
+    profile: &str,
 ) -> Vec<ChatBlock> {
     let Some(boundary) = boundary else {
         return chat_history;
@@ -1953,7 +1968,9 @@ async fn compact_for_request(
     }
     let transcript = filar_core::transcript_for_summary(&chat_history[..boundary]);
     // The usage goes back in both branches: the call was billed whether or not
-    // the reply turned out to be usable (#387).
+    // the reply turned out to be usable. So does the profile that computed it,
+    // which is this run's, not whichever one the session holds by the time the
+    // result lands (#387).
     let outcome = filar_agent::summarise_history(llm, &transcript).await;
     let usage = outcome.usage;
     match outcome.summary {
@@ -1964,6 +1981,7 @@ async fn compact_for_request(
                 boundary,
                 summary: Ok(summary),
                 usage,
+                profile: profile.to_string(),
             });
             compacted
         }
@@ -1976,6 +1994,7 @@ async fn compact_for_request(
                 boundary,
                 summary: Err(e.to_string()),
                 usage,
+                profile: profile.to_string(),
             });
             chat_history
         }

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1952,13 +1952,18 @@ async fn compact_for_request(
         return chat_history;
     }
     let transcript = filar_core::transcript_for_summary(&chat_history[..boundary]);
-    match filar_agent::summarise_history(llm, &transcript).await {
+    // The usage goes back in both branches: the call was billed whether or not
+    // the reply turned out to be usable (#387).
+    let outcome = filar_agent::summarise_history(llm, &transcript).await;
+    let usage = outcome.usage;
+    match outcome.summary {
         Ok(summary) => {
             let compacted = filar_core::compact_history(&chat_history, boundary, &summary);
             let _ = tx.send(TuiEvent::HistoryCompacted {
                 session_id: sid,
                 boundary,
                 summary: Ok(summary),
+                usage,
             });
             compacted
         }
@@ -1970,6 +1975,7 @@ async fn compact_for_request(
                 session_id: sid,
                 boundary,
                 summary: Err(e.to_string()),
+                usage,
             });
             chat_history
         }


### PR DESCRIPTION
Closes #387

## Summary

Compaction sends a real request to the model, and only the reply was kept from it. `summarise_history` returned `Result<String>`, so the `usage` on the `ChatResponse` went nowhere: neither the session's `tokens_in` / `tokens_out` / `cost_usd` nor `per_profile` saw it. On a long session the input of every summary is the whole head being folded, so the cost shown to the user was short by a large amount and grew shorter with use.

- `summarise_history` now returns `SummaryOutcome { usage, summary }`. The two are separated because they are owed to different places: whether the brief is usable decides only whether the head is folded, while the request was billed before anyone could judge it. A reply rejected as too short (#378) therefore comes back with its usage intact; a call that failed before a response existed reports `None` rather than a fabricated zero.
- `TuiEvent::HistoryCompacted` gains a `usage` field, and the runner fills it in on both branches.
- `App::record_summary_usage` adds it to the session totals and `per_profile`.

## Where it is counted, and why not the obvious place

Not through `AgentEvent::TokenUsage`. That arm also records `last_prompt_tokens` — the measured size of the context actually sent, and the trigger compaction fires on (#376). A summary's prompt is the head being folded, in a request of its own, so routing it there would move the trigger by an amount unrelated to how full the session's context is, and could re-arm compaction immediately after one just ran. Arbiter usage is excluded from that same figure for exactly this reason, so the new helper follows the arbiter's precedent: session totals and `per_profile`, no `last_prompt_tokens`, no `last_served_model`.

Counted in the `HistoryCompacted` arm, before the summary is judged, rather than inside `apply_compaction`. The two look equivalent and are not: `apply_compaction` is reachable again with the same boundary and its stale guard rejects a result whose history has moved, so charging from there would either double the figures or drop them exactly when the user was billed. Both cases have tests.

## Attribution and the cheap profile

Attribution follows `pending_llm_profile`, the profile the request was sent under. Correct today, because the summary runs on the session's own profile inside the same agent task.

The cheap-profile option from the #377 spec is **not** implemented here. The issue makes it conditional ("если реализуется"), and nothing in the repo defines how such a profile would be configured or selected — inventing that is outside this issue. When it lands, the profile that computed the summary has to travel on the event, because the value read here would then be the wrong one. That warning is in the doc comment on `record_summary_usage` so the next person meets it in place rather than in a changelog.

## Tests

Nine new tests. Four in `filar-agent`: usage survives an accepted summary, survives one rejected as too short, and is absent when no response came back at all. Five in `app.rs`: counted once in the session and in `per_profile`; re-applying the same result does not double the figures; an unusable summary is still paid for; the compaction trigger does not move; a provider that reports no usage changes nothing.

## Verified in the agent environment

The container **does** have a Rust toolchain this time — `rustup` installs fine now, contrary to what the skill's `reference/environment.md` still says. That file is stale and needs its own fix.

- `cargo build --workspace` — green.
- `cargo test --workspace` — green: 780 passed, 0 failed, 8 ignored (the docker-sshd `#[ignore]` tests; no docker here, still manual).
- `cargo build --release` — green; `target/release/filar --help` runs.
- The four positive `app.rs` tests were confirmed to **fail** with the accounting call removed, so they are testing the change rather than passing on the old code.

## Not verified — needs a human

The TUI itself was not driven: there is no interactive terminal in this environment. The user-facing DoD check is yours:

1. Start a session with `compact_at_tokens` low enough to fire, or force one with `Ctrl+K`.
2. After the summary lands, compare the session cost in the status bar / help overlay against the sum of the agent requests alone.
3. Expected: the total is now higher by the summarising request, and `per_profile` for the session's profile carries it. Before this change the two matched exactly, which was the bug.

Also worth a glance: trigger a deliberately unusable summary (a model that answers "OK") and confirm the cost still moves while the history is left alone.

## Out of scope

- The cheap-profile summariser, as above.
- `docs/ENGINE_API.md` does not document `summarise_history` or `ChatBlock::Summary` at all — a gap noted back in #377 for "the next engine tag", still open, not touched here.
- No platform-specific behaviour surfaced, so `docs/PLATFORM_NOTES.md` is unchanged.

## Notes for CI

`COMPACTION_SYSTEM_PROMPT` and the agent loop are unchanged, so eval behaviour should be unaffected — but the change is inside `crates/agent/src/**`, so `eval-smoke` triggers automatically. Threshold is ≥ 90%.

`summarise_history` changes signature, which is breaking for any embedder calling it directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Session cost reporting now includes requests used to compact conversation history.
  - Usage is counted even when a generated summary is too short to use.
  - Summary costs are attributed to the profile that generated them, including after cancellation and profile switching.
  - Summary costs are recorded once in session totals and profile usage, preventing duplicate charges.
  - Failed summarization requests continue to report no usage when billing data is unavailable.
  - History-compaction usage remains separate from context-size tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->