### PR TITLE
fix(tui): cancel the summarising request when the user cancels (#394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- `Ctrl+Z` during compaction now cancels the summarising request itself instead
+  of leaving it to finish and be discarded, so a cancelled fold stops costing
+  tokens ([#394](https://github.com/devlawey/filar/issues/394)).
+
 - Compacting the history no longer shortens the transcript or the saved session:
   the folded head is kept alongside the compacted context
   ([#379](https://github.com/devlawey/filar/issues/379)).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6219,6 +6219,58 @@ cancellation token, so Ctrl+Z during compaction leaves the user paying for a
 request whose result is thrown away: the history is safe, the money is not.
 `prepare-release` after those.
 
+## Issue #394: fix(tui) — cancelling compaction now cancels the request
+
+**Milestone:** 1.0.6. **Branch:** `fix/394-cancel-summary-request`. Found while
+answering review on PR #391, filed rather than folded into that PR.
+
+**Problem.** `compact_for_request` awaited `summarise_history` without ever
+consulting the `CancellationToken` it had in scope one frame up. `Ctrl+Z` during
+a fold therefore stopped nothing: the task ran the summary to completion and
+sent `HistoryCompacted` afterwards. Everything downstream behaved — the stale
+guard from #377 discarded the result, so the history was safe, and #387
+attributed the cost to the right profile — but the user kept paying for several
+more seconds for a result already destined for the bin. On a long history the
+summary's input is the entire head being folded, so a cancelled compaction cost
+more than the turn it was cancelling.
+
+**Shape.** The token is passed into `compact_for_request` and the call runs
+inside a `tokio::select!` against `cancellation.cancelled()`, matching how
+`Agent::run` guards its own LLM calls. There is also an `is_cancelled()` check
+before the request is built, for the case where Ctrl+Z lands between arming the
+compaction and reaching it: not opening the request at all is the cheapest
+outcome and the one the user asked for.
+
+**Two deliberate silences.** A cancelled fold sends no `HistoryCompacted`, not
+even an error one. The stale guard would discard it, and a feed line about a
+failed summary underneath the user's own "Cancelled." is noise about something
+they stopped. And nothing is charged: the provider returned no `usage` for an
+abandoned request, and inventing a zero or an estimate would be worse than
+recording nothing, since these figures are meant to be measured rather than
+guessed. Both are commented at the site.
+
+**Done:** 3 tests in `runner.rs`, using an `LlmClient` that hangs until
+released so the cancel lands mid-flight: cancelling abandons the request and
+emits nothing while the turn keeps its full history; an already-cancelled token
+means the request is never sent at all; and an uncancelled summary still folds
+and still reports, so the guard did not quietly disable the feature. The first
+two were confirmed to fail on the old code — by hanging, since without the guard
+the call never returns, so both are wrapped in a `tokio::time::timeout`: a
+regression should fail an assertion rather than wedge the suite.
+
+**Public contract:** none. `compact_for_request` is private to `filar-tui`;
+nothing in `crates/agent/src/**` or `crates/core/src/**` changed, so `eval-smoke`
+should not trigger.
+
+**Verification:** `cargo build --workspace`, `cargo test --workspace`,
+`cargo build --release`. The TUI was not driven — no interactive terminal here —
+so the manual check that Ctrl+Z now stops the spinner immediately rather than
+some seconds later is the human's, and is written out in the PR.
+
+**Next steps:** #393 (engine docs) and #395 (README and user guide) remain in
+1.0.6, both deliberately sequenced after this one so they describe final
+behaviour. #395 in particular has to mention what Ctrl+Z does during a fold.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/crates/tui/src/runner.rs
+++ b/crates/tui/src/runner.rs
@@ -1821,6 +1821,7 @@ fn spawn_agent(
             &tx,
             sid,
             &profile_name,
+            &cancellation,
         )
         .await;
 
@@ -1912,6 +1913,7 @@ fn spawn_agent(
                 &tx,
                 sid,
                 &profile_name,
+                &cancellation,
             )
             .await;
             if chat_history.len() >= before {
@@ -1964,6 +1966,12 @@ fn should_retry_after_overflow(
 /// Returns the history to send. A failed or unusable summary returns it
 /// **unchanged**: losing the user's turn because the summariser misbehaved
 /// would be a worse outcome than a long context (#377, #378).
+/// Fold the head of `chat_history` into a summary before the request goes out.
+///
+/// Returns the history to send. On cancellation, on a summary the model refuses
+/// to produce, or on one too short to use, that is the history it was given:
+/// compaction is an optimisation, and failing at it must never cost the user
+/// their turn (#378).
 async fn compact_for_request(
     chat_history: Vec<ChatBlock>,
     boundary: Option<usize>,
@@ -1971,6 +1979,7 @@ async fn compact_for_request(
     tx: &mpsc::UnboundedSender<TuiEvent>,
     sid: SessionId,
     profile: &str,
+    cancellation: &CancellationToken,
 ) -> Vec<ChatBlock> {
     let Some(boundary) = boundary else {
         return chat_history;
@@ -1978,12 +1987,30 @@ async fn compact_for_request(
     if boundary == 0 || boundary > chat_history.len() {
         return chat_history;
     }
+    // Ctrl+Z between arming the compaction and getting here: do not start a
+    // request the user has already called off (#394).
+    if cancellation.is_cancelled() {
+        return chat_history;
+    }
     let transcript = filar_core::transcript_for_summary(&chat_history[..boundary]);
     // The usage goes back in both branches: the call was billed whether or not
     // the reply turned out to be usable. So does the profile that computed it,
     // which is this run's, not whichever one the session holds by the time the
     // result lands (#387).
-    let outcome = filar_agent::summarise_history(llm, &transcript).await;
+    let outcome = tokio::select! {
+        outcome = filar_agent::summarise_history(llm, &transcript) => outcome,
+        _ = cancellation.cancelled() => {
+            // Deliberately silent. The result is abandoned, so no
+            // `HistoryCompacted` goes out: the stale guard would discard it
+            // anyway, and a second feed line about a failed summary underneath
+            // the user's own "Cancelled." is noise about a thing they stopped.
+            //
+            // Nothing is charged either. The provider returned no `usage`, and
+            // inventing a zero or an estimate would be worse than recording
+            // nothing — the figures the user reads are meant to be measured.
+            return chat_history;
+        }
+    };
     let usage = outcome.usage;
     match outcome.summary {
         Ok(summary) => {
@@ -2107,6 +2134,145 @@ mod tests {
         assert!(
             !should_retry_after_overflow(true, false, true, false),
             "cancellation is the user asking for it to stop"
+        );
+    }
+
+    /// An `LlmClient` that hangs until released, so a test can cancel it
+    /// mid-flight the way `Ctrl+Z` does.
+    struct HangingLlm {
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for HangingLlm {
+        async fn chat(
+            &self,
+            _request: &filar_agent::ChatRequest,
+        ) -> filar_core::Result<filar_agent::ChatResponse> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.started.notify_one();
+            self.release.notified().await;
+            Ok(filar_agent::ChatResponse::text(
+                "A real summary of the earlier turns of this session.".to_string(),
+            ))
+        }
+    }
+
+    fn history(n: usize) -> Vec<ChatBlock> {
+        (0..n).map(|i| ChatBlock::User(format!("turn {i}"))).collect()
+    }
+
+    #[tokio::test]
+    async fn cancelling_mid_summary_abandons_the_request_and_says_nothing() {
+        // Ctrl+Z used to leave the summary running to completion: the user
+        // stopped the work and went on paying for a result that the stale
+        // guard would then throw away (#394).
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let llm = HangingLlm {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let blocks = history(6);
+
+        let cancel = token.clone();
+        let waiter = tokio::spawn(async move {
+            started.notified().await;
+            cancel.cancel();
+        });
+
+        // Bounded: without the guard this call never returns, and a hung
+        // suite is a much worse regression signal than a failed assertion.
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            compact_for_request(blocks.clone(), Some(4), &llm, &tx, SessionId(1), "p", &token),
+        )
+        .await
+        .expect("cancellation must abandon the request, not wait it out");
+        waiter.await.unwrap();
+        release.notify_waiters();
+
+        assert_eq!(
+            format!("{out:?}"),
+            format!("{blocks:?}"),
+            "the turn goes out on the history it already had"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no HistoryCompacted: the user stopped this, and the feed already says so"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_summary_is_not_even_started_after_a_cancel() {
+        // Cancelling between arming the compaction and reaching it must not
+        // open a request at all — the cheapest possible outcome, and the one
+        // the user asked for.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        token.cancel();
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let llm = HangingLlm {
+            started: Arc::new(tokio::sync::Notify::new()),
+            release: Arc::new(tokio::sync::Notify::new()),
+            calls: Arc::clone(&calls),
+        };
+        let blocks = history(6);
+
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            compact_for_request(blocks.clone(), Some(4), &llm, &tx, SessionId(1), "p", &token),
+        )
+        .await
+        .expect("an already-cancelled compaction must return at once");
+
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0, "no request sent");
+        assert_eq!(format!("{out:?}"), format!("{blocks:?}"), "history untouched");
+        assert!(rx.try_recv().is_err(), "and nothing announced");
+    }
+
+    #[tokio::test]
+    async fn an_uncancelled_summary_still_compacts_and_reports() {
+        // The guard must not have turned compaction off in the normal case.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let release = Arc::new(tokio::sync::Notify::new());
+        release.notify_waiters();
+        let llm = HangingLlm {
+            started: Arc::new(tokio::sync::Notify::new()),
+            release: Arc::clone(&release),
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let blocks = history(6);
+
+        let releaser = {
+            let release = Arc::clone(&release);
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                release.notify_waiters();
+            })
+        };
+        let out = compact_for_request(
+            blocks.clone(),
+            Some(4),
+            &llm,
+            &tx,
+            SessionId(1),
+            "p",
+            &token,
+        )
+        .await;
+        releaser.await.unwrap();
+
+        assert!(out.len() < blocks.len(), "the head was folded");
+        assert!(
+            matches!(rx.try_recv(), Ok(TuiEvent::HistoryCompacted { summary: Ok(_), .. })),
+            "and the result was reported"
         );
     }
 


### PR DESCRIPTION
Closes #394

## The problem

`compact_for_request` awaited `summarise_history` without ever consulting the `CancellationToken` it had in scope one frame up. `Ctrl+Z` during a fold therefore stopped nothing: the task ran the summary to completion and sent `HistoryCompacted` afterwards.

Everything downstream behaved correctly. The stale guard from #377 discarded the late result, so the history was never left half-folded, and #387 attributed the cost to the profile that computed it rather than whichever one the session had moved to. What did not behave was the bill: the user kept paying for several more seconds for a result already destined for the bin. On a long history the summary's input is the entire head being folded, so a cancelled compaction cost more than the turn it was cancelling.

## The change

The token is passed into `compact_for_request`, and the call runs inside a `tokio::select!` against `cancellation.cancelled()` — the same shape `Agent::run` uses for its own LLM calls. There is also an `is_cancelled()` check before the request is built, for the case where `Ctrl+Z` lands between arming the compaction and reaching it: not opening the request at all is the cheapest outcome and the one the user asked for.

## Two deliberate silences

**No event.** A cancelled fold sends no `HistoryCompacted`, not even an error one. The stale guard would discard it anyway, and a feed line about a failed summary sitting underneath the user's own "Cancelled." is noise about a thing they stopped.

**No charge.** The provider returned no `usage` for an abandoned request. Inventing a zero, or an estimate from the prompt, would be worse than recording nothing — the figures the session reports are meant to be measured, and #387 exists precisely so they can be trusted. After a cancel the counters simply do not move. Both choices are commented at the site.

## Tests

Three in `runner.rs`, using an `LlmClient` that hangs until released so the cancel lands mid-flight:

- Cancelling abandons the request and emits nothing, while the turn keeps the full history it started with.
- An already-cancelled token means the request is never sent at all — asserted on a call counter, not on the outcome.
- An uncancelled summary still folds and still reports, so the guard did not quietly disable the feature.

The first two were confirmed to fail against the old code, and it is worth saying how: they **hang**, because without the guard the call never returns. A wedged suite is a much worse regression signal than a failed assertion, so both are wrapped in a `tokio::time::timeout` with a message naming what should have happened.

## Verified in the agent environment

- `cargo build --workspace` — green.
- `cargo test --workspace` — green: 793 passed, 0 failed, 8 ignored (the docker-sshd `#[ignore]` tests; no docker here).
- `cargo build --release` — green; `target/release/filar --help` runs.

## Not verified — the manual check is yours

No interactive terminal in this environment, so the TUI does not start.

1. Start a session long enough to compact, or force one with `Ctrl+K`.
2. Press `Ctrl+Z` while the compaction spinner is up. It should stop **immediately**, not after the several seconds a summary takes.
3. The history should be unchanged, no summary or failure line should appear in the feed beyond the usual "Cancelled.", and the session's token and cost figures should not move.
4. Send another turn afterwards and confirm the session still works normally, and that compaction can still fire.

## Public contract

None. `compact_for_request` is private to `filar-tui`. Nothing under `crates/agent/src/**` or `crates/core/src/**` changed, so `eval-smoke` should not be triggered by this PR.

## Sequencing note

#393 (engine docs) and #395 (README and user guide) are the remaining 1.0.6 issues, both deliberately ordered after this one so they describe final behaviour. #395 in particular has to state what `Ctrl+Z` does during a fold, which is only now worth writing down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pressing `Ctrl+Z` now cancels an active compaction summary request instead of allowing it to complete and discarding the result.
  - Cancelled compaction no longer emits a history-compacted event or charges usage.
  - Added safeguards for cancellation before and during compaction, while preserving successful compaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->