### PR TITLE
feat(tui/core): keep the folded head out of the context, not out of the session (#379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,8 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
-- Compacting the history no longer shortens the transcript or the saved
-  session: the folded head is kept alongside the compacted context, so the `.md`
-  record and a reopened session still hold every turn
+- Compacting the history no longer shortens the transcript or the saved session:
+  the folded head is kept alongside the compacted context
   ([#379](https://github.com/devlawey/filar/issues/379)).
 
 - Session cost now includes the requests made to compact the history, counting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- Compacting the history no longer shortens the transcript or the saved
+  session: the folded head is kept alongside the compacted context, so the `.md`
+  record and a reopened session still hold every turn
+  ([#379](https://github.com/devlawey/filar/issues/379)).
+
 - Session cost now includes the requests made to compact the history, counting
   a summary the model returns unusably short as well, since it is billed either
   way ([#387](https://github.com/devlawey/filar/issues/387)).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6196,13 +6196,28 @@ crashing with a stack dump on the final link. It reads as a compiler bug and is
 not one; clearing the release artifacts fixed it. Worth knowing before anyone
 files it upstream.
 
-**Next steps:** milestone 1.0.6 has no open issues left and is ready for
-`prepare-release`. `docs/ENGINE_API.md` still documents neither
-`ChatBlock::Summary` (noted in #377), nor `summarise_history`, whose signature
-#387 changed, nor this field — all three want a pass before the next engine tag.
-Also still open from #391's review: the summarising call ignores the
+**Review (PR #392).** Two findings taken. The manual `Ctrl+S` export still ran
+off `messages`, so an export taken after a compaction would have had the same
+hole this issue is about — only the silent transcript save had been switched.
+Both save paths now go through `full_history()`, which is the point of having
+the accessor. And `session_snapshot`, made `pub(crate)` for a test, had no doc
+comment. The changelog entry was condensed as well.
+
+Declined: a blocker claiming `apply_loaded_session` sets `App::messages` without
+touching `Session::messages`, leaving a restored session with its old context.
+`App` derefs to the active session, so those are one field and the suggested fix
+is the same assignment written twice. The review was right that the round-trip
+test could not have caught such a divergence, though — it snapshotted the
+session it then loaded — so there is now a test that loads a session whose
+content differs from the current one.
+
+**Next steps:** both loose ends now have issues in 1.0.6. #393 covers
+`docs/ENGINE_API.md`, which documents neither `ChatBlock::Summary` (noted in
+#377), nor `summarise_history`, whose signature #387 changed, nor this field —
+it blocks `engine-v1.0.6`. #394 covers the summarising call ignoring the
 cancellation token, so Ctrl+Z during compaction leaves the user paying for a
-request whose result is then thrown away. The history is safe; the money is not.
+request whose result is thrown away: the history is safe, the money is not.
+`prepare-release` after those.
 
 ## Release v1.0.5 (2026-08-27)
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6124,6 +6124,86 @@ separate defect surfaced in review and is **not** fixed here: the summarising
 call ignores the cancellation token, so Ctrl+Z leaves the user paying for a
 request whose result is then discarded. Needs its own issue.
 
+## Issue #379: feat(tui/core) — compaction stopped costing the record (4/4)
+
+**Milestone:** 1.0.6. **Branch:** `feat/379-compaction-transcript-session`.
+Closes the four-part compaction series (376 → 377 → 378 → 379).
+
+**Problem.** The issue allowed that its first requirement might already hold:
+the transcript is written from `Session::messages`, so it keeps the whole
+conversation *if* compaction only changes what goes to the model. It did not.
+`apply_compaction` assigned `messages = compacted`, so the folded head left the
+session outright — the `.md` record had a hole exactly where the beginning of
+the conversation used to be, and a reopened session had lost it for good. The
+issue's second branch applied: fix it, do not describe it.
+
+**Decision, stated as the issue asks.** The full history is kept, but not in
+`messages`. `Session` gains `folded_history: Vec<ChatBlock>`, appended to by
+`apply_compaction` before the head is replaced, in both the TUI session and the
+persisted `filar_core::Session`.
+
+This is deliberately not the spec's literal recommendation of holding the whole
+history in `messages` and projecting it for the model. #377 made the feed and
+the model's context one list on purpose: the summary is visible in the feed
+precisely so that compaction is something the user can audit, and a projection
+would mean the feed shows turns the model no longer has. It would also force
+every reader of `messages` — feed rendering, block indices, collapse overrides,
+topic slug, the #376 fill measurement — to choose between the full and the
+projected list, which is a change across `app.rs` and `ui/` rather than a change
+to compaction. The guarantee is identical either way: nothing is lost. What
+differs is where the folded head lives and how much code has to know about it.
+
+**Consumers.** New `App::full_history()` returns archive followed by context;
+`save_transcript_silent` writes from it. `session_snapshot` persists both lists
+and `apply_loaded_session` restores both. `#[serde(default)]` keeps older files
+readable, and a file with the new field is ignored rather than rejected by
+readers that do not know it, the same way every other field added since 1.0 has
+behaved. The record reads head, then the summary that stood in for it, then the
+verbatim tail — it says both what happened and where the model's view was
+folded.
+
+**Profile switch and cancel needed no change, and the tests say so honestly.**
+Ctrl+L only reassigns `llm_profile` and pushes a notice; it touches neither the
+history nor `pending_compaction`, `compacted_without_relief` or
+`context_full_notice_shown`, and `compact_at_tokens_for` already reads the
+threshold from whichever profile is active, so a switch changes the threshold
+with no restart. Ctrl+Z clears `pending_compaction` in `cancel_work`, so a late
+summary is discarded by the stale guard from #377 and nothing is half-folded.
+Both are covered, but as characterisation tests: they do **not** fail on the old
+code, because the behaviour was already right. Only the archive tests do.
+
+**Done:** 2 tests in `filar-core` (the archive survives a round trip; a file
+saved before this field loads with an empty one) and 5 in `app.rs` (the head
+moves to the archive rather than out of the session, with the exact shape of the
+record pinned; the transcript holds the whole conversation while `messages`
+alone would not; reopening keeps both lists; Ctrl+L driven through the real key
+handler leaves the archive and takes the new threshold; Ctrl+Z leaves history
+and archive alone).
+
+**Public contract:** `filar_core::Session` gains a field. Additive and
+`#[serde(default)]`, but embedders constructing it with a struct literal must
+add it. `ChatBlock`, `CommandExecutor` and `LlmClient` are untouched, and
+nothing in `crates/agent/src/**` changed, so `eval-smoke` should not be
+triggered by this.
+
+**Verification:** `cargo build --workspace`, `cargo test --workspace` (789
+passed, 0 failed, 8 ignored — the docker-sshd tests) and `cargo build
+--release`. The TUI was not driven: no interactive terminal here, so the three
+manual DoD checks are the human's and are written out in the PR.
+
+**Environment note:** the container disk filled to 99% mid-task and `lld` began
+crashing with a stack dump on the final link. It reads as a compiler bug and is
+not one; clearing the release artifacts fixed it. Worth knowing before anyone
+files it upstream.
+
+**Next steps:** milestone 1.0.6 has no open issues left and is ready for
+`prepare-release`. `docs/ENGINE_API.md` still documents neither
+`ChatBlock::Summary` (noted in #377), nor `summarise_history`, whose signature
+#387 changed, nor this field — all three want a pass before the next engine tag.
+Also still open from #391's review: the summarising call ignores the
+cancellation token, so Ctrl+Z during compaction leaves the user paying for a
+request whose result is then thrown away. The history is safe; the money is not.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -55,6 +55,20 @@ pub struct Session {
     pub llm_profile: Option<String>,
     /// Chat history blocks.
     pub messages: Vec<ChatBlock>,
+    /// Heads folded away by compaction, oldest first (#379).
+    ///
+    /// Compaction replaces the head of [`Self::messages`] with a
+    /// [`ChatBlock::Summary`], because what the model is sent and what the feed
+    /// shows are deliberately the same list (#377). The blocks it replaced are
+    /// kept here so nothing is actually lost: the transcript is written from
+    /// this followed by `messages`, and a reopened session still holds every
+    /// turn it ever had. Repeated compactions append, so this stays in order
+    /// and a summary of a summary still has the original turns behind it.
+    ///
+    /// `#[serde(default)]` for backward compat: sessions saved before this
+    /// existed simply have none.
+    #[serde(default)]
+    pub folded_history: Vec<ChatBlock>,
     /// History of user prompts in agent mode (for Up/Down navigation).
     /// Limited to [`MAX_INPUT_HISTORY`] entries when saved.
     #[serde(default)]
@@ -413,6 +427,7 @@ mod tests {
     #[test]
     fn session_meta_from_session() {
         let session = Session {
+            folded_history: Vec::new(),
             id: "123".into(),
             timestamp: "2026-06-21 12:00:00".into(),
             target: "local".into(),
@@ -443,6 +458,7 @@ mod tests {
     #[test]
     fn session_meta_empty_messages() {
         let session = Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "t".into(),
@@ -471,6 +487,7 @@ mod tests {
 
         let store = SessionStore { dir: tmp.clone() };
         let session = Session {
+            folded_history: Vec::new(),
             id: "777".into(),
             timestamp: "2026-01-01 00:00:00".into(),
             target: "test".into(),
@@ -515,6 +532,7 @@ mod tests {
         };
 
         let session = Session {
+            folded_history: Vec::new(),
             id: "999".into(),
             timestamp: "2026-01-01 00:00:00".into(),
             target: "test".into(),
@@ -566,6 +584,7 @@ mod tests {
         // Save 5 sessions with different IDs (timestamps).
         for i in 1..=5u64 {
             let session = Session {
+                folded_history: Vec::new(),
                 id: format!("{i:010}"),
                 timestamp: format!("t{i}"),
                 target: "t".into(),
@@ -692,6 +711,7 @@ mod tests {
     #[test]
     fn tokens_in_out_roundtrip() {
         let s = Session {
+            folded_history: Vec::new(),
             id: "1".into(), timestamp: "t".into(), target: "t".into(),
             llm_profile: Some("glm".into()), messages: vec![], input_history: vec![],
             tokens_in: 150, tokens_out: 300,
@@ -725,6 +745,7 @@ mod tests {
     #[test]
     fn input_history_serialize_roundtrip() {
         let session = Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "t".into(),
@@ -767,8 +788,64 @@ mod tests {
     }
 
     #[test]
+    fn folded_history_survives_a_save_and_load() {
+        // The compacted context and the head it replaced are stored side by
+        // side, so reopening a session that has been compacted does not
+        // quietly shorten it (#379).
+        let session = Session {
+            id: "1".into(),
+            timestamp: "t".into(),
+            target: "t".into(),
+            llm_profile: None,
+            messages: vec![
+                ChatBlock::Summary { text: "earlier turns".into(), replaced_blocks: 2 },
+                ChatBlock::User("still here".into()),
+            ],
+            folded_history: vec![
+                ChatBlock::User("the very first question".into()),
+                ChatBlock::Agent("the answer to it".into()),
+            ],
+            input_history: vec![],
+            tokens_in: 0,
+            tokens_out: 0,
+            cost_usd: None,
+            per_profile: HashMap::new(),
+            last_served_model: None,
+            model_per_profile: HashMap::new(),
+            ssh_info: None,
+            model: None,
+            api_base_url: None,
+            confirm_mode: None,
+        };
+        let json = serde_json::to_string(&session).unwrap();
+        let loaded: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.folded_history.len(), 2);
+        assert!(
+            matches!(&loaded.folded_history[0], ChatBlock::User(t) if t == "the very first question"),
+            "the folded head comes back verbatim"
+        );
+        assert_eq!(loaded.messages.len(), 2, "and the context is unchanged by it");
+    }
+
+    #[test]
+    fn a_session_saved_before_folded_history_still_loads() {
+        // Files written by any earlier version simply have no archive.
+        let json = r#"{
+            "id":"123",
+            "timestamp":"2026-01-01 00:00:00",
+            "target":"test",
+            "llm_profile":"glm",
+            "messages":[{"User":"hello"},{"Agent":"world"}]
+        }"#;
+        let session: Session = serde_json::from_str(json).unwrap();
+        assert!(session.folded_history.is_empty(), "missing field → empty archive");
+        assert_eq!(session.messages.len(), 2, "and the history is untouched");
+    }
+
+    #[test]
     fn truncate_input_history_keeps_last_entries() {
         let mut session = Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "t".into(),
@@ -813,6 +890,7 @@ mod tests {
     #[test]
     fn model_per_profile_survives_roundtrip() {
         let mut session = Session {
+            folded_history: Vec::new(),
             id: "1".into(), timestamp: "t".into(), target: "t".into(),
             llm_profile: None, messages: vec![], input_history: vec![],
             tokens_in: 0, tokens_out: 0,
@@ -843,6 +921,7 @@ mod tests {
     #[test]
     fn launch_context_roundtrip() {
         let session = Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "prod".into(),
@@ -888,6 +967,7 @@ mod tests {
     #[test]
     fn session_meta_includes_launch_context() {
         let session = Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "prod".into(),

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -330,8 +330,15 @@ pub struct Session {
     pub id: SessionId,
     /// Display name shown on the tab label.
     pub target_name: String,
-    /// Chat history blocks.
+    /// Chat history blocks: what the feed shows and what the model is sent.
     pub messages: Vec<ChatBlock>,
+    /// Heads folded away by compaction, oldest first (#379).
+    ///
+    /// `messages` is deliberately one list for the feed and the model (#377),
+    /// so compaction really does drop the head from it. These are the blocks it
+    /// dropped, kept so the transcript and the saved session still hold the
+    /// whole conversation. Append-only; the only writer is `apply_compaction`.
+    pub folded_history: Vec<ChatBlock>,
     /// Current input text.
     pub input: String,
     /// Cursor position in the input (char index, 0 = before first char).
@@ -748,6 +755,7 @@ impl Session {
         Self {
             id: SessionId::next(),
             target_name,
+            folded_history: Vec::new(),
             messages: vec![ChatBlock::System(format!(
                 "Connected to: {name}"
             ))],
@@ -1335,6 +1343,23 @@ impl App {
     ///
     /// `boundary` is echoed back from the request so a history that changed
     /// while the summary was being produced cannot be cut at a stale index.
+    /// The active session's whole conversation: everything compaction folded
+    /// away, followed by what the feed currently shows.
+    ///
+    /// `messages` alone is the *context* — the compacted view the model is
+    /// sent. Anything that claims to be a record of the session rather than a
+    /// view of its context wants this instead (#379).
+    pub fn full_history(&self) -> Vec<ChatBlock> {
+        let s = self.active_session();
+        if s.folded_history.is_empty() {
+            return s.messages.clone();
+        }
+        let mut out = Vec::with_capacity(s.folded_history.len() + s.messages.len());
+        out.extend_from_slice(&s.folded_history);
+        out.extend_from_slice(&s.messages);
+        out
+    }
+
     pub fn apply_compaction(&mut self, boundary: usize, summary: String) {
         // The history may have moved while the summary was being produced: the
         // user can cancel the run or restore a saved session, and cutting the
@@ -1358,6 +1383,13 @@ impl App {
             &summary,
         );
         let after = compacted.len();
+        // The head leaves `messages` — that is the point of compaction — but it
+        // does not leave the session. The transcript and the saved file are
+        // written from `folded_history` followed by `messages`, so folding the
+        // context the model carries never costs the user the record of what
+        // happened (#379).
+        let folded: Vec<_> = self.active_session().messages[..boundary].to_vec();
+        self.active_session_mut().folded_history.extend(folded);
         self.active_session_mut().messages = compacted;
         self.active_session_mut().pending_compaction = None;
         // Re-arm the threshold. The flag records that the notice was shown for
@@ -1604,6 +1636,10 @@ impl App {
         self.selection = None;
 
         self.messages = session.messages;
+        // Restored alongside the context it was folded out of, so reopening a
+        // compacted session does not quietly shorten its transcript. Sessions
+        // saved before #379 carry none, which is simply an empty archive.
+        self.active_session_mut().folded_history = session.folded_history;
         self.message_rev = self.message_rev.wrapping_add(1);
         // A summary still in flight was made from the history this just
         // replaced, so it must not be applied to the restored one (#377).
@@ -1969,7 +2005,10 @@ impl App {
         };
 
         let sid = self.sessions[self.active].id;
-        let messages = self.messages.clone();
+        // The whole conversation, not the compacted context: an audit trail
+        // with a hole where the head used to be is worth little, and the
+        // transcript must not depend on whether compaction happened (#379).
+        let messages = self.full_history();
         let session_name = self.sessions[self.active].target_name.clone();
         let ssh_info = self.sessions[self.active].ssh_info.clone();
 
@@ -8097,6 +8136,175 @@ mod tests {
         assert_eq!(app.active, other_tab, "the user's tab must be where it was");
     }
 
+    /// An app whose head has already been folded once.
+    fn app_after_one_compaction() -> (App, Vec<ChatBlock>, usize) {
+        let (mut app, sid, boundary) = app_awaiting_summary();
+        let before = app.active_session().messages.clone();
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: None,
+            profile: "p".into(),
+        });
+        assert!(
+            app.active_session().messages.len() < before.len(),
+            "the fixture must actually have compacted something"
+        );
+        (app, before, boundary)
+    }
+
+    #[test]
+    fn compaction_moves_the_head_into_the_archive_rather_than_out_of_the_session() {
+        // The context shrinks — that is the point — but the record does not.
+        // An audit trail with a hole where the head used to be is worth little,
+        // and it must not depend on whether compaction happened (#379).
+        let (app, before, boundary) = app_after_one_compaction();
+
+        assert_eq!(
+            format!("{:?}", app.active_session().folded_history),
+            format!("{:?}", &before[..boundary]),
+            "every folded block is kept, in order"
+        );
+        let full = app.full_history();
+        assert!(
+            full.iter().any(|b| matches!(b, ChatBlock::User(t) if t == "turn 0")),
+            "the record still holds the first turn, which the context no longer does"
+        );
+        // The record reads head, then the summary that stood in for it, then
+        // the verbatim tail — so it says both what happened and where the
+        // model's view of it was folded.
+        // Two blocks more than before: the summary, and the feed line
+        // announcing the fold.
+        assert_eq!(full.len(), before.len() + 2);
+        assert!(
+            matches!(full.last(), Some(ChatBlock::System(t)) if t.starts_with("History compacted")),
+            "the notice is the last thing on the record"
+        );
+        for (i, block) in before[..boundary].iter().enumerate() {
+            assert_eq!(
+                format!("{:?}", &full[i]),
+                format!("{:?}", block),
+                "head block {i}"
+            );
+        }
+        assert!(
+            matches!(full[boundary], ChatBlock::Summary { replaced_blocks, .. } if replaced_blocks == boundary),
+            "the summary sits where the fold happened"
+        );
+        for (i, block) in before[boundary..].iter().enumerate() {
+            assert_eq!(
+                format!("{:?}", &full[boundary + 1 + i]),
+                format!("{:?}", block),
+                "tail block {i}"
+            );
+        }
+        // The model-facing context is untouched by any of this.
+        assert!(matches!(app.messages.first(), Some(ChatBlock::Summary { .. })));
+    }
+
+    #[test]
+    fn the_transcript_is_written_from_the_whole_conversation() {
+        let (app, _, _) = app_after_one_compaction();
+        let md = messages_to_markdown(&app.full_history(), "test", &None);
+        assert!(md.contains("turn 0"), "the folded head reaches the transcript");
+        assert!(md.contains("turn 19"), "so does the tail");
+        assert!(
+            !messages_to_markdown(&app.messages, "test", &None).contains("turn 0"),
+            "and the compacted context alone would not have — which is the bug"
+        );
+    }
+
+    #[test]
+    fn a_reopened_session_keeps_both_the_context_and_the_folded_head() {
+        let (mut app, before, boundary) = app_after_one_compaction();
+        let saved = crate::runner::session_snapshot(&app, "test", "1", "t");
+
+        app.apply_loaded_session(saved);
+
+        assert_eq!(
+            format!("{:?}", app.active_session().folded_history),
+            format!("{:?}", &before[..boundary]),
+            "the archive came back with the session"
+        );
+        let full = app.full_history();
+        for (i, block) in before[..boundary].iter().enumerate() {
+            assert_eq!(
+                format!("{:?}", &full[i]),
+                format!("{:?}", block),
+                "folded block {i} survived the round trip"
+            );
+        }
+    }
+
+    #[test]
+    fn switching_profile_keeps_the_folded_history_and_takes_the_new_threshold() {
+        // Ctrl+L changes the profile of the tab, not the history of the
+        // session, and the threshold is read from whichever profile is active.
+        let (mut app, _, _) = app_after_one_compaction();
+        app.profiles.push(filar_core::LlmProfile {
+            name: "wide".into(), model: "m2".into(), api_base_url: "u".into(),
+            max_tokens: 4096, key_env: "k".into(),
+            temperature: None, top_p: None, extra_body: None,
+            compact_at_tokens: 900_000,
+        });
+        let folded = app.active_session().folded_history.clone();
+        let messages = app.messages.clone();
+
+        app.mode = AppMode::Normal;
+        let ctrl_l = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('l'),
+            crossterm::event::KeyModifiers::CONTROL,
+        );
+        app.handle_key(ctrl_l);
+
+        assert_eq!(
+            format!("{:?}", app.active_session().folded_history),
+            format!("{:?}", folded),
+            "archive intact"
+        );
+        assert_eq!(
+            app.messages.iter().filter(|b| !matches!(b, ChatBlock::System(_))).count(),
+            messages.iter().filter(|b| !matches!(b, ChatBlock::System(_))).count(),
+            "the compacted context is intact apart from the switch notice"
+        );
+        let now = app.llm_profile.clone().expect("a profile is selected");
+        assert_eq!(
+            app.compact_at_tokens_for(&now),
+            if now == "wide" { 900_000 } else { 1_000 },
+            "the threshold follows the active profile, with no restart"
+        );
+    }
+
+    #[test]
+    fn cancelling_during_compaction_leaves_the_history_and_the_archive_alone() {
+        // Ctrl+Z mid-compaction behaves like a failed summary (#378): nothing
+        // is half-folded, and the late result is discarded by the stale guard.
+        let (mut app, sid, boundary) = app_awaiting_summary();
+
+        app.mode = AppMode::Thinking;
+        app.cancel_work();
+        // Snapshot after the cancel notice, so the comparison is about the
+        // history and not about that one system line.
+        let before = app.active_session().messages.clone();
+
+        app.handle_agent_event(TuiEvent::HistoryCompacted {
+            session_id: sid,
+            boundary,
+            summary: Ok("A real summary of the earlier turns of this session.".into()),
+            usage: None,
+            profile: "p".into(),
+        });
+
+        assert_eq!(
+            format!("{:?}", app.active_session().messages),
+            format!("{:?}", before),
+            "history byte for byte"
+        );
+        assert!(app.active_session().folded_history.is_empty(), "nothing archived");
+        assert_eq!(format!("{:?}", app.full_history()), format!("{:?}", before));
+    }
+
     #[test]
     fn a_reactive_compaction_is_adopted_by_the_session() {
         // The reactive path decides mid-run, so nothing armed
@@ -8620,6 +8828,7 @@ mod tests {
             compact_at_tokens: filar_core::DEFAULT_COMPACT_AT_TOKENS,
         }];
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "prod".into(),
@@ -8674,6 +8883,7 @@ mod tests {
         app.active_session_mut().compaction_exhausted = true;
 
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "prod".into(),
@@ -8715,6 +8925,7 @@ mod tests {
     fn apply_loaded_session_ssh_reconnects() {
         let mut app = App::new("local".into(), CommandConfirmMode::Always);
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "prod".into(),
@@ -8753,6 +8964,7 @@ mod tests {
         let token = tokio_util::sync::CancellationToken::new();
         app.pending_ssh_cancel = Some(token.clone());
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "local".into(),
@@ -8787,6 +8999,7 @@ mod tests {
         });
         app.pending_ssh_handle = Some(handle);
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "local".into(),
@@ -8821,6 +9034,7 @@ mod tests {
         });
         app.ctrl_o_handle = Some(handle);
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "local".into(),
@@ -8855,6 +9069,7 @@ mod tests {
             host_key_policy: filar_core::HostKeyPolicy::Tofu,
         }];
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "prod".into(),
@@ -8899,6 +9114,7 @@ mod tests {
         }];
         app.llm_profile = Some("other".into());
         let session = filar_core::Session {
+            folded_history: Vec::new(),
             id: "1".into(),
             timestamp: "t".into(),
             target: "local".into(),

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1932,9 +1932,11 @@ impl App {
 
         let session_name = self.sessions[self.active].target_name.clone();
         let ssh_info = self.sessions[self.active].ssh_info.clone();
-        // Live chat lives on `App::messages`; `Session::messages` is only
-        // populated on F3 restore (#350).
-        let messages = self.messages.clone();
+        // The whole conversation, for the same reason the silent save uses it:
+        // an export that drops the turns compaction folded away is a record
+        // with a hole in it (#379). Both save paths go through this one
+        // accessor so they cannot drift apart.
+        let messages = self.full_history();
         let tx = tx.clone();
         // Resolve the export directory: configured `save_dir`, else CWD.
         let base_dir = self
@@ -8235,6 +8237,40 @@ mod tests {
                 "folded block {i} survived the round trip"
             );
         }
+    }
+
+    #[test]
+    fn loading_a_session_replaces_the_context_as_well_as_the_archive() {
+        // Raised in review of #392 as a claim that `apply_loaded_session` sets
+        // only `App::messages` and leaves `Session::messages` behind. `App`
+        // derefs to the active session, so the two are one field — but the
+        // test is cheaper than the argument, and it uses a session whose
+        // content differs from the current one so a real divergence would show.
+        let (mut app, _, _) = app_after_one_compaction();
+        let mut saved = crate::runner::session_snapshot(&app, "test", "1", "t");
+        saved.messages = vec![ChatBlock::User("from the saved file".into())];
+        saved.folded_history = vec![ChatBlock::User("folded in the saved file".into())];
+
+        app.apply_loaded_session(saved);
+
+        assert!(
+            app.active_session().messages.iter().any(
+                |b| matches!(b, ChatBlock::User(t) if t == "from the saved file")
+            ),
+            "the loaded context reached the session, not just App::messages"
+        );
+        assert!(
+            !app.active_session().messages.iter().any(
+                |b| matches!(b, ChatBlock::User(t) if t == "turn 19")
+            ),
+            "and the previous context is gone"
+        );
+        assert!(
+            app.full_history().iter().any(
+                |b| matches!(b, ChatBlock::User(t) if t == "folded in the saved file")
+            ),
+            "the loaded archive is what the record is built from"
+        );
     }
 
     #[test]

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1621,7 +1621,12 @@ async fn save_session_async(
 /// Build a serialisable [`filar_core::Session`] snapshot from the active TUI
 /// session, including launch context (ssh_info, model, api_base_url,
 /// confirm_mode) so a later restore can re-select the same host and model.
-fn session_snapshot(app: &App, target_name: &str, id: &str, timestamp: &str) -> filar_core::Session {
+pub(crate) fn session_snapshot(
+    app: &App,
+    target_name: &str,
+    id: &str,
+    timestamp: &str,
+) -> filar_core::Session {
     let active_profile_name = app
         .llm_profile
         .clone()
@@ -1638,6 +1643,10 @@ fn session_snapshot(app: &App, target_name: &str, id: &str, timestamp: &str) -> 
         target: target_name.to_string(),
         llm_profile: app.llm_profile.clone(),
         messages: app.messages.clone(),
+        // Persisted separately from `messages` so a reopened session keeps the
+        // context compaction left it with, while still holding every turn it
+        // ever had (#379).
+        folded_history: app.active_session().folded_history.clone(),
         input_history: app.input_history().to_vec(),
         tokens_in: app.tokens_in,
         tokens_out: app.tokens_out,

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1621,6 +1621,9 @@ async fn save_session_async(
 /// Build a serialisable [`filar_core::Session`] snapshot from the active TUI
 /// session, including launch context (ssh_info, model, api_base_url,
 /// confirm_mode) so a later restore can re-select the same host and model.
+/// Build the persisted snapshot of the active session: its compacted context,
+/// the heads compaction folded away, and the launch metadata that goes with
+/// them.
 pub(crate) fn session_snapshot(
     app: &App,
     target_name: &str,


### PR DESCRIPTION
Closes #379

Closes the four-part compaction series (376 → 377 → 378 → 379).

## The first requirement was not already met

The issue allowed that it might be: the transcript is written from `Session::messages`, so it keeps the whole conversation *if* compaction only changes what goes to the model. It did not. `apply_compaction` assigned `messages = compacted`, so the folded head left the session outright — the `.md` record had a hole exactly where the beginning of the conversation used to be, and a reopened session had lost it permanently. The issue's second branch applied, so this is a fix rather than a description.

## Decision, stated explicitly as the issue asks

The full history is kept, but **not** in `messages`. `Session` gains `folded_history: Vec<ChatBlock>`, appended to by `apply_compaction` before the head is replaced, in both the TUI session and the persisted `filar_core::Session`.

This is deliberately not the spec's literal recommendation of holding the whole history in `messages` and projecting it for the model. #377 made the feed and the model's context one list on purpose — the summary is visible in the feed precisely so compaction is something the user can audit — and a projection would mean the feed shows turns the model no longer has. It would also force every reader of `messages` (feed rendering, block indices, collapse overrides, topic slug, the #376 fill measurement) to choose between the full and the projected list, which is a change across `app.rs` and `ui/` rather than a change to compaction.

The guarantee is identical either way: nothing is lost. What differs is where the folded head lives and how much code has to know about it.

## What that touches

- `App::full_history()` — archive followed by context. `save_transcript_silent` writes from it.
- `session_snapshot` persists both lists; `apply_loaded_session` restores both.
- `#[serde(default)]` on the new field, so sessions saved by any earlier version load with an empty archive, and a file carrying the field is ignored rather than rejected by a reader that does not know it — the same way every field added since 1.0 behaves.

The record reads head, then the summary that stood in for it, then the verbatim tail. It says both what happened and where the model's view of it was folded. That shape is pinned by a test rather than left to chance.

## Profile switch and cancel needed no change

Ctrl+L only reassigns `llm_profile` and pushes a notice — it touches neither the history nor `pending_compaction`, `compacted_without_relief` or `context_full_notice_shown` — and `compact_at_tokens_for` already reads the threshold from whichever profile is active, so switching changes the threshold with no restart. Ctrl+Z clears `pending_compaction` in `cancel_work`, so a late summary is discarded by the stale guard from #377 and nothing is left half-folded.

Both are covered, but stated plainly: these are **characterisation** tests and they do **not** fail against the old code, because the behaviour was already correct. The DoD asks that new tests fail on the old code; that is true of the archive tests and cannot be true of these two, so I am not claiming it.

## Tests

Two in `filar-core`: the archive survives a save/load round trip; a file saved before this field existed loads with an empty one and an untouched history.

Five in `app.rs`: the head moves into the archive rather than out of the session; the transcript holds the whole conversation while `messages` alone would not (the assertion that fails on the old code); reopening a session keeps both the compacted context and the folded head; Ctrl+L driven through the real key handler leaves the archive intact and takes the new profile's threshold; Ctrl+Z during compaction leaves history and archive alone.

## Verified in the agent environment

- `cargo build --workspace` — green.
- `cargo test --workspace` — green: 789 passed, 0 failed, 8 ignored (the docker-sshd `#[ignore]` tests; no docker here).
- `cargo build --release` — green; `target/release/filar --help` runs.

## Not verified — the three manual DoD checks are yours

No interactive terminal in this environment, so the TUI does not start.

1. **Transcript.** In Explain mode, let compaction fire (or force it with `Ctrl+K`), then open the `.md`. It should contain the folded turns *and* the summary line, with no gap. Before this change the head was simply missing.
2. **Session round trip.** Save a session after a compaction, reopen it. The feed should come back compacted, as it was, and the transcript written from the reopened session should still hold the folded turns. Also worth opening a session saved by 1.0.5 to confirm it loads.
3. **Cancel.** `Ctrl+Z` while the "Compacting…" spinner is up. History unchanged, work continues, and a summary that lands afterwards changes nothing.

## Public contract

`filar_core::Session` gains a field. Additive and defaulted, but embedders constructing it with a struct literal must add it. `ChatBlock`, `CommandExecutor` and `LlmClient` are untouched. Nothing under `crates/agent/src/**` changed, so `eval-smoke` should not be triggered by this PR.

## Out of scope / still open

- `docs/ENGINE_API.md` documents neither `ChatBlock::Summary` (noted in #377), nor `summarise_history` — whose signature #387 changed — nor this field. All three want a pass before the next engine tag is cut.
- From #391's review: the summarising call ignores the cancellation token, so `Ctrl+Z` during compaction still leaves the user paying for a request whose result is thrown away. The history is safe; the money is not. Needs its own issue.
- Per-command output compaction, as the issue says.

## Environment note

The container disk filled and `lld` began crashing with a stack dump on the final link. It reads as a compiler bug and is not one — it was out of space. Worth knowing before anyone files it upstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed history compaction so folded conversation turns are preserved in Markdown transcripts.
  * Reopened sessions now retain the complete conversation history, including archived turns, summaries, and the current transcript.
  * Existing sessions remain compatible and load successfully with the updated history format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->