### PR TITLE
docs(engine): document the three 1.0.6 contract changes (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ dependency point for embedders (see `docs/ENGINE_API.md`).
 
 ### Fixed
 
+- `docs/ENGINE_API.md` now documents the three contract changes in this release
+  — `ChatBlock::Summary`, the `summarise_history` signature, and
+  `Session::folded_history` — with an upgrade table for embedders
+  ([#393](https://github.com/devlawey/filar/issues/393)).
+
 - `Ctrl+Z` during compaction now cancels the summarising request itself instead
   of leaving it to finish and be discarded, so a cancelled fold stops costing
   tokens ([#394](https://github.com/devlawey/filar/issues/394)).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6271,6 +6271,63 @@ some seconds later is the human's, and is written out in the PR.
 1.0.6, both deliberately sequenced after this one so they describe final
 behaviour. #395 in particular has to mention what Ctrl+Z does during a fold.
 
+## Issue #393: docs(engine) — ENGINE_API.md caught up with the 1.0.6 contract
+
+**Milestone:** 1.0.6. **Branch:** `docs/393-engine-api-contract`. Blocks
+`engine-v1.0.6`.
+
+**Problem.** Three changes to the public API landed across the compaction series
+and none reached the document embedders read: `ChatBlock::Summary` (#377), the
+`summarise_history` signature (#387), and `Session::folded_history` (#379). The
+gap was noticed in #377 and deferred to "the next engine tag", which was never
+cut, so it accumulated.
+
+**Shape.** A new "Chat history and compaction" section covering all three, and
+an "Upgrading to `engine-v1.0.6`" table. The tag references in the Cargo
+examples were left at `engine-v1.0.5`: `prepare-release` rewrites them in the
+bump commit, and pointing at a tag that does not exist yet would be worse than
+pointing at the current one.
+
+**What the document had to get across.** Two of the three break the build and
+document themselves; the section spends its length on the parts that do not.
+
+`ChatBlock::Summary` looks like `ChatBlock::System` and must not be treated like
+it. Flattening blocks into messages happens in the embedder's code —
+`history_to_messages` lives in `filar-tui`, not in an engine crate — so the
+temptation on upgrade is a `_ => None` arm to make it compile. That erases the
+whole beginning of the conversation with no error at all, and the model then
+answers as though the session had just started. Called out explicitly, with the
+user-role framing filar itself uses.
+
+`folded_history` is the one that can be missed entirely: it only breaks the
+build for embedders who construct `Session` with a struct literal. Anyone who
+deserializes sessions gets a clean compile and transcripts with a hole where the
+head used to be — visible only in sessions long enough to have been compacted,
+which are exactly the ones where it matters. The section draws the line between
+`messages` as *context* and the pair as *record*.
+
+For `summarise_history`, the point worth documenting is why usage is returned
+apart from the summary: the call is billed before its reply can be judged, so a
+rejected brief still owes its tokens.
+
+**Kept honest by the compiler.** Markdown in `docs/` is compiled by nothing, so
+a document describing a signature can drift without a single test going red —
+which is how this issue happened in the first place. The snippets now live in
+`crates/agent/examples/engine_api_snippets.rs`, so `cargo build --workspace`
+fails when the API they describe moves. That is the part of this PR most likely
+to still be paying off in a year.
+
+**Done:** the example compiles as part of the workspace build. No behaviour
+changed, so there are no behavioural tests to fail on the old code, and none are
+claimed.
+
+**Verification:** `cargo build --workspace`, `cargo test --workspace`,
+`cargo build --release`.
+
+**Next steps:** #395 (README and user guide) is the last open issue in 1.0.6.
+After it, `prepare-release` — which will also rewrite the `engine-v1.0.5` tags
+in this document.
+
 ## Release v1.0.5 (2026-08-27)
 
 **Scope:** milestone 1.0.5 — regression fixes for 1.0.4: Unicode export topic slug

--- a/crates/agent/examples/engine_api_snippets.rs
+++ b/crates/agent/examples/engine_api_snippets.rs
@@ -1,0 +1,44 @@
+//! Compile check for the snippets in `docs/ENGINE_API.md` (#393).
+//!
+//! Markdown in `docs/` is not compiled by anything, so documentation that talks
+//! about a signature can drift out of date without a single test going red —
+//! which is how `ENGINE_API.md` came to describe none of the three contract
+//! changes in 1.0.6. Keeping the snippets here as an example means `cargo build
+//! --workspace` fails when the API they describe moves.
+//!
+//! Keep this in step with the document. It is not a usage sample.
+
+use filar_agent::{ChatMessage, LlmClient};
+use filar_core::{ChatBlock, Session};
+
+/// "`ChatBlock::Summary` — this one goes to the model".
+pub fn flatten(block: &ChatBlock) -> Option<ChatMessage> {
+    match block {
+        ChatBlock::Summary { text, .. } => Some(ChatMessage::user(format!(
+            "Summary of earlier turns in this session:\n{text}"
+        ))),
+        _ => None,
+    }
+}
+
+/// "`Session::folded_history` — where the folded turns live".
+pub fn whole_conversation(session: &Session) -> Vec<ChatBlock> {
+    session
+        .folded_history
+        .iter()
+        .chain(session.messages.iter())
+        .cloned()
+        .collect()
+}
+
+/// "`summarise_history` — asking the model for the summary".
+pub async fn summarise(llm: &dyn LlmClient, blocks: &[ChatBlock], boundary: usize) {
+    let transcript = filar_core::transcript_for_summary(&blocks[..boundary]);
+    let outcome = filar_agent::summarise_history(llm, &transcript).await;
+    if let Ok(summary) = outcome.summary {
+        let _compacted = filar_core::compact_history(blocks, boundary, &summary);
+    }
+    let _usage = outcome.usage;
+}
+
+fn main() {}

--- a/docs/ENGINE_API.md
+++ b/docs/ENGINE_API.md
@@ -195,7 +195,135 @@ let store = SessionStore::new(std::path::PathBuf::from("/data/data/com.example.a
 For desktop platforms, use `SessionStore::with_default_dir()` which uses
 `dirs::data_dir()` (Windows `%APPDATA%`, macOS Application Support, Linux XDG).
 
-## LLM request parameters
+## Chat history and compaction
+
+A long session eventually fills the model's context window. The engine deals
+with this by **compaction**: the head of the history is folded into a single
+summary and the recent turns are kept verbatim. Three parts of the public API
+are involved, and an embedder that ignores any of them will lose data silently
+rather than loudly.
+
+### `ChatBlock::Summary` — this one goes to the model
+
+```rust
+ChatBlock::Summary { text: String, replaced_blocks: usize }
+```
+
+`replaced_blocks` is how many blocks were folded into it — useful for a status
+line, not otherwise load-bearing.
+
+Flattening `ChatBlock`s into `ChatMessage`s is the embedder's job, and this is
+where the mistake is easy to make. `ChatBlock::System` is chrome: connection
+notices, error banners, anything the frontend wrote for the user rather than for
+the model, and it is correct to drop it. `ChatBlock::Summary` looks like chrome
+and is not. It **stands in for turns that are no longer in the history at all**,
+so dropping it does not shorten the context — it erases the entire beginning of
+the conversation without any error, and the model then answers as though the
+session had just started.
+
+A summary is best sent as a user-role message that says what it is, so the model
+treats it as context rather than as something it said:
+
+```rust
+ChatBlock::Summary { text, .. } => Some(ChatMessage::user(
+    format!("Summary of earlier turns in this session:\n{text}")
+)),
+```
+
+If your match on `ChatBlock` is exhaustive, the compiler will point at this
+variant when you upgrade. Do not reach for a `_ => None` arm to make it build.
+
+### `summarise_history` — asking the model for the summary
+
+```rust
+pub async fn summarise_history(llm: &dyn LlmClient, transcript: &str) -> SummaryOutcome;
+
+pub struct SummaryOutcome {
+    pub usage: Option<TokenUsage>,
+    pub summary: Result<String>,
+}
+```
+
+The usage is returned separately from the summary because the two are owed to
+different places. Whether the brief is usable decides only whether you fold the
+head; the request was billed before anyone could judge it. So a reply the engine
+rejects as too short still carries its `usage` back, and any per-session cost
+accounting you keep should add it. `usage` is `None` when the provider reported
+none, and when the call failed before a response existed — a real absence, not a
+zero.
+
+`summary` is `Err` both for transport failures and for a reply too short to be a
+usable brief. Treat them the same way: leave the history alone and send the turn
+on the full history. A failed summary must not cost the user their turn.
+
+Pair it with the two helpers in `filar-core`:
+
+```rust
+let transcript = filar_core::transcript_for_summary(&blocks[..boundary]);
+let outcome = filar_agent::summarise_history(llm.as_ref(), &transcript).await;
+if let Ok(summary) = outcome.summary {
+    let compacted = filar_core::compact_history(&blocks, boundary, &summary);
+}
+```
+
+If you drive the summarising call from a task the user can cancel, guard it —
+otherwise a cancelled fold keeps billing for a result you are going to discard.
+
+### `Session::folded_history` — where the folded turns live
+
+```rust
+pub struct Session {
+    pub messages: Vec<ChatBlock>,        // the context: what the model is sent
+    pub folded_history: Vec<ChatBlock>,  // the heads compaction folded away
+    // ...
+}
+```
+
+`compact_history` really does drop the head from the list it returns, so the two
+fields mean different things and are not interchangeable:
+
+- **`messages`** is the working context — what you send to the model and, in
+  filar's own UI, what the feed shows.
+- **`folded_history`** is every block compaction has removed, oldest first,
+  appended to on each fold. It is never sent to the model.
+
+Anything that claims to be a *record* of the session rather than a *view of its
+context* must be built from both, in order:
+
+```rust
+let whole_conversation: Vec<ChatBlock> = session
+    .folded_history
+    .iter()
+    .chain(session.messages.iter())
+    .cloned()
+    .collect();
+```
+
+Transcripts, exports, audit logs and anything you show a user as "the
+conversation" belong in that category. Building them from `messages` alone
+produces a record with a hole exactly where the beginning used to be — and the
+hole appears only in sessions long enough to have been compacted, which is to
+say the ones where it matters.
+
+`folded_history` is `#[serde(default)]`, so sessions written before it existed
+load with an empty archive.
+
+## Upgrading to `engine-v1.0.6`
+
+Three changes to the public API. All three fail loudly at compile time except
+the third, which is the one worth reading twice.
+
+| Change | Breaks | What to do |
+|--------|--------|------------|
+| `ChatBlock::Summary` added | Exhaustive matches on `ChatBlock` | Send it to the model. See above — a `_ => None` arm here is a silent data loss |
+| `summarise_history` returns `SummaryOutcome` instead of `Result<String>` | Direct callers | Match on `outcome.summary`; add `outcome.usage` to your cost accounting |
+| `Session::folded_history` added | Struct literals constructing `Session` | `Vec::new()` for a fresh session. Build transcripts from it plus `messages` |
+
+The first two stop the build. The third stops the build only if you construct
+`Session` with a struct literal — if you deserialize sessions, it compiles and
+runs, and your transcripts quietly lose the folded head.
+
+
 
 `LlmConfig` supports optional parameters that are sent in the API request body:
 


### PR DESCRIPTION
Closes #393

Blocks `engine-v1.0.6`.

## What was missing

Three changes to the public API landed across the compaction series and none of them reached the document embedders actually read: `ChatBlock::Summary` (#377), the `summarise_history` signature (#387), and `Session::folded_history` (#379). The gap was noticed back in #377 and deferred to "the next engine tag", which was never cut — so it accumulated instead of being paid off.

## What this adds

A **Chat history and compaction** section covering all three, and an **Upgrading to `engine-v1.0.6`** table.

Two of the three break the build and largely document themselves. The section spends its length on the parts that do not:

**`ChatBlock::Summary` looks like `ChatBlock::System` and must not be treated like it.** Flattening blocks into messages is the embedder's own code — `history_to_messages` lives in `filar-tui`, not in an engine crate — so the natural move on upgrade is a `_ => None` arm to make it compile. That does not shorten the context; it erases the entire beginning of the conversation with no error, and the model then answers as though the session had just started. Called out explicitly, with the user-role framing filar itself uses.

**`folded_history` is the one that can be missed entirely.** It only breaks the build for embedders who construct `Session` with a struct literal. Anyone who deserializes sessions gets a clean compile and transcripts with a hole where the head used to be — visible only in sessions long enough to have been compacted, which are exactly the ones where it matters. The section draws the line between `messages` as *context* and the pair as *record*, with the `chain` snippet for building the latter.

**For `summarise_history`,** the part worth documenting is why usage comes back apart from the summary: the call is billed before its reply can be judged, so a brief the engine rejects as too short still owes its tokens.

## Kept honest by the compiler

Markdown in `docs/` is compiled by nothing, so a document describing a signature can drift without a single test going red. That is precisely how this issue came to exist. The snippets now live in `crates/agent/examples/engine_api_snippets.rs`, so `cargo build --workspace` fails when the API they describe moves.

That is the part of this PR most likely to still be earning its keep in a year, and it is why the example is in the repository rather than being a one-off check I ran locally.

## Tag references left alone

The Cargo examples still say `engine-v1.0.5`. `prepare-release` rewrites them in the bump commit, and pointing at a tag that does not exist yet would be worse than pointing at the current one.

## Verified

- `cargo build --workspace` — green, including the new example.
- `cargo test --workspace` — green: 793 passed, 0 failed, 8 ignored (docker-sshd).
- `cargo build --release` — green; `target/release/filar --help` runs.

No behaviour changed, so there are no behavioural tests that would fail on the old code, and I am not claiming any. The example is a compile-time guard, not a test of runtime behaviour.

## Review focus

The value of this PR is entirely in whether the descriptions are **correct**, so that is where review effort is best spent — particularly the claim about which blocks reach the model, and the `messages` vs `folded_history` split. Both were checked against `history_to_messages` and `compact_history` in the current tree rather than from memory, but a second reading is cheap and a wrong instruction in this file is expensive.

## Out of scope

`README.md` and `USER_GUIDE.md` are #395 — different audience, no overlap with this file.
